### PR TITLE
Add project switcher

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -28,11 +28,13 @@ const {
   readRepositoryChangeSignature,
   readRepositoryState,
 } = require('./git-state.cjs');
+const { createProjectManager } = require('./project-manager.cjs');
 
 const root = dirname(__dirname);
 const repositoryWatchers = new Map();
-const windowRepositories = new Map();
 let preferences = {
+  lastProjectRoot: null,
+  projects: [],
   showWhitespace: false,
 };
 
@@ -41,8 +43,11 @@ const getCommandLineRepositoryPath = (commandLine = process.argv) => {
   return args.find((arg) => arg && !arg.startsWith('-'));
 };
 
+const getExplicitLaunchPath = () =>
+  process.env.CODIFF_REPOSITORY_PATH || getCommandLineRepositoryPath();
+
 const getLaunchPath = () =>
-  resolve(process.env.CODIFF_REPOSITORY_PATH || getCommandLineRepositoryPath() || process.cwd());
+  resolve(getExplicitLaunchPath() || preferences.lastProjectRoot || process.cwd());
 
 const getPreferencesPath = () => join(app.getPath('userData'), 'preferences.json');
 
@@ -60,6 +65,17 @@ const readPreferences = () => {
 const writePreferences = () => {
   writeFileSync(getPreferencesPath(), JSON.stringify(preferences, null, 2));
 };
+
+const updatePreferences = (updater) => {
+  preferences = updater(preferences);
+  writePreferences();
+};
+
+const projectManager = createProjectManager({
+  getLaunchPath,
+  getPreferences: () => preferences,
+  updatePreferences,
+});
 
 const sendPreferencesChanged = () => {
   for (const window of BrowserWindow.getAllWindows()) {
@@ -93,6 +109,11 @@ const resetRepositoryWatcher = async (webContentsId, repositoryPath) => {
 
 const startRepositoryWatcher = (browserWindow, repositoryPath) => {
   const webContentsId = browserWindow.webContents.id;
+  const existingWatcher = repositoryWatchers.get(webContentsId);
+  if (existingWatcher?.interval) {
+    clearInterval(existingWatcher.interval);
+  }
+
   const watcher = {
     changed: false,
     checking: false,
@@ -247,11 +268,10 @@ const buildApplicationMenu = () =>
         {
           checked: preferences.showWhitespace,
           click: (menuItem) => {
-            preferences = {
+            updatePreferences((preferences) => ({
               ...preferences,
               showWhitespace: menuItem.checked,
-            };
-            writePreferences();
+            }));
             sendPreferencesChanged();
           },
           label: 'Show Whitespace',
@@ -268,7 +288,8 @@ const buildApplicationMenu = () =>
     },
   ]);
 
-const createWindow = (repositoryPath) => {
+const createWindow = (repositoryPath = getLaunchPath()) => {
+  const activeRoot = resolve(repositoryPath || preferences.lastProjectRoot || getLaunchPath());
   const display = screen.getPrimaryDisplay();
   const { height, width } = display.workAreaSize;
   const window = new BrowserWindow({
@@ -279,7 +300,7 @@ const createWindow = (repositoryPath) => {
     minHeight: 520,
     minWidth: 880,
     show: false,
-    title: `Codiff - ${repositoryPath}`,
+    title: `Codiff - ${activeRoot}`,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
     trafficLightPosition: { x: 25, y: 24 },
     webPreferences: {
@@ -291,8 +312,8 @@ const createWindow = (repositoryPath) => {
   });
 
   const webContentsId = window.webContents.id;
-  windowRepositories.set(webContentsId, repositoryPath);
-  startRepositoryWatcher(window, repositoryPath);
+  projectManager.seedWindow(webContentsId, activeRoot);
+  startRepositoryWatcher(window, activeRoot);
   window.once('ready-to-show', () => window.show());
   window.on('closed', () => {
     const watcher = repositoryWatchers.get(webContentsId);
@@ -300,7 +321,7 @@ const createWindow = (repositoryPath) => {
       clearInterval(watcher.interval);
     }
     repositoryWatchers.delete(webContentsId);
-    windowRepositories.delete(webContentsId);
+    projectManager.removeWindow(webContentsId);
   });
 
   const rendererURL = process.env.ELECTRON_RENDERER_URL;
@@ -311,7 +332,11 @@ const createWindow = (repositoryPath) => {
   }
 };
 
-const lock = !squirrelStartup && app.requestSingleInstanceLock({ repositoryPath: getLaunchPath() });
+const lock =
+  !squirrelStartup &&
+  app.requestSingleInstanceLock({
+    repositoryPath: getExplicitLaunchPath() ? resolve(getExplicitLaunchPath()) : null,
+  });
 
 if (squirrelStartup || !lock) {
   app.quit();
@@ -331,12 +356,12 @@ if (squirrelStartup || !lock) {
   app.on('ready', () => {
     preferences = readPreferences();
     Menu.setApplicationMenu(buildApplicationMenu());
-    createWindow(getLaunchPath());
+    createWindow();
   });
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
-      createWindow(getLaunchPath());
+      createWindow();
     }
   });
 
@@ -346,26 +371,59 @@ if (squirrelStartup || !lock) {
 }
 
 ipcMain.handle('codiff:getRepositoryState', async (event, source) => {
-  const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
+  const repositoryPath = projectManager.getActiveRepositoryPath(event.sender.id);
   const state = await readRepositoryState(repositoryPath, source);
   await resetRepositoryWatcher(event.sender.id, repositoryPath);
   return state;
 });
 
 ipcMain.handle('codiff:getDiffSectionContent', async (event, request) => {
-  const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
+  const repositoryPath = projectManager.getActiveRepositoryPath(event.sender.id);
   return readDiffSectionContent(repositoryPath, request);
 });
 
 ipcMain.handle('codiff:getRepositoryHistory', async (event, limit) => {
-  const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
+  const repositoryPath = projectManager.getActiveRepositoryPath(event.sender.id);
   return listRepositoryHistory(repositoryPath, limit);
+});
+
+ipcMain.handle('codiff:getProjects', async (event) =>
+  projectManager.readProjectList(event.sender.id),
+);
+
+ipcMain.handle('codiff:selectProject', async (event, root) => {
+  projectManager.addProject(event.sender.id, root);
+  const window = BrowserWindow.fromWebContents(event.sender);
+  if (window) {
+    startRepositoryWatcher(window, root);
+  }
+  return projectManager.readProjectList(event.sender.id);
+});
+
+ipcMain.handle('codiff:openProject', async (event) => {
+  const window = BrowserWindow.fromWebContents(event.sender);
+  const result = await dialog.showOpenDialog(window, {
+    buttonLabel: 'Open Repository',
+    properties: ['openDirectory'],
+    title: 'Open Repository',
+  });
+
+  if (result.canceled || !result.filePaths[0]) {
+    return projectManager.readProjectList(event.sender.id);
+  }
+
+  const project = await projectManager.readProject(result.filePaths[0]);
+  projectManager.addProject(event.sender.id, project.root);
+  if (window) {
+    startRepositoryWatcher(window, project.root);
+  }
+  return projectManager.readProjectList(event.sender.id);
 });
 
 ipcMain.handle('codiff:getPreferences', () => preferences);
 
 ipcMain.handle('codiff:showInFolder', async (event, filePath) => {
-  const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
+  const repositoryPath = projectManager.getActiveRepositoryPath(event.sender.id);
   const state = await readRepositoryState(repositoryPath);
   const absolutePath = resolve(state.root, filePath);
 
@@ -377,7 +435,7 @@ ipcMain.handle('codiff:showInFolder', async (event, filePath) => {
 });
 
 ipcMain.handle('codiff:getRelativePath', async (event, filePath) => {
-  const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
+  const repositoryPath = projectManager.getActiveRepositoryPath(event.sender.id);
   const state = await readRepositoryState(repositoryPath);
   return relative(state.root, filePath);
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -3,6 +3,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('codiff', {
   getDiffSectionContent: (request) => ipcRenderer.invoke('codiff:getDiffSectionContent', request),
   getPreferences: () => ipcRenderer.invoke('codiff:getPreferences'),
+  getProjects: () => ipcRenderer.invoke('codiff:getProjects'),
   getRepositoryHistory: (limit) => ipcRenderer.invoke('codiff:getRepositoryHistory', limit),
   getRepositoryState: (source) => ipcRenderer.invoke('codiff:getRepositoryState', source),
   onPreferencesChanged: (callback) => {
@@ -15,5 +16,7 @@ contextBridge.exposeInMainWorld('codiff', {
     ipcRenderer.on('codiff:repositoryChanged', listener);
     return () => ipcRenderer.removeListener('codiff:repositoryChanged', listener);
   },
+  openProject: () => ipcRenderer.invoke('codiff:openProject'),
+  selectProject: (root) => ipcRenderer.invoke('codiff:selectProject', root),
   showInFolder: (path) => ipcRenderer.invoke('codiff:showInFolder', path),
 });

--- a/electron/project-manager.cjs
+++ b/electron/project-manager.cjs
@@ -1,0 +1,119 @@
+const { basename, resolve } = require('node:path');
+const { readRepositoryState } = require('./git-state.cjs');
+
+const compactPath = (path) =>
+  path.replace(/^\/Users\/[^/]+(?=\/|$)/, '~').replace(/^\/home\/[^/]+(?=\/|$)/, '~');
+
+const getProjectLabel = (path) => basename(path) || compactPath(path);
+
+const normalizeProjectRoots = (roots) => [
+  ...new Set(roots.filter((root) => typeof root === 'string' && root).map((root) => resolve(root))),
+];
+
+const createProjectManager = ({ getLaunchPath, getPreferences, updatePreferences }) => {
+  const windowRepositories = new Map();
+
+  const getInitialProjectRoots = (activeRoot) => {
+    const { projects } = getPreferences();
+    return normalizeProjectRoots([activeRoot, ...(Array.isArray(projects) ? projects : [])]);
+  };
+
+  const seedWindow = (webContentsId, activeRoot) => {
+    windowRepositories.set(webContentsId, {
+      activeRoot,
+      roots: getInitialProjectRoots(activeRoot),
+    });
+  };
+
+  const removeWindow = (webContentsId) => {
+    windowRepositories.delete(webContentsId);
+  };
+
+  const getWindowProjects = (webContentsId) => {
+    const projects = windowRepositories.get(webContentsId);
+    if (projects) {
+      return projects;
+    }
+
+    const activeRoot = getLaunchPath();
+    const fallback = {
+      activeRoot,
+      roots: getInitialProjectRoots(activeRoot),
+    };
+    windowRepositories.set(webContentsId, fallback);
+    return fallback;
+  };
+
+  const getActiveRepositoryPath = (webContentsId) => getWindowProjects(webContentsId).activeRoot;
+
+  const writeProjectState = (webContentsId, activeRoot, roots, persistLastProject = true) => {
+    const normalizedRoots = normalizeProjectRoots(roots);
+    windowRepositories.set(webContentsId, {
+      activeRoot,
+      roots: normalizedRoots,
+    });
+
+    updatePreferences((preferences) => ({
+      ...preferences,
+      lastProjectRoot: persistLastProject ? activeRoot : preferences.lastProjectRoot,
+      projects: normalizedRoots,
+    }));
+  };
+
+  const readProject = async (launchPath) => {
+    const state = await readRepositoryState(launchPath);
+    return {
+      label: getProjectLabel(state.root),
+      root: state.root,
+    };
+  };
+
+  const readProjectList = async (webContentsId) => {
+    const projects = getWindowProjects(webContentsId);
+    const entries = [];
+    const validRoots = [];
+
+    for (const root of projects.roots) {
+      try {
+        const project = await readProject(root);
+        entries.push(project);
+        validRoots.push(project.root);
+      } catch (error) {
+        if (root === projects.activeRoot) {
+          throw error;
+        }
+      }
+    }
+
+    if (validRoots.length !== projects.roots.length) {
+      writeProjectState(webContentsId, projects.activeRoot, validRoots, false);
+    }
+
+    return {
+      activeRoot: projects.activeRoot,
+      entries,
+    };
+  };
+
+  const addProject = (webContentsId, root) => {
+    const projects = getWindowProjects(webContentsId);
+    const nextRoots = normalizeProjectRoots([
+      root,
+      ...projects.roots.filter((projectRoot) => projectRoot !== root),
+    ]);
+    writeProjectState(webContentsId, root, nextRoots);
+  };
+
+  return {
+    addProject,
+    getActiveRepositoryPath,
+    readProject,
+    readProjectList,
+    removeWindow,
+    seedWindow,
+  };
+};
+
+module.exports = {
+  createProjectManager,
+};

--- a/src/App.css
+++ b/src/App.css
@@ -160,21 +160,61 @@
 .sidebar-path-row {
   align-items: center;
   display: flex;
+  gap: 10px;
   min-height: 42px;
   min-width: 0;
   padding-top: 10px;
   padding-left: 72px;
 }
 
-.sidebar-path {
+.sidebar-project-select {
+  -webkit-app-region: no-drag;
+  appearance: none;
+  background: rgb(127 127 127 / 0.1);
+  border: 0;
+  border-radius: 15px;
   color: var(--sidebar-text);
   font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 600;
+  height: 32px;
+  line-height: 32px;
+  min-width: 0;
+  outline: none;
   overflow: hidden;
+  padding: 0 24px 0 12px;
   text-overflow: ellipsis;
-  transform: translateY(-6px);
   white-space: nowrap;
+  width: 100%;
+}
+
+.sidebar-project-select:focus,
+.sidebar-open-button:focus-visible {
+  box-shadow: 0 0 0 2px rgb(61 135 245 / 0.32);
+}
+
+.sidebar-open-button {
+  -webkit-app-region: no-drag;
+  align-items: center;
+  background: rgb(127 127 127 / 0.1);
+  border: 0;
+  border-radius: 16px;
+  color: var(--sidebar-text);
+  cursor: pointer;
+  display: inline-flex;
+  flex: none;
+  font-size: 20px;
+  font-weight: 500;
+  height: 32px;
+  justify-content: center;
+  line-height: 1;
+  outline: none;
+  padding: 0 0 2px;
+  width: 32px;
+}
+
+.sidebar-open-button:hover {
+  background: rgb(127 127 127 / 0.16);
 }
 
 .sidebar-search-row {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { CodeView, type CodeViewHandle, WorkerPoolContextProvider } from '@pierre/diffs/react';
 import { FileTree, useFileTree } from '@pierre/trees/react';
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react';
+import { ProjectSelector } from './project-selector.tsx';
 import dunkelTheme from './themes/dunkel.json' with { type: 'json' };
 import lichtTheme from './themes/licht.json' with { type: 'json' };
 import type {
@@ -16,6 +17,7 @@ import type {
   CodiffPreferences,
   DiffSection,
   GitFileStatus,
+  ProjectList,
   RepositoryState,
 } from './types.ts';
 
@@ -107,24 +109,6 @@ const codeViewUnsafeCSS = `
     margin-right: 14px;
   }
 `;
-
-const compactPath = (path: string) => {
-  const homePath = path
-    .replace(/^\/Users\/[^/]+(?=\/|$)/, '~')
-    .replace(/^\/home\/[^/]+(?=\/|$)/, '~');
-  const parts = homePath.split('/').filter(Boolean);
-
-  if (parts.length <= 2) {
-    return homePath;
-  }
-
-  const prefix = homePath.startsWith('/') ? '/' : '';
-  const [first, ...rest] = parts;
-  const last = rest.pop();
-  const middle = rest.map((part) => part[0]).join('/');
-
-  return `${prefix}${first}/${middle ? `${middle}/` : ''}${last}`;
-};
 
 function compareTreePaths(leftPath: string, rightPath: string) {
   const leftParts = leftPath.split('/');
@@ -803,6 +787,7 @@ export default function App() {
   const [itemVersionByPath, setItemVersionByPath] = useState<Record<string, number>>({});
   const [localChangesDetected, setLocalChangesDetected] = useState(false);
   const [preferences, setPreferences] = useState<CodiffPreferences>(defaultPreferences);
+  const [projects, setProjects] = useState<ProjectList | null>(null);
   const [scrollTarget, setScrollTarget] = useState<{ path: string; request: number } | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -811,6 +796,52 @@ export default function App() {
   const loadingSectionKeysRef = useRef<Set<string>>(new Set());
   const programmaticScrollPathRef = useRef<string | null>(null);
   const programmaticScrollTimerRef = useRef<number | null>(null);
+
+  const applyRepositoryState = useCallback(
+    (nextState: RepositoryState, preserveSelection = false) => {
+      const orderedState = {
+        ...nextState,
+        files: sortFiles(nextState.files),
+      };
+      const nextViewed = readViewed(orderedState.root);
+
+      setState(orderedState);
+      setError(null);
+      setCollapsed(
+        new Set(
+          orderedState.files
+            .filter((file) => nextViewed[file.path] === file.fingerprint)
+            .map((file) => file.path),
+        ),
+      );
+      setItemVersionByPath({});
+      setViewed(nextViewed);
+      setScrollTarget(null);
+      setSearchQuery('');
+      setSelectedPath((current) =>
+        preserveSelection && current && orderedState.files.some((file) => file.path === current)
+          ? current
+          : (orderedState.files[0]?.path ?? null),
+      );
+    },
+    [],
+  );
+
+  const loadRepositoryState = useCallback(
+    (preserveSelection = false) => {
+      setError(null);
+
+      return window.codiff
+        .getRepositoryState()
+        .then((nextState) => {
+          applyRepositoryState(nextState, preserveSelection);
+        })
+        .catch((error: unknown) => {
+          setError(error instanceof Error ? error.message : String(error));
+        });
+    },
+    [applyRepositoryState],
+  );
 
   const bumpItemVersion = useCallback((path: string) => {
     setItemVersionByPath((current) => ({
@@ -822,31 +853,14 @@ export default function App() {
   useEffect(() => {
     let canceled = false;
 
-    window.codiff
-      .getRepositoryState()
-      .then((nextState) => {
+    Promise.all([window.codiff.getProjects(), window.codiff.getRepositoryState()])
+      .then(([nextProjects, nextState]) => {
         if (canceled) {
           return;
         }
 
-        const orderedState = {
-          ...nextState,
-          files: sortFiles(nextState.files),
-        };
-        const nextViewed = readViewed(orderedState.root);
-
-        setState(orderedState);
-        setError(null);
-        setCollapsed(
-          new Set(
-            orderedState.files
-              .filter((file) => nextViewed[file.path] === file.fingerprint)
-              .map((file) => file.path),
-          ),
-        );
-        setItemVersionByPath({});
-        setViewed(nextViewed);
-        setSelectedPath((current) => current ?? orderedState.files[0]?.path ?? null);
+        setProjects(nextProjects);
+        applyRepositoryState(nextState);
       })
       .catch((error: unknown) => {
         if (!canceled) {
@@ -857,7 +871,7 @@ export default function App() {
     return () => {
       canceled = true;
     };
-  }, []);
+  }, [applyRepositoryState]);
 
   useEffect(
     () =>
@@ -1131,6 +1145,34 @@ export default function App() {
     [bumpItemVersion, state],
   );
 
+  const loadProject = useCallback(
+    (projectAction: () => Promise<ProjectList>) =>
+      projectAction()
+        .then((nextProjects) => {
+          setProjects(nextProjects);
+          return loadRepositoryState();
+        })
+        .catch((error: unknown) => {
+          setError(error instanceof Error ? error.message : String(error));
+        }),
+    [loadRepositoryState],
+  );
+
+  const handleOpenProject = useCallback(() => {
+    loadProject(() => window.codiff.openProject());
+  }, [loadProject]);
+
+  const handleSelectProject = useCallback(
+    (root: string) => {
+      if (root === projects?.activeRoot) {
+        return;
+      }
+
+      loadProject(() => window.codiff.selectProject(root));
+    },
+    [loadProject, projects?.activeRoot],
+  );
+
   if (error) {
     return (
       <main className="empty-state">
@@ -1156,11 +1198,12 @@ export default function App() {
       <RepositoryChangeBanner visible={localChangesDetected} />
       <aside className="sidebar squircle">
         <div className="sidebar-header">
-          <div className="sidebar-path-row">
-            <div className="sidebar-path" title={state.root}>
-              {compactPath(state.root)}
-            </div>
-          </div>
+          <ProjectSelector
+            activeRoot={state.root}
+            onOpenProject={handleOpenProject}
+            onSelectProject={handleSelectProject}
+            projects={projects}
+          />
         </div>
         <Sidebar
           files={visibleFiles}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,6 +2,7 @@ import type {
   CodiffPreferences,
   DiffSection,
   DiffSectionContentRequest,
+  ProjectList,
   RepositoryHistory,
   RepositoryState,
   ReviewSource,
@@ -12,10 +13,13 @@ declare global {
     codiff: {
       getDiffSectionContent: (request: DiffSectionContentRequest) => Promise<DiffSection>;
       getPreferences: () => Promise<CodiffPreferences>;
+      getProjects: () => Promise<ProjectList>;
       getRepositoryHistory: (limit?: number) => Promise<RepositoryHistory>;
       getRepositoryState: (source?: ReviewSource) => Promise<RepositoryState>;
       onPreferencesChanged: (callback: (preferences: CodiffPreferences) => void) => () => void;
       onRepositoryChanged: (callback: (change: { root: string }) => void) => () => void;
+      openProject: () => Promise<ProjectList>;
+      selectProject: (root: string) => Promise<ProjectList>;
       showInFolder: (path: string) => Promise<void>;
     };
   }

--- a/src/project-selector.tsx
+++ b/src/project-selector.tsx
@@ -1,0 +1,62 @@
+import type { ProjectList } from './types.ts';
+
+const compactPath = (path: string) => {
+  const homePath = path
+    .replace(/^\/Users\/[^/]+(?=\/|$)/, '~')
+    .replace(/^\/home\/[^/]+(?=\/|$)/, '~');
+  const parts = homePath.split('/').filter(Boolean);
+
+  if (parts.length <= 2) {
+    return homePath;
+  }
+
+  const prefix = homePath.startsWith('/') ? '/' : '';
+  const [first, ...rest] = parts;
+  const last = rest.pop();
+  const middle = rest.map((part) => part[0]).join('/');
+
+  return `${prefix}${first}/${middle ? `${middle}/` : ''}${last}`;
+};
+
+const projectLabel = (path: string) => path.split('/').filter(Boolean).at(-1) ?? compactPath(path);
+
+export function ProjectSelector({
+  activeRoot,
+  onOpenProject,
+  onSelectProject,
+  projects,
+}: {
+  activeRoot: string;
+  onOpenProject: () => void;
+  onSelectProject: (root: string) => void;
+  projects: ProjectList | null;
+}) {
+  const entries = projects?.entries ?? [{ label: projectLabel(activeRoot), root: activeRoot }];
+
+  return (
+    <div className="sidebar-path-row">
+      <select
+        aria-label="Selected repository"
+        className="sidebar-project-select"
+        onChange={(event) => onSelectProject(event.currentTarget.value)}
+        title={activeRoot}
+        value={projects?.activeRoot ?? activeRoot}
+      >
+        {entries.map((project) => (
+          <option key={project.root} value={project.root}>
+            {project.label}
+          </option>
+        ))}
+      </select>
+      <button
+        aria-label="Open repository"
+        className="sidebar-open-button"
+        onClick={onOpenProject}
+        title="Open repository"
+        type="button"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,16 @@ export type RepositoryHistory = {
   root: string;
 };
 
+export type ProjectEntry = {
+  label: string;
+  root: string;
+};
+
+export type ProjectList = {
+  activeRoot: string;
+  entries: ReadonlyArray<ProjectEntry>;
+};
+
 export type RepositoryState = {
   files: ReadonlyArray<ChangedFile>;
   generatedAt: number;


### PR DESCRIPTION
## Description
Codiff currently opens a single repository per window and requires launching the app again to inspect a different project. That works for the smallest workflow, but it makes switching between nearby repositories awkward. This PR adds a lightweight project switcher so users can open another repository from the sidebar, switch back to recently opened repositories, and have the last selected project restored on launch.

This is intentionally small, but I am not fully sure yet what structure fits the project best as it grows. I split the project state handling into a small Electron-side project manager and the sidebar control into a React component, but I would be happy to adjust naming or structure if there is a preferred convention for this codebase.

## Changes
- Added Electron IPC handlers for reading known projects, selecting a project, and opening a repository directory through the native folder picker.
- Added `electron/project-manager.cjs` to track the active repository per window, normalize project roots, validate repositories, persist recent projects, and restore the last project.
- Extended preferences with `lastProjectRoot` and `projects`.
- Updated repository state, history, show-in-folder, and relative-path IPC handlers to use the active project for the current window.
- Added a `ProjectSelector` React component for the sidebar repository dropdown and open-repository button.
- Refactored repository loading in `App.tsx` so project switching resets repository-specific UI state and loads viewed/collapsed state for the selected repository.
- Added `ProjectEntry` and `ProjectList` types plus preload/global API definitions for the new project APIs.
- Updated sidebar styles for the project selector and open button.

## Type of Change
- [x] New feature / capability
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Behavior Change
Codiff can now switch repositories from within the app instead of being tied to only the repository selected at launch.

**Before:**
The sidebar showed the current repository path as static text. To inspect another repository, the user had to relaunch/open another Codiff instance with a different path.

**After:**
The sidebar shows a repository selector. Users can open another repository with the native folder picker, switch between known repositories from the dropdown, and Codiff restores the last selected repository on the next launch unless an explicit launch path is provided.

## Pre-Deployment Migrations
No migrations required before deploying.