### PR TITLE
feat: export review comments for automation

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -347,8 +347,12 @@ const createWindow = (repositoryPath, launchOptions = { walkthrough: false }) =>
     minWidth: 880,
     show: false,
     title: `Codiff - ${repositoryPath}`,
-    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
-    trafficLightPosition: { x: 25, y: 24 },
+    // Keep the native Windows/Linux title bar so the desktop window has
+    // normal minimize/maximize/close controls. Codiff's upstream hidden title
+    // bar works on macOS, but on Windows it leaves our packaged app without a
+    // practical close button.
+    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+    ...(process.platform === 'darwin' ? { trafficLightPosition: { x: 25, y: 24 } } : {}),
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
@@ -473,6 +477,41 @@ ipcMain.handle('codiff:showInFolder', async (event, filePath) => {
   } else {
     shell.openPath(state.root);
   }
+});
+
+ipcMain.handle('codiff:writeReviewComments', async (event, payload) => {
+  // Persist the renderer's in-memory review comments next to the repository
+  // being reviewed. This gives external automation a stable file to read after
+  // a human finishes commenting in the Codiff window.
+  const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
+  const state = await readRepositoryState(repositoryPath);
+  const directory = join(state.root, '.codiff');
+  const markdownPath = join(directory, 'review-comments.md');
+  const jsonPath = join(directory, 'review-comments.json');
+
+  // Treat the IPC payload as untrusted UI input: normalize missing/malformed
+  // values so a bad renderer message cannot crash the main process handler.
+  const comments = Array.isArray(payload?.comments) ? payload.comments : [];
+  const markdown = typeof payload?.markdown === 'string' ? payload.markdown : '';
+
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(markdownPath, markdown, 'utf8');
+  writeFileSync(
+    jsonPath,
+    JSON.stringify(
+      {
+        comments,
+        generatedAt: new Date().toISOString(),
+        repositoryRoot: state.root,
+        source: state.source,
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  return { jsonPath, markdownPath };
 });
 
 ipcMain.handle('codiff:getRelativePath', async (event, filePath) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -24,4 +24,5 @@ contextBridge.exposeInMainWorld('codiff', {
     return () => ipcRenderer.removeListener('codiff:repositoryChanged', listener);
   },
   showInFolder: (path) => ipcRenderer.invoke('codiff:showInFolder', path),
+  writeReviewComments: (payload) => ipcRenderer.invoke('codiff:writeReviewComments', payload),
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2314,6 +2314,27 @@ export default function App() {
     reviewCommentsRef.current = reviewComments;
   }, [reviewComments]);
 
+  useEffect(() => {
+    if (!state) {
+      return;
+    }
+
+    // Review comments normally live only in React state. Export them whenever
+    // they change so external review tooling can read the latest reviewer
+    // feedback from disk and apply fixes in the source worktree.
+    const markdown = buildReviewCommentsMarkdown(
+      state.files,
+      reviewComments,
+      preferences.showWhitespace,
+    );
+    window.codiff
+      .writeReviewComments({
+        comments: reviewComments,
+        markdown,
+      })
+      .catch(() => undefined);
+  }, [preferences.showWhitespace, reviewComments, state]);
+
   const showWhitespace = preferences.showWhitespace;
   const walkthroughNotes = useMemo(() => getWalkthroughNotes(walkthrough), [walkthrough]);
   const orderedFiles = useMemo(

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -24,6 +24,17 @@ declare global {
       onPreferencesChanged: (callback: (preferences: CodiffPreferences) => void) => () => void;
       onRepositoryChanged: (callback: (change: { root: string }) => void) => () => void;
       showInFolder: (path: string) => Promise<void>;
+      writeReviewComments: (payload: {
+        comments: ReadonlyArray<{
+          body: string;
+          filePath: string;
+          id: string;
+          lineNumber: number;
+          sectionId: string;
+          side: 'additions' | 'deletions';
+        }>;
+        markdown: string;
+      }) => Promise<{ jsonPath: string; markdownPath: string }>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- export in-memory review comments to `.codiff/review-comments.md` and `.codiff/review-comments.json`
- expose a small Electron IPC bridge so external review automation can consume reviewer feedback
- keep native window controls visible on Windows/Linux while preserving macOS hidden title bar behavior

## Test plan
- `npx --yes pnpm@11.0.6 test`
- `npx --yes pnpm@11.0.6 exec vp build`
