### PR TITLE
Handful of UI updates

### DIFF
--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -813,12 +813,22 @@ const readPullRequestState = async (launchPath, source) => {
 
 const toGitHubReviewSide = (side) => (side === 'deletions' ? 'LEFT' : 'RIGHT');
 
-const normalizePullRequestComment = (comment) => ({
-  body: comment.body,
-  line: comment.lineNumber,
-  path: comment.filePath,
-  side: toGitHubReviewSide(comment.side),
-});
+const normalizePullRequestComment = (comment) => {
+  const payload = {
+    body: comment.body,
+    line: comment.lineNumber,
+    path: comment.filePath,
+    side: toGitHubReviewSide(comment.side),
+  };
+  if (
+    typeof comment.startLineNumber === 'number' &&
+    comment.startLineNumber !== comment.lineNumber
+  ) {
+    payload.start_line = comment.startLineNumber;
+    payload.start_side = toGitHubReviewSide(comment.side);
+  }
+  return payload;
+};
 
 const submitPullRequestComment = async (launchPath, request) => {
   const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -44,6 +44,7 @@ const windowRepositories = new Map();
 const windowLaunchOptions = new Map();
 let preferences = {
   showWhitespace: false,
+  theme: 'system',
 };
 
 const commitHashPattern = /^[0-9a-f]{4,64}$/i;
@@ -280,10 +281,14 @@ const getPreferencesPath = () => join(app.getPath('userData'), 'preferences.json
 
 const readPreferences = () => {
   try {
-    return {
+    const merged = {
       ...preferences,
       ...JSON.parse(readFileSync(getPreferencesPath(), 'utf8')),
     };
+    if (merged.theme !== 'system' && merged.theme !== 'light' && merged.theme !== 'dark') {
+      merged.theme = 'system';
+    }
+    return merged;
   } catch {
     return preferences;
   }
@@ -299,6 +304,14 @@ const sendPreferencesChanged = () => {
       window.webContents.send('codiff:preferencesChanged', preferences);
     }
   }
+};
+
+const updateTheme = (theme) => {
+  preferences = { ...preferences, theme };
+  nativeTheme.themeSource = theme;
+  writePreferences();
+  sendPreferencesChanged();
+  Menu.setApplicationMenu(buildApplicationMenu());
 };
 
 const readRepositoryWatcherSnapshot = async (repositoryPath) => {
@@ -604,6 +617,29 @@ const buildApplicationMenu = () =>
           label: 'Show Whitespace',
           type: 'checkbox',
         },
+        {
+          label: 'Theme',
+          submenu: [
+            {
+              checked: preferences.theme === 'system',
+              click: () => updateTheme('system'),
+              label: 'Match System',
+              type: 'radio',
+            },
+            {
+              checked: preferences.theme === 'light',
+              click: () => updateTheme('light'),
+              label: 'Light',
+              type: 'radio',
+            },
+            {
+              checked: preferences.theme === 'dark',
+              click: () => updateTheme('dark'),
+              label: 'Dark',
+              type: 'radio',
+            },
+          ],
+        },
         { type: 'separator' },
         { role: 'togglefullscreen' },
         { role: 'reload' },
@@ -691,6 +727,7 @@ if (squirrelStartup || !lock) {
 
   app.on('ready', () => {
     preferences = readPreferences();
+    nativeTheme.themeSource = preferences.theme;
     Menu.setApplicationMenu(buildApplicationMenu());
     createWindow(getLaunchPath(), getLaunchOptions());
   });

--- a/src/App.css
+++ b/src/App.css
@@ -67,6 +67,48 @@
     }
   }
 
+  :root[data-theme='light'] {
+    --app-bg: #f8f8f6;
+    --code-bg: #ffffff;
+    --danger: #a33a3a;
+    --diff-addition: rgb(31 122 68);
+    --diff-deletion: rgb(184 49 47);
+    --file-bg: rgb(255 255 255 / 0.78);
+    --file-border: rgb(17 17 17 / 0.09);
+    --inline-code-bg: rgb(242 242 242);
+    --muted: rgb(17 17 17 / 0.48);
+    --sidebar-bg: rgb(255 255 255 / 0.58);
+    --sidebar-border: rgb(17 17 17 / 0.1);
+    --sidebar-ref: #c56e0e;
+    --sidebar-text: rgb(17 17 17 / 0.76);
+    --text: #111111;
+    --tree-selection-bg: #c2e8ff50;
+    --tree-selection-focus: #3d87f5;
+    --viewed: rgb(31 122 68);
+    color-scheme: light;
+  }
+
+  :root[data-theme='dark'] {
+    --app-bg: #141414;
+    --code-bg: #1c1c1c;
+    --danger: #e07878;
+    --diff-addition: rgb(111 208 148);
+    --diff-deletion: rgb(238 126 126);
+    --file-bg: rgb(38 38 38 / 0.72);
+    --file-border: rgb(230 230 230 / 0.1);
+    --inline-code-bg: rgb(39 39 39);
+    --muted: rgb(230 230 230 / 0.48);
+    --sidebar-bg: rgb(38 38 38 / 0.58);
+    --sidebar-border: rgb(230 230 230 / 0.1);
+    --sidebar-ref: #eb9a3d;
+    --sidebar-text: rgb(230 230 230 / 0.78);
+    --text: rgb(230 230 230);
+    --tree-selection-bg: #a5a5a540;
+    --tree-selection-focus: #3d87f5;
+    --viewed: rgb(111 208 148);
+    color-scheme: dark;
+  }
+
   * {
     box-sizing: border-box;
   }

--- a/src/App.css
+++ b/src/App.css
@@ -677,9 +677,37 @@
 }
 
 .review-source-loading {
+  align-items: center;
   background: var(--code-bg);
+  display: flex;
   height: 100%;
+  justify-content: center;
   width: 100%;
+}
+
+.review-source-loading-indicator {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  gap: 10px;
+}
+
+.review-source-loading-spinner {
+  animation: review-source-loading-spin 0.8s linear infinite;
+  border: 2px solid var(--file-border);
+  border-radius: 50%;
+  border-top-color: var(--text);
+  display: inline-block;
+  height: 16px;
+  width: 16px;
+}
+
+@keyframes review-source-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .code-view {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2261,21 +2261,6 @@ function ReviewCodeView({
             side,
           });
         },
-        onLineClick: (line, context) => {
-          if (line.type !== 'diff-line') {
-            return;
-          }
-          const meta = itemMetadata.get(context.item.id);
-          if (!meta || meta.isCollapsed) {
-            return;
-          }
-          onCreateComment({
-            filePath: meta.file.path,
-            lineNumber: line.lineNumber,
-            sectionId: meta.section.id,
-            side: line.annotationSide,
-          });
-        },
         stickyHeaders: true,
         theme: {
           dark: 'Dunkel',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -371,6 +371,7 @@ const fileTreeSort = (
 
 const defaultPreferences: CodiffPreferences = {
   showWhitespace: false,
+  theme: 'system',
 };
 
 const codeViewUnsafeCSS = `
@@ -3252,6 +3253,15 @@ export default function App() {
       removeListener();
     };
   }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (preferences.theme === 'system') {
+      root.removeAttribute('data-theme');
+    } else {
+      root.setAttribute('data-theme', preferences.theme);
+    }
+  }, [preferences.theme]);
 
   useEffect(
     () => () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,7 @@ type ReviewComment = {
   lineNumber: number;
   sectionId: string;
   side: 'additions' | 'deletions';
+  startLineNumber?: number;
   submittedAt?: string;
   url?: string;
 };
@@ -1070,8 +1071,10 @@ export const fileHasVisibleDiff = (file: ChangedFile, showWhitespace: boolean) =
 const getFirstVisibleSection = (file: ChangedFile, showWhitespace: boolean) =>
   getVisibleDiffSections(file, showWhitespace)[0]?.section;
 
-const getCommentKey = (comment: Pick<ReviewComment, 'lineNumber' | 'sectionId' | 'side'>) =>
-  `${comment.sectionId}:${comment.side}:${comment.lineNumber}`;
+const getCommentKey = (
+  comment: Pick<ReviewComment, 'lineNumber' | 'sectionId' | 'side' | 'startLineNumber'>,
+) =>
+  `${comment.sectionId}:${comment.side}:${comment.lineNumber}:${comment.startLineNumber ?? comment.lineNumber}`;
 
 const getReviewCommentsDigest = (comments: ReadonlyArray<ReviewComment>) =>
   comments
@@ -1155,23 +1158,28 @@ const getReviewCommentPatchContext = (
       additionLineNumber += content.additions;
     }
 
-    const targetIndex = rows.findIndex((row) =>
+    const matchesLine = (row: (typeof rows)[number], lineNumber: number) =>
       row.side
         ? row.side === comment.side &&
           (comment.side === 'additions'
-            ? row.additionLineNumber === comment.lineNumber
-            : row.deletionLineNumber === comment.lineNumber)
+            ? row.additionLineNumber === lineNumber
+            : row.deletionLineNumber === lineNumber)
         : comment.side === 'additions'
-          ? row.additionLineNumber === comment.lineNumber
-          : row.deletionLineNumber === comment.lineNumber,
-    );
+          ? row.additionLineNumber === lineNumber
+          : row.deletionLineNumber === lineNumber;
+
+    const startLine = comment.startLineNumber ?? comment.lineNumber;
+    const endLine = comment.lineNumber;
+    const targetIndex = rows.findIndex((row) => matchesLine(row, endLine));
+    const rangeStartIndex = rows.findIndex((row) => matchesLine(row, startLine));
 
     if (targetIndex === -1) {
       continue;
     }
 
-    const start = Math.max(0, targetIndex - 3);
-    const end = Math.min(rows.length, targetIndex + 4);
+    const anchorStart = rangeStartIndex === -1 ? targetIndex : rangeStartIndex;
+    const start = Math.max(0, Math.min(anchorStart, targetIndex) - 3);
+    const end = Math.min(rows.length, Math.max(anchorStart, targetIndex) + 4);
     const context = rows.slice(start, end).map((row) => {
       const lineNumber =
         row.prefix === '+'
@@ -1215,8 +1223,13 @@ export const buildReviewCommentsMarkdown = (
           : 'No patch context available.';
       const fence = getMarkdownFence(context);
 
+      const lineLabel =
+        comment.startLineNumber != null && comment.startLineNumber !== comment.lineNumber
+          ? `lines ${comment.startLineNumber}–${comment.lineNumber}`
+          : `line ${comment.lineNumber}`;
+
       return [
-        `${index + 1}. **${comment.filePath}** (${comment.side} line ${comment.lineNumber})`,
+        `${index + 1}. **${comment.filePath}** (${comment.side} ${lineLabel})`,
         '',
         indentMarkdown(`${fence}diff\n${context}\n${fence}`),
         '',
@@ -1998,7 +2011,11 @@ function ReviewAnnotation({
                 >
                   <strong>{displayName}</strong>
                   <span>
-                    {comment.side === 'additions' ? 'New' : 'Old'} line {comment.lineNumber}
+                    {comment.side === 'additions' ? 'New' : 'Old'}{' '}
+                    {comment.startLineNumber != null &&
+                    comment.startLineNumber !== comment.lineNumber
+                      ? `lines ${comment.startLineNumber}–${comment.lineNumber}`
+                      : `line ${comment.lineNumber}`}
                   </span>
                   {!comment.isReadOnly ? (
                     <button
@@ -2039,7 +2056,12 @@ function ReviewAnnotation({
                   ) : null}
                 </div>
                 <textarea
-                  aria-label={`Comment on ${comment.filePath} line ${comment.lineNumber}`}
+                  aria-label={`Comment on ${comment.filePath} ${
+                    comment.startLineNumber != null &&
+                    comment.startLineNumber !== comment.lineNumber
+                      ? `lines ${comment.startLineNumber}–${comment.lineNumber}`
+                      : `line ${comment.lineNumber}`
+                  }`}
                   className={`review-comment-input${comment.isReadOnly ? ' read-only' : ''}`}
                   onChange={(event) => onUpdateComment(comment.id, event.currentTarget.value)}
                   onKeyDown={(event) => handleCommentKeyDown(event, comment)}
@@ -2240,7 +2262,7 @@ function ReviewCodeView({
         diffIndicators: 'bars',
         diffStyle: 'split',
         enableGutterUtility: true,
-        enableLineSelection: false,
+        enableLineSelection: true,
         expandUnchanged: false,
         expansionLineCount: diffContextExpansionLineCount,
         hunkSeparators: 'line-info-basic',
@@ -2254,11 +2276,14 @@ function ReviewCodeView({
             return;
           }
           const side = range.side ?? range.endSide ?? 'additions';
+          const start = Math.min(range.start, range.end);
+          const end = Math.max(range.start, range.end);
           onCreateComment({
             filePath: meta.file.path,
-            lineNumber: range.start,
+            lineNumber: end,
             sectionId: meta.section.id,
             side,
+            ...(end !== start ? { startLineNumber: start } : {}),
           });
         },
         stickyHeaders: true,
@@ -3852,6 +3877,9 @@ export default function App() {
             filePath: comment.filePath,
             lineNumber: comment.lineNumber,
             side: comment.side,
+            ...(comment.startLineNumber != null && comment.startLineNumber !== comment.lineNumber
+              ? { startLineNumber: comment.startLineNumber }
+              : {}),
           },
           source: currentState.source,
         })
@@ -3906,6 +3934,9 @@ export default function App() {
             filePath: comment.filePath,
             lineNumber: comment.lineNumber,
             side: comment.side,
+            ...(comment.startLineNumber != null && comment.startLineNumber !== comment.lineNumber
+              ? { startLineNumber: comment.startLineNumber }
+              : {}),
           })),
           event,
           source: currentState.source,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2506,6 +2506,26 @@ function ReviewCodeView({
   );
 }
 
+function ReviewSourceLoading() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setVisible(true), 200);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return (
+    <div className="review-source-loading">
+      {visible ? (
+        <div className="review-source-loading-indicator" role="status">
+          <span aria-hidden className="review-source-loading-spinner" />
+          <span>Loading diff…</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function RepositoryChangeBanner({ visible }: { visible: boolean }) {
   return (
     <div aria-live="polite" className={`repository-change-banner${visible ? ' visible' : ''}`}>
@@ -4032,7 +4052,7 @@ export default function App() {
       </aside>
       <main className="review">
         {isSwitchingSource ? (
-          <div className="review-source-loading" />
+          <ReviewSourceLoading />
         ) : state.files.length === 0 ? (
           <div className="empty-state">
             <div className="empty-panel squircle">

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,7 @@ export type PullRequestReviewComment = {
   filePath: string;
   lineNumber: number;
   side: 'additions' | 'deletions';
+  startLineNumber?: number;
 };
 
 export type PullRequestExistingReviewComment = PullRequestReviewComment & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,8 +159,11 @@ export type DiffSectionContentRequest = {
   source?: ReviewSource;
 };
 
+export type CodiffTheme = 'system' | 'light' | 'dark';
+
 export type CodiffPreferences = {
   showWhitespace: boolean;
+  theme: CodiffTheme;
 };
 
 export type PullRequestReviewComment = {


### PR DESCRIPTION
Really like this app for my current workflow. Thought I would make a few changes. Happy to separate these into separate PRs or you can discard altogether, I can just use locally as needed

## Loading indicator
I used this in a large repo and the time for the diff to load in history can take a few seconds

## Comment box toggle
 Made it so that comment only happens when clicking "+" now. This is because I couldn't select text for copy/paste without toggling a comment box
<img width="417" height="128" alt="Screenshot 2026-05-19 at 11 51 11 AM" src="https://github.com/user-attachments/assets/4901d983-d4ef-4cea-9313-5ef3ead01013" />

## Theme Switcher
Added a theme switcher. I use a dynamic system theme but prefer the app to always use one specific scheme.
<img width="401" height="209" alt="Screenshot 2026-05-19 at 11 50 37 AM" src="https://github.com/user-attachments/assets/f3de9feb-083b-444c-8341-2b3bae693213" />

## Multi line comment
Being able to comment on a specific range is helpful
<img width="728" height="335" alt="Screenshot 2026-05-19 at 11 50 22 AM" src="https://github.com/user-attachments/assets/2c00ac6f-a8a8-41fe-b4a9-2f5744987741" />
