### PR TITLE
Add option to automatically copy comments to clipboard on quit

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -17,6 +17,7 @@ const { parseArgs } = require('node:util');
 const {
   app,
   BrowserWindow,
+  clipboard,
   dialog,
   ipcMain,
   Menu,
@@ -49,6 +50,7 @@ const repositoryWatchers = new Map();
 const windowRepositories = new Map();
 const windowLaunchOptions = new Map();
 let preferences = {
+  copyCommentsOnClose: false,
   openAIModel: DEFAULT_OPENAI_MODEL,
   showWhitespace: false,
   theme: 'system',
@@ -672,6 +674,16 @@ const buildApplicationMenu = () =>
           type: 'checkbox',
         },
         {
+          checked: preferences.copyCommentsOnClose,
+          click: (menuItem) => {
+            updatePreferences({
+              copyCommentsOnClose: menuItem.checked,
+            });
+          },
+          label: 'Copy Comments on Close',
+          type: 'checkbox',
+        },
+        {
           label: 'Theme',
           submenu: [
             {
@@ -706,6 +718,46 @@ const buildApplicationMenu = () =>
     },
   ]);
 
+let nextCopyPendingCommentsRequestId = 0;
+const pendingCopyPendingCommentsRequests = new Map();
+let quitting = false;
+
+ipcMain.on('codiff:copyPendingCommentsResult', (event, requestId, markdown) => {
+  const pending = pendingCopyPendingCommentsRequests.get(requestId);
+  if (!pending || pending.webContentsId !== event.sender.id) {
+    return;
+  }
+
+  pendingCopyPendingCommentsRequests.delete(requestId);
+  pending.resolve(typeof markdown === 'string' ? markdown : '');
+});
+
+const requestPendingCommentsMarkdown = (browserWindow) =>
+  new Promise((resolve) => {
+    if (browserWindow.isDestroyed() || browserWindow.webContents.isDestroyed()) {
+      resolve('');
+      return;
+    }
+
+    const requestId = ++nextCopyPendingCommentsRequestId;
+    const webContentsId = browserWindow.webContents.id;
+    const timeout = setTimeout(() => {
+      if (pendingCopyPendingCommentsRequests.delete(requestId)) {
+        resolve('');
+      }
+    }, 2000);
+
+    pendingCopyPendingCommentsRequests.set(requestId, {
+      resolve: (markdown) => {
+        clearTimeout(timeout);
+        resolve(markdown);
+      },
+      webContentsId,
+    });
+
+    browserWindow.webContents.send('codiff:copyPendingCommentsRequest', requestId);
+  });
+
 const createWindow = (
   repositoryPath,
   launchOptions = { repositoryPathProvided: true, walkthrough: false },
@@ -738,6 +790,26 @@ const createWindow = (
     startRepositoryWatcher(window, repositoryPath);
   }
   window.once('ready-to-show', () => window.show());
+  let allowClose = false;
+  window.on('close', (event) => {
+    if (allowClose || quitting || !preferences.copyCommentsOnClose) {
+      return;
+    }
+
+    event.preventDefault();
+    requestPendingCommentsMarkdown(window)
+      .then((markdown) => {
+        if (markdown) {
+          clipboard.writeText(markdown);
+        }
+      })
+      .finally(() => {
+        allowClose = true;
+        if (!window.isDestroyed()) {
+          window.close();
+        }
+      });
+  });
   window.on('closed', () => {
     const watcher = repositoryWatchers.get(webContentsId);
     if (watcher?.interval) {
@@ -794,6 +866,10 @@ if (squirrelStartup || !lock) {
 
   app.on('window-all-closed', () => {
     app.quit();
+  });
+
+  app.on('before-quit', () => {
+    quitting = true;
   });
 }
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -11,6 +11,24 @@ contextBridge.exposeInMainWorld('codiff', {
   getTerminalHelperStatus: () => ipcRenderer.invoke('codiff:getTerminalHelperStatus'),
   getWalkthrough: (source) => ipcRenderer.invoke('codiff:getWalkthrough', source),
   installTerminalHelper: () => ipcRenderer.invoke('codiff:installTerminalHelper'),
+  onCopyPendingCommentsRequest: (callback) => {
+    const listener = (_event, requestId) => {
+      Promise.resolve(callback()).then(
+        (markdown) => {
+          ipcRenderer.send(
+            'codiff:copyPendingCommentsResult',
+            requestId,
+            typeof markdown === 'string' ? markdown : '',
+          );
+        },
+        () => {
+          ipcRenderer.send('codiff:copyPendingCommentsResult', requestId, '');
+        },
+      );
+    };
+    ipcRenderer.on('codiff:copyPendingCommentsRequest', listener);
+    return () => ipcRenderer.removeListener('codiff:copyPendingCommentsRequest', listener);
+  },
   onFindInDiffs: (callback) => {
     const listener = () => callback();
     ipcRenderer.on('codiff:findInDiffs', listener);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -416,6 +416,7 @@ const fileTreeSort = (
 ) => compareTreePaths(left.path, right.path);
 
 const defaultPreferences: CodiffPreferences = {
+  copyCommentsOnClose: false,
   openAIModel: 'gpt-5.3-codex-spark',
   showWhitespace: false,
   theme: 'system',
@@ -2965,6 +2966,7 @@ export default function App() {
   const sourceSessionsRef = useRef<Map<string, SourceSession>>(new Map());
   const stateRef = useRef<RepositoryState | null>(null);
   const collapsedRef = useRef<Set<string>>(new Set());
+  const preferencesRef = useRef<CodiffPreferences>(defaultPreferences);
   const reviewCommentsRef = useRef<ReadonlyArray<ReviewComment>>([]);
   const selectedPathRef = useRef<string | null>(null);
   const sidebarModeRef = useRef<SidebarMode>('tree');
@@ -3426,6 +3428,26 @@ export default function App() {
   useEffect(() => {
     reviewCommentsRef.current = reviewComments;
   }, [reviewComments]);
+
+  useEffect(() => {
+    preferencesRef.current = preferences;
+  }, [preferences]);
+
+  useEffect(() => {
+    const removeListener = window.codiff.onCopyPendingCommentsRequest(() => {
+      const currentState = stateRef.current;
+      if (!currentState) {
+        return '';
+      }
+
+      return buildReviewCommentsMarkdown(
+        currentState.files,
+        reviewCommentsRef.current,
+        preferencesRef.current.showWhitespace,
+      );
+    });
+    return removeListener;
+  }, []);
 
   useEffect(() => {
     selectedPathRef.current = selectedPath;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -29,6 +29,9 @@ declare global {
       getTerminalHelperStatus: () => Promise<TerminalHelperStatus>;
       getWalkthrough: (source?: ReviewSource) => Promise<WalkthroughResult>;
       installTerminalHelper: () => Promise<TerminalHelperStatus>;
+      onCopyPendingCommentsRequest: (
+        callback: () => string | Promise<string>,
+      ) => () => void;
       onFindInDiffs: (callback: () => void) => () => void;
       onPreferencesChanged: (callback: (preferences: CodiffPreferences) => void) => () => void;
       onRepositoryChanged: (callback: (change: { root: string }) => void) => () => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,7 @@ export type DiffSectionContentRequest = {
 export type CodiffTheme = 'system' | 'light' | 'dark';
 
 export type CodiffPreferences = {
+  copyCommentsOnClose: boolean;
   openAIModel: string;
   showWhitespace: boolean;
   theme: CodiffTheme;


### PR DESCRIPTION
Another random bit that I find myself using so that I don't have to click the copy button. Again, feel free to disregard if you don't think it is helpful or aligns with the app.

By default it is not enabled, but here is a shot of it enabled.

<img width="287" height="236" alt="Screenshot 2026-05-19 at 1 25 16 PM" src="https://github.com/user-attachments/assets/9571dcde-5d2a-4c20-bd0e-1b110c567aef" />


----

**Demo:** (I used CMD+w to close codiff)


https://github.com/user-attachments/assets/47b8d3ff-1a3a-4a4a-8f36-331436b4a771



