### PR TITLE
A few more UI improvements

### DIFF
--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -33,6 +33,7 @@ const defaultSettings = {
 /** @type {CodiffKeymap} */
 const defaultKeymap = {
   closeSearch: 'Escape',
+  commandBar: 'Mod+Shift+p',
   diffSearch: 'Mod+f',
   discardComment: 'Escape',
   fileFilter: 'Mod+p',
@@ -152,6 +153,8 @@ const mergeConfig = (raw) => {
         typeof rawKeymap.closeSearch === 'string'
           ? rawKeymap.closeSearch
           : defaultKeymap.closeSearch,
+      commandBar:
+        typeof rawKeymap.commandBar === 'string' ? rawKeymap.commandBar : defaultKeymap.commandBar,
       diffSearch:
         typeof rawKeymap.diffSearch === 'string' ? rawKeymap.diffSearch : defaultKeymap.diffSearch,
       discardComment:

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -40,6 +40,7 @@ const defaultKeymap = {
   nextSearchMatch: 'Enter',
   prevSearchMatch: 'Shift+Enter',
   submitComment: 'Mod+Enter',
+  toggleSidebar: 'Mod+b',
 };
 
 /** @type {CodiffConfig} */
@@ -175,6 +176,10 @@ const mergeConfig = (raw) => {
         typeof rawKeymap.submitComment === 'string'
           ? rawKeymap.submitComment
           : defaultKeymap.submitComment,
+      toggleSidebar:
+        typeof rawKeymap.toggleSidebar === 'string'
+          ? rawKeymap.toggleSidebar
+          : defaultKeymap.toggleSidebar,
     },
     settings: {
       copyCommentsOnClose:

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -1,0 +1,348 @@
+// @ts-check
+
+const {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  watch,
+  writeFileSync,
+} = require('node:fs');
+const { homedir } = require('node:os');
+const { join } = require('node:path');
+
+/**
+ * @typedef {import('../src/config/types.ts').CodiffConfig} CodiffConfig
+ * @typedef {import('../src/config/types.ts').CodiffKeymap} CodiffKeymap
+ * @typedef {import('../src/config/types.ts').CodiffSettings} CodiffSettings
+ * @typedef {import('../src/config/types.ts').CodiffTheme} CodiffTheme
+ * @typedef {import('../src/types.ts').CodiffPreferences} CodiffPreferences
+ */
+
+const SCHEMA_URL =
+  'https://raw.githubusercontent.com/nkzw-tech/codiff/main/src/config/codiff-config.schema.json';
+
+/** @type {CodiffSettings} */
+const defaultSettings = {
+  copyCommentsOnClose: false,
+  openAIModel: 'gpt-5.3-codex-spark',
+  showWhitespace: false,
+  theme: 'system',
+};
+
+/** @type {CodiffKeymap} */
+const defaultKeymap = {
+  closeSearch: 'Escape',
+  diffSearch: 'Mod+f',
+  discardComment: 'Escape',
+  fileFilter: 'Mod+p',
+  nextSearchMatch: 'Enter',
+  prevSearchMatch: 'Shift+Enter',
+  submitComment: 'Mod+Enter',
+};
+
+/** @type {CodiffConfig} */
+const defaultConfig = {
+  keymap: defaultKeymap,
+  settings: defaultSettings,
+};
+
+const getConfigDir = () => join(homedir(), '.codiff');
+
+const getConfigPath = () => join(getConfigDir(), 'codiff.jsonc');
+
+/**
+ * Strip JSONC comments (line comments and block comments) to produce valid JSON.
+ * @param {string} text
+ * @returns {string}
+ */
+const stripJsoncComments = (text) => {
+  let result = '';
+  let i = 0;
+  let inString = false;
+
+  while (i < text.length) {
+    if (inString) {
+      if (text[i] === '\\') {
+        result += text[i] + (text[i + 1] ?? '');
+        i += 2;
+        continue;
+      }
+      if (text[i] === '"') {
+        inString = false;
+      }
+      result += text[i];
+      i++;
+      continue;
+    }
+
+    if (text[i] === '"') {
+      inString = true;
+      result += text[i];
+      i++;
+      continue;
+    }
+
+    if (text[i] === '/' && text[i + 1] === '/') {
+      // Line comment: skip to end of line
+      while (i < text.length && text[i] !== '\n') {
+        i++;
+      }
+      continue;
+    }
+
+    if (text[i] === '/' && text[i + 1] === '*') {
+      // Block comment: skip to closing */
+      i += 2;
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) {
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+
+    result += text[i];
+    i++;
+  }
+
+  return result;
+};
+
+/**
+ * Strip trailing commas from JSON (e.g., `[1, 2,]` or `{"a": 1,}`).
+ * @param {string} text
+ * @returns {string}
+ */
+const stripTrailingCommas = (text) => text.replace(/,\s*([\]}])/g, '$1');
+
+/**
+ * Parse a JSONC string into a JavaScript object.
+ * @param {string} text
+ * @returns {unknown}
+ */
+const parseJsonc = (text) => JSON.parse(stripTrailingCommas(stripJsoncComments(text)));
+
+/** @param {unknown} theme @returns {CodiffTheme} */
+const normalizeTheme = (theme) =>
+  theme === 'system' || theme === 'light' || theme === 'dark' ? theme : 'system';
+
+/**
+ * Merge a partial config object on top of defaults.
+ * @param {unknown} raw
+ * @returns {CodiffConfig}
+ */
+const mergeConfig = (raw) => {
+  if (typeof raw !== 'object' || raw === null) {
+    return defaultConfig;
+  }
+
+  const obj = /** @type {Record<string, unknown>} */ (raw);
+  const rawSettings =
+    typeof obj.settings === 'object' && obj.settings !== null
+      ? /** @type {Record<string, unknown>} */ (obj.settings)
+      : {};
+  const rawKeymap =
+    typeof obj.keymap === 'object' && obj.keymap !== null
+      ? /** @type {Record<string, unknown>} */ (obj.keymap)
+      : {};
+
+  return {
+    keymap: {
+      closeSearch:
+        typeof rawKeymap.closeSearch === 'string'
+          ? rawKeymap.closeSearch
+          : defaultKeymap.closeSearch,
+      diffSearch:
+        typeof rawKeymap.diffSearch === 'string' ? rawKeymap.diffSearch : defaultKeymap.diffSearch,
+      discardComment:
+        typeof rawKeymap.discardComment === 'string'
+          ? rawKeymap.discardComment
+          : defaultKeymap.discardComment,
+      fileFilter:
+        typeof rawKeymap.fileFilter === 'string' ? rawKeymap.fileFilter : defaultKeymap.fileFilter,
+      nextSearchMatch:
+        typeof rawKeymap.nextSearchMatch === 'string'
+          ? rawKeymap.nextSearchMatch
+          : defaultKeymap.nextSearchMatch,
+      prevSearchMatch:
+        typeof rawKeymap.prevSearchMatch === 'string'
+          ? rawKeymap.prevSearchMatch
+          : defaultKeymap.prevSearchMatch,
+      submitComment:
+        typeof rawKeymap.submitComment === 'string'
+          ? rawKeymap.submitComment
+          : defaultKeymap.submitComment,
+    },
+    settings: {
+      copyCommentsOnClose:
+        typeof rawSettings.copyCommentsOnClose === 'boolean'
+          ? rawSettings.copyCommentsOnClose
+          : defaultSettings.copyCommentsOnClose,
+      openAIModel:
+        typeof rawSettings.openAIModel === 'string'
+          ? rawSettings.openAIModel
+          : defaultSettings.openAIModel,
+      showWhitespace:
+        typeof rawSettings.showWhitespace === 'boolean'
+          ? rawSettings.showWhitespace
+          : defaultSettings.showWhitespace,
+      theme: normalizeTheme(rawSettings.theme),
+    },
+  };
+};
+
+/**
+ * Read and parse the config file. Returns defaults if the file does not exist or is invalid.
+ * @returns {CodiffConfig}
+ */
+const readConfig = () => {
+  const configPath = getConfigPath();
+
+  if (!existsSync(configPath)) {
+    return defaultConfig;
+  }
+
+  try {
+    const text = readFileSync(configPath, 'utf8');
+    const raw = parseJsonc(text);
+    return mergeConfig(raw);
+  } catch {
+    return defaultConfig;
+  }
+};
+
+/**
+ * Write a config object to the config file as JSONC with a $schema reference.
+ * @param {CodiffConfig} config
+ */
+const writeConfig = (config) => {
+  const configDir = getConfigDir();
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true });
+  }
+
+  const output = {
+    $schema: SCHEMA_URL,
+    keymap: config.keymap,
+    settings: config.settings,
+  };
+
+  writeFileSync(getConfigPath(), JSON.stringify(output, null, 2) + '\n');
+};
+
+/**
+ * Create the config file with defaults if it doesn't already exist.
+ * @returns {boolean} true if the file was created, false if it already existed.
+ */
+const initConfig = () => {
+  if (existsSync(getConfigPath())) {
+    return false;
+  }
+
+  writeConfig(defaultConfig);
+  return true;
+};
+
+/**
+ * Migrate from the old preferences.json (in Electron's userData) to the new config file.
+ * @param {string} userDataPath - Electron's app.getPath('userData')
+ * @param {(model: string) => string} normalizeOpenAIModel
+ */
+const migrateFromPreferences = (userDataPath, normalizeOpenAIModel) => {
+  const oldPath = join(userDataPath, 'preferences.json');
+
+  if (!existsSync(oldPath)) {
+    return;
+  }
+
+  // Only migrate if the new config doesn't exist yet
+  if (existsSync(getConfigPath())) {
+    // New config exists; remove old file
+    try {
+      renameSync(oldPath, oldPath + '.bak');
+    } catch {
+      // Ignore: best effort cleanup
+    }
+    return;
+  }
+
+  try {
+    const oldPrefs = JSON.parse(readFileSync(oldPath, 'utf8'));
+    const config = mergeConfig({
+      settings: {
+        ...oldPrefs,
+        openAIModel: normalizeOpenAIModel(oldPrefs?.openAIModel ?? defaultSettings.openAIModel),
+        theme: normalizeTheme(oldPrefs?.theme),
+      },
+    });
+    writeConfig(config);
+    renameSync(oldPath, oldPath + '.bak');
+  } catch {
+    // Migration failed; fall through to defaults
+  }
+};
+
+/**
+ * Watch the config file for changes.
+ * @param {(config: CodiffConfig) => void} onChange
+ * @returns {() => void} stop watching
+ */
+const watchConfig = (onChange) => {
+  const configPath = getConfigPath();
+  const configDir = getConfigDir();
+
+  // Ensure the directory exists for watching
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true });
+  }
+
+  let debounceTimer = /** @type {ReturnType<typeof setTimeout> | null} */ (null);
+
+  // Watch the directory so we detect file creation/deletion too
+  const watcher = watch(configDir, (eventType, filename) => {
+    if (filename !== 'codiff.jsonc') {
+      return;
+    }
+
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      onChange(readConfig());
+    }, 200);
+  });
+
+  return () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    watcher.close();
+  };
+};
+
+/**
+ * Convert a CodiffConfig's settings to the legacy CodiffPreferences format
+ * for backward compatibility with renderer code during migration.
+ * @param {CodiffConfig} config
+ * @returns {CodiffPreferences}
+ */
+const configToPreferences = (config) => ({
+  copyCommentsOnClose: config.settings.copyCommentsOnClose,
+  openAIModel: config.settings.openAIModel,
+  showWhitespace: config.settings.showWhitespace,
+  theme: config.settings.theme,
+});
+
+module.exports = {
+  configToPreferences,
+  defaultConfig,
+  getConfigPath,
+  initConfig,
+  mergeConfig,
+  migrateFromPreferences,
+  readConfig,
+  watchConfig,
+  writeConfig,
+};

--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-const { parseStatus, validateRepositoryPath } = require('./git-state/common.cjs');
+const { gitOrEmpty, parseStatus, validateRepositoryPath } = require('./git-state/common.cjs');
 const {
   listRepositoryHistory,
   readCommitSectionContent,
@@ -28,12 +28,16 @@ const {
  */
 
 /** @param {string} launchPath @param {ReviewSource} [source] @returns {Promise<RepositoryState>} */
-const readRepositoryState = async (launchPath, source = { type: 'working-tree' }) =>
-  source.type === 'pull-request'
-    ? readPullRequestState(launchPath, source)
-    : source.type === 'commit'
-      ? readCommitState(launchPath, source.ref)
-      : readWorkingTreeState(launchPath, { eagerContents: false });
+const readRepositoryState = async (launchPath, source = { type: 'working-tree' }) => {
+  const state =
+    source.type === 'pull-request'
+      ? await readPullRequestState(launchPath, source)
+      : source.type === 'commit'
+        ? await readCommitState(launchPath, source.ref)
+        : await readWorkingTreeState(launchPath, { eagerContents: false });
+  const branch = (await gitOrEmpty(state.root, ['symbolic-ref', '--short', 'HEAD'])).trim() || null;
+  return { ...state, branch };
+};
 
 /** @param {string} launchPath @param {DiffSectionContentRequest} request */
 const readDiffSectionContent = async (launchPath, request) =>

--- a/electron/git-state/commit.cjs
+++ b/electron/git-state/commit.cjs
@@ -553,17 +553,18 @@ const listRepositoryHistory = async (launchPath, limit = 200) => {
   const raw = await git(repoRoot, [
     'log',
     `--max-count=${limit}`,
-    '--format=%H%x1f%P%x1f%ct%x1f%s%x1e',
+    '--format=%H%x1f%P%x1f%ct%x1f%s%x1f%aN%x1e',
   ]);
   const entries = [];
 
   for (const record of raw.split('\x1e')) {
-    const [ref, parents, committedAt, subject] = record.trim().split('\x1f');
+    const [ref, parents, committedAt, subject, author] = record.trim().split('\x1f');
     if (!ref || !committedAt || subject == null) {
       continue;
     }
 
     entries.push({
+      author: author || '',
       committedAt: Number(committedAt) * 1000,
       parents: parents ? parents.split(' ') : [],
       ref,

--- a/electron/git-state/commit.cjs
+++ b/electron/git-state/commit.cjs
@@ -8,6 +8,7 @@ const {
   fileSort,
   formatBytes,
   getFingerprint,
+  getGravatarHash,
   git,
   gitBufferWithInput,
   normalizeStatus,
@@ -553,19 +554,24 @@ const listRepositoryHistory = async (launchPath, limit = 200) => {
   const raw = await git(repoRoot, [
     'log',
     `--max-count=${limit}`,
-    '--format=%H%x1f%P%x1f%ct%x1f%s%x1f%aN%x1e',
+    '--format=%H%x1f%P%x1f%ct%x1f%s%x1f%aN%x1f%aE%x1e',
   ]);
   const entries = [];
 
   for (const record of raw.split('\x1e')) {
-    const [ref, parents, committedAt, subject, author] = record.trim().split('\x1f');
+    const [ref, parents, committedAt, subject, author, email] = record.trim().split('\x1f');
     if (!ref || !committedAt || subject == null) {
       continue;
     }
 
+    const gravatarUrl = email
+      ? `https://www.gravatar.com/avatar/${getGravatarHash(email)}?s=80&d=identicon`
+      : undefined;
+
     entries.push({
       author: author || '',
       committedAt: Number(committedAt) * 1000,
+      gravatarUrl,
       parents: parents ? parents.split(' ') : [],
       ref,
       subject,

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -31,6 +31,16 @@ const {
   normalizeOpenAIModel,
   OPENAI_MODELS,
 } = require('./codex.cjs');
+const {
+  configToPreferences,
+  defaultConfig,
+  getConfigPath,
+  initConfig,
+  migrateFromPreferences,
+  readConfig,
+  watchConfig,
+  writeConfig,
+} = require('./config.cjs');
 const { readReviewAssistantReply } = require('./review-assist.cjs');
 const {
   findMatchingWindowIdentity,
@@ -49,6 +59,7 @@ const { createTerminalHelper } = require('./main/terminal-helper.cjs');
 const { readWalkthrough } = require('./walkthrough.cjs');
 
 /**
+ * @typedef {import('../src/config/types.ts').CodiffConfig} CodiffConfig
  * @typedef {import('../src/types.ts').CodiffLaunchOptions} CodiffLaunchOptions
  * @typedef {import('../src/types.ts').CodiffPreferences} CodiffPreferences
  * @typedef {import('../src/types.ts').CodiffTheme} CodiffTheme
@@ -73,13 +84,8 @@ const windowLaunchOptions = new Map();
 /** @type {Map<number, Promise<RepositoryState>>} */
 const windowInitialRepositoryStates = new Map();
 const pendingCommentsClipboardController = createPendingCommentsClipboardController({ clipboard });
-/** @type {CodiffPreferences} */
-let preferences = {
-  copyCommentsOnClose: false,
-  openAIModel: DEFAULT_OPENAI_MODEL,
-  showWhitespace: false,
-  theme: 'system',
-};
+/** @type {CodiffConfig} */
+let config = defaultConfig;
 
 const { getTerminalHelperStatus, installTerminalHelper } = createTerminalHelper({
   app,
@@ -88,75 +94,54 @@ const { getTerminalHelperStatus, installTerminalHelper } = createTerminalHelper(
 });
 const { openFileInEditor } = createEditorOpener({ shell });
 
-const getPreferencesPath = () => join(app.getPath('userData'), 'preferences.json');
-
-/** @param {unknown} theme @returns {CodiffTheme} */
-const normalizeTheme = (theme) =>
-  theme === 'system' || theme === 'light' || theme === 'dark' ? theme : 'system';
-
-/** @returns {CodiffPreferences} */
-const readPreferences = () => {
-  try {
-    const storedPreferences = JSON.parse(readFileSync(getPreferencesPath(), 'utf8'));
-    return {
-      ...preferences,
-      ...storedPreferences,
-      openAIModel: normalizeOpenAIModel(storedPreferences?.openAIModel),
-      theme: normalizeTheme(storedPreferences?.theme),
-    };
-  } catch {
-    return preferences;
-  }
-};
-
-const writePreferences = () => {
-  writeFileSync(getPreferencesPath(), JSON.stringify(preferences, null, 2));
-};
-
-const sendPreferencesChanged = () => {
+const sendConfigChanged = () => {
   for (const window of BrowserWindow.getAllWindows()) {
     if (!window.isDestroyed()) {
-      window.webContents.send('codiff:preferencesChanged', preferences);
+      window.webContents.send('codiff:configChanged', config);
     }
   }
 };
 
-/** @param {Partial<CodiffPreferences>} nextPreferences */
-const updatePreferences = (nextPreferences) => {
-  preferences = {
-    ...preferences,
-    ...nextPreferences,
-    openAIModel: normalizeOpenAIModel(nextPreferences.openAIModel ?? preferences.openAIModel),
-    theme: normalizeTheme(nextPreferences.theme ?? preferences.theme),
+/** @param {Partial<CodiffConfig>} nextConfig */
+const updateConfig = (nextConfig) => {
+  config = {
+    keymap: { ...config.keymap, ...nextConfig.keymap },
+    settings: {
+      ...config.settings,
+      ...nextConfig.settings,
+      openAIModel: normalizeOpenAIModel(
+        nextConfig.settings?.openAIModel ?? config.settings.openAIModel,
+      ),
+    },
   };
-  nativeTheme.themeSource = preferences.theme;
-  writePreferences();
-  sendPreferencesChanged();
+  nativeTheme.themeSource = config.settings.theme;
+  writeConfig(config);
+  sendConfigChanged();
   Menu.setApplicationMenu(buildApplicationMenu());
 };
 
 /** @param {string} model */
 const selectOpenAIModel = (model) => {
   const openAIModel = normalizeOpenAIModel(model);
-  if (preferences.openAIModel === openAIModel) {
+  if (config.settings.openAIModel === openAIModel) {
     return;
   }
 
-  updatePreferences({ openAIModel });
+  updateConfig({ settings: { ...config.settings, openAIModel } });
 };
 
 const getCodexOptions = () => ({
   fallbackModel: FALLBACK_OPENAI_MODEL,
-  model: preferences.openAIModel,
+  model: config.settings.openAIModel,
   /** @param {string} fallbackModel */
   onModelFallback: async (fallbackModel) => {
-    updatePreferences({ openAIModel: fallbackModel });
+    updateConfig({ settings: { ...config.settings, openAIModel: fallbackModel } });
   },
 });
 
 /** @param {CodiffTheme} theme */
 const updateTheme = (theme) => {
-  updatePreferences({ theme });
+  updateConfig({ settings: { ...config.settings, theme } });
 };
 
 /** @param {string} repositoryPath */
@@ -241,7 +226,7 @@ const openRepositoryFolder = async (browserWindow) => {
 /** @returns {Array<import('electron').MenuItemConstructorOptions>} */
 const buildOpenAIModelSubmenu = () =>
   OPENAI_MODELS.map((model) => ({
-    checked: preferences.openAIModel === model.id,
+    checked: config.settings.openAIModel === model.id,
     click: () => selectOpenAIModel(model.id),
     label: model.label,
     type: 'radio',
@@ -329,20 +314,20 @@ const buildApplicationMenu = () =>
         label: 'View',
         submenu: [
           {
-            checked: preferences.showWhitespace,
+            checked: config.settings.showWhitespace,
             click: (menuItem) => {
-              updatePreferences({
-                showWhitespace: menuItem.checked,
+              updateConfig({
+                settings: { ...config.settings, showWhitespace: menuItem.checked },
               });
             },
             label: 'Show Whitespace',
             type: 'checkbox',
           },
           {
-            checked: preferences.copyCommentsOnClose,
+            checked: config.settings.copyCommentsOnClose,
             click: (menuItem) => {
-              updatePreferences({
-                copyCommentsOnClose: menuItem.checked,
+              updateConfig({
+                settings: { ...config.settings, copyCommentsOnClose: menuItem.checked },
               });
             },
             label: 'Copy Comments on Close',
@@ -352,24 +337,32 @@ const buildApplicationMenu = () =>
             label: 'Theme',
             submenu: [
               {
-                checked: preferences.theme === 'system',
+                checked: config.settings.theme === 'system',
                 click: () => updateTheme('system'),
                 label: 'Match System',
                 type: 'radio',
               },
               {
-                checked: preferences.theme === 'light',
+                checked: config.settings.theme === 'light',
                 click: () => updateTheme('light'),
                 label: 'Light',
                 type: 'radio',
               },
               {
-                checked: preferences.theme === 'dark',
+                checked: config.settings.theme === 'dark',
                 click: () => updateTheme('dark'),
                 label: 'Dark',
                 type: 'radio',
               },
             ],
+          },
+          { type: 'separator' },
+          {
+            click: () => {
+              initConfig();
+              shell.openPath(getConfigPath());
+            },
+            label: 'Open Config File...',
           },
           { type: 'separator' },
           { role: 'togglefullscreen' },
@@ -444,7 +437,7 @@ const createWindow = (
   let allowClose = false;
   let copyingPendingCommentsBeforeClose = false;
   window.on('close', (event) => {
-    if (allowClose || quitting || !preferences.copyCommentsOnClose) {
+    if (allowClose || quitting || !config.settings.copyCommentsOnClose) {
       return;
     }
 
@@ -543,10 +536,25 @@ if (squirrelStartup || !lock) {
   });
 
   app.on('ready', () => {
-    preferences = readPreferences();
-    nativeTheme.themeSource = preferences.theme;
+    migrateFromPreferences(app.getPath('userData'), normalizeOpenAIModel);
+    config = readConfig();
+    config.settings.openAIModel = normalizeOpenAIModel(config.settings.openAIModel);
+    nativeTheme.themeSource = config.settings.theme;
     Menu.setApplicationMenu(buildApplicationMenu());
     focusOrCreateWindow(getLaunchPath(), getLaunchOptions());
+
+    watchConfig((nextConfig) => {
+      config = {
+        ...nextConfig,
+        settings: {
+          ...nextConfig.settings,
+          openAIModel: normalizeOpenAIModel(nextConfig.settings.openAIModel),
+        },
+      };
+      nativeTheme.themeSource = config.settings.theme;
+      sendConfigChanged();
+      Menu.setApplicationMenu(buildApplicationMenu());
+    });
   });
 
   app.on('activate', () => {
@@ -564,7 +572,7 @@ if (squirrelStartup || !lock) {
       (window) => !window.isDestroyed() && !window.webContents.isDestroyed(),
     );
 
-    if (preferences.copyCommentsOnClose && !quitAfterCopyingPendingComments && windows.length) {
+    if (config.settings.copyCommentsOnClose && !quitAfterCopyingPendingComments && windows.length) {
       event.preventDefault();
       if (copyingPendingCommentsBeforeQuit) {
         return;
@@ -655,7 +663,14 @@ ipcMain.handle('codiff:getGitIdentity', async (event) => {
   return readGitIdentity(repositoryPath);
 });
 
-ipcMain.handle('codiff:getPreferences', () => preferences);
+ipcMain.handle('codiff:getPreferences', () => configToPreferences(config));
+
+ipcMain.handle('codiff:getConfig', () => config);
+
+ipcMain.handle('codiff:openConfigFile', () => {
+  initConfig();
+  shell.openPath(getConfigPath());
+});
 
 ipcMain.handle('codiff:openFile', async (event, filePath) => {
   const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -45,12 +45,6 @@ const codiff = {
     ipcRenderer.on('codiff:findInDiffs', listener);
     return () => ipcRenderer.removeListener('codiff:findInDiffs', listener);
   },
-  onPreferencesChanged: (callback) => {
-    /** @param {Electron.IpcRendererEvent} _event @param {import('../src/types.ts').CodiffPreferences} preferences */
-    const listener = (_event, preferences) => callback(preferences);
-    ipcRenderer.on('codiff:preferencesChanged', listener);
-    return () => ipcRenderer.removeListener('codiff:preferencesChanged', listener);
-  },
   onRepositoryChanged: (callback) => {
     /** @param {Electron.IpcRendererEvent} _event @param {{root: string}} change */
     const listener = (_event, change) => callback(change);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -5,6 +5,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 /** @type {Window['codiff']} */
 const codiff = {
   askReviewAssistant: (request) => ipcRenderer.invoke('codiff:askReviewAssistant', request),
+  getConfig: () => ipcRenderer.invoke('codiff:getConfig'),
   getDiffSectionContent: (request) => ipcRenderer.invoke('codiff:getDiffSectionContent', request),
   getGitIdentity: () => ipcRenderer.invoke('codiff:getGitIdentity'),
   getLaunchOptions: () => ipcRenderer.invoke('codiff:getLaunchOptions'),
@@ -14,6 +15,12 @@ const codiff = {
   getTerminalHelperStatus: () => ipcRenderer.invoke('codiff:getTerminalHelperStatus'),
   getWalkthrough: (source) => ipcRenderer.invoke('codiff:getWalkthrough', source),
   installTerminalHelper: () => ipcRenderer.invoke('codiff:installTerminalHelper'),
+  onConfigChanged: (callback) => {
+    /** @param {Electron.IpcRendererEvent} _event @param {import('../src/config/types.ts').CodiffConfig} nextConfig */
+    const listener = (_event, nextConfig) => callback(nextConfig);
+    ipcRenderer.on('codiff:configChanged', listener);
+    return () => ipcRenderer.removeListener('codiff:configChanged', listener);
+  },
   onCopyPendingCommentsRequest: (callback) => {
     /** @param {Electron.IpcRendererEvent} _event @param {number} requestId */
     const listener = (_event, requestId) => {
@@ -50,6 +57,7 @@ const codiff = {
     ipcRenderer.on('codiff:repositoryChanged', listener);
     return () => ipcRenderer.removeListener('codiff:repositoryChanged', listener);
   },
+  openConfigFile: () => ipcRenderer.invoke('codiff:openConfigFile'),
   openFile: (path) => ipcRenderer.invoke('codiff:openFile', path),
   showInFolder: (path) => ipcRenderer.invoke('codiff:showInFolder', path),
   submitPullRequestComment: (request) =>

--- a/src/App.css
+++ b/src/App.css
@@ -1010,7 +1010,8 @@
 .codiff-header-toggle,
 .codiff-markdown-button,
 .codiff-open-button,
-.codiff-viewed-button {
+.codiff-viewed-button,
+.codiff-copy-path-button {
   -webkit-app-region: no-drag;
   align-items: center;
   background: transparent;
@@ -1019,6 +1020,79 @@
   cursor: pointer;
   display: inline-flex;
   justify-content: center;
+}
+
+.codiff-copy-path-button {
+  border-radius: 6px;
+  color: var(--muted);
+  corner-shape: squircle;
+  flex: none;
+  height: 20px;
+  opacity: 0;
+  padding: 0;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    opacity 120ms ease;
+  width: 20px;
+}
+
+.codiff-file-header:hover .codiff-copy-path-button,
+.codiff-copy-path-button:focus-visible,
+.codiff-copy-path-button.copied {
+  opacity: 1;
+}
+
+.codiff-copy-path-button:hover {
+  background: rgb(127 127 127 / 0.14);
+  color: var(--text);
+}
+
+.codiff-copy-path-button.copied {
+  color: var(--viewed);
+}
+
+.codiff-copy-path-icon {
+  border: 1.5px solid currentColor;
+  border-radius: 2px;
+  display: block;
+  height: 9px;
+  position: relative;
+  width: 9px;
+}
+
+.codiff-copy-path-icon::after {
+  background: var(--file-bg);
+  border: 1.5px solid currentColor;
+  border-radius: 2px;
+  content: '';
+  display: block;
+  height: 9px;
+  left: 3px;
+  position: absolute;
+  top: 3px;
+  width: 9px;
+}
+
+.codiff-copy-path-icon.check {
+  border: 0;
+  height: 12px;
+  width: 12px;
+}
+
+.codiff-copy-path-icon.check::after {
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid currentColor;
+  border-left: 2px solid currentColor;
+  border-radius: 0;
+  content: '';
+  height: 5px;
+  left: 1px;
+  position: absolute;
+  top: 1px;
+  transform: rotate(-45deg);
+  width: 9px;
 }
 
 .codiff-header-toggle {
@@ -1071,6 +1145,13 @@
   overflow: hidden;
 }
 
+.codiff-file-path-row {
+  align-items: center;
+  display: flex;
+  gap: 6px;
+  min-width: 0;
+}
+
 .codiff-file-path,
 .codiff-file-old-path {
   display: block;
@@ -1082,6 +1163,7 @@
 
 .codiff-file-path {
   font-size: 13px;
+  min-width: 0;
 }
 
 .codiff-file-old-path {

--- a/src/App.css
+++ b/src/App.css
@@ -145,6 +145,77 @@
   overflow: hidden;
 }
 
+.app-shell.sidebar-collapsed {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.app-shell.sidebar-collapsed .sidebar {
+  display: none;
+}
+
+.app-shell.sidebar-collapsed .sidebar-resizer {
+  display: none;
+}
+
+.collapsed-sidebar-bar {
+  -webkit-app-region: drag;
+  -webkit-backdrop-filter: blur(28px) saturate(1.3);
+  align-items: center;
+  backdrop-filter: blur(28px) saturate(1.3);
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: 18px;
+  corner-shape: squircle;
+  display: flex;
+  gap: 8px;
+  grid-column: 1 / -1;
+  height: 38px;
+  margin: 10px 10px 0;
+  padding: 0 14px 0 98px;
+}
+
+.collapsed-sidebar-label {
+  color: var(--sidebar-text);
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-toggle-button {
+  -webkit-app-region: no-drag;
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  color: var(--muted);
+  corner-shape: squircle;
+  cursor: pointer;
+  display: inline-flex;
+  flex: none;
+  height: 28px;
+  justify-content: center;
+  padding: 0;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+  width: 28px;
+}
+
+.sidebar-toggle-button:hover {
+  background: rgb(127 127 127 / 0.14);
+  color: var(--sidebar-text);
+}
+
+.sidebar-toggle-button:active {
+  background: rgb(127 127 127 / 0.2);
+}
+
 .sidebar-resizer {
   -webkit-app-region: no-drag;
   cursor: col-resize;
@@ -414,6 +485,7 @@
 .sidebar-path-row {
   align-items: center;
   display: flex;
+  gap: 8px;
   min-height: 38px;
   min-width: 0;
   padding-left: 84px;
@@ -421,9 +493,11 @@
 
 .sidebar-path {
   color: var(--sidebar-text);
+  flex: 1;
   font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 600;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/App.css
+++ b/src/App.css
@@ -547,10 +547,32 @@
   display: grid;
   gap: 0 6px;
   grid-template-columns: 62px minmax(0, 1fr);
-  min-height: 34px;
-  padding: 4px;
+  padding: 6px 6px 6px 40px;
   text-align: left;
   width: 100%;
+}
+
+.history-entry.with-avatar {
+  grid-template-columns: 26px minmax(0, 1fr);
+  padding: 6px 6px 6px 8px;
+}
+
+.history-entry.with-avatar > .gravatar {
+  align-self: center;
+}
+
+.history-entry-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.history-entry-title-row {
+  align-items: baseline;
+  display: flex;
+  gap: 6px;
+  min-width: 0;
 }
 
 .history-entry:hover,
@@ -571,6 +593,7 @@
 .history-entry-ref {
   align-self: center;
   color: var(--sidebar-ref);
+  flex: none;
   font: 12px/1.35 var(--font-mono);
   min-width: 0;
   white-space: nowrap;
@@ -580,17 +603,22 @@
   align-self: center;
   color: var(--text);
   font: 12px/1.35 var(--font-sans);
+  min-width: 0;
   padding-inline: 4px;
 }
 
 .history-entry-meta {
   color: var(--text-secondary, color-mix(in srgb, var(--text) 40%, transparent));
   display: flex;
-  font: 10px/1.2 var(--font-sans);
+  font: italic 10px/1.2 var(--font-sans);
   gap: 8px;
   justify-content: space-between;
   padding-inline: 4px;
   white-space: nowrap;
+}
+
+.history-entry-content > .history-entry-meta {
+  padding-inline: 0;
 }
 
 .history-entry-meta > span:first-child {
@@ -1048,6 +1076,7 @@
   corner-shape: squircle;
   flex: none;
   height: 20px;
+  margin-top: -2px;
   opacity: 0;
   padding: 0;
   transition:
@@ -1066,6 +1095,10 @@
 .codiff-copy-path-button:hover {
   background: rgb(127 127 127 / 0.14);
   color: var(--text);
+}
+
+.codiff-copy-path-button:hover .codiff-copy-path-icon::after {
+  background: transparent;
 }
 
 .codiff-copy-path-button.copied {
@@ -1353,30 +1386,46 @@
   width: 100%;
 }
 
-.review-comment-avatar {
-  align-self: start;
+.gravatar {
   background: rgb(127 127 127 / 0.14);
-  margin-top: 1px;
-  border-radius: var(--review-avatar-radius);
+  border-radius: 50%;
   color: var(--muted);
-  corner-shape: squircle;
   display: inline-flex;
   flex: none;
-  font: 700 12px/1 var(--font-sans);
-  height: 34px;
   justify-content: center;
   object-fit: cover;
+}
+
+.review-comment > .gravatar {
+  margin-top: 1px;
+}
+
+.gravatar.medium {
+  font: 700 12px/1 var(--font-sans);
+  height: 34px;
   width: 34px;
 }
 
-.review-comment-avatar.fallback {
+.gravatar.small {
+  font: 700 10px/1 var(--font-sans);
+  height: 26px;
+  width: 26px;
+}
+
+.gravatar.fallback {
   align-items: center;
 }
 
-.review-comment-avatar.codex {
+.review-comment-avatar-codex {
   background: transparent;
+  border-radius: 24px;
+  corner-shape: squircle;
+  display: inline-flex;
+  flex: none;
+  height: 34px;
   object-fit: cover;
   padding: 0;
+  width: 34px;
 }
 
 .review-comment-body {

--- a/src/App.css
+++ b/src/App.css
@@ -545,7 +545,7 @@
   corner-shape: squircle;
   cursor: pointer;
   display: grid;
-  gap: 6px;
+  gap: 0 6px;
   grid-template-columns: 62px minmax(0, 1fr);
   min-height: 34px;
   padding: 4px;
@@ -581,6 +581,26 @@
   color: var(--text);
   font: 12px/1.35 var(--font-sans);
   padding-inline: 4px;
+}
+
+.history-entry-meta {
+  color: var(--text-secondary, color-mix(in srgb, var(--text) 40%, transparent));
+  display: flex;
+  font: 10px/1.2 var(--font-sans);
+  gap: 8px;
+  justify-content: space-between;
+  padding-inline: 4px;
+  white-space: nowrap;
+}
+
+.history-entry-meta > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.history-entry-meta > span:last-child {
+  flex: none;
 }
 
 .history-loading {

--- a/src/App.css
+++ b/src/App.css
@@ -1963,6 +1963,114 @@
   }
 }
 
+.command-bar-overlay {
+  align-items: flex-start;
+  background: rgb(0 0 0 / 0.32);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding-top: min(20vh, 140px);
+  position: fixed;
+  z-index: 100;
+}
+
+.command-bar {
+  -webkit-backdrop-filter: blur(28px) saturate(1.4);
+  backdrop-filter: blur(28px) saturate(1.4);
+  background: color-mix(in srgb, var(--code-bg) 82%, transparent);
+  border: 1px solid var(--file-border);
+  border-radius: 18px;
+  box-shadow:
+    0 24px 80px -20px rgb(0 0 0 / 0.6),
+    0 0 0 1px rgb(255 255 255 / 0.06) inset;
+  corner-shape: squircle;
+  display: flex;
+  flex-direction: column;
+  max-height: 400px;
+  overflow: hidden;
+  width: min(520px, 90vw);
+}
+
+.command-bar-input {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--file-border);
+  color: var(--text);
+  font: 14px/1.35 var(--font-sans);
+  height: 48px;
+  outline: none;
+  padding: 0 18px;
+  width: 100%;
+}
+
+.command-bar-input::placeholder {
+  color: var(--muted);
+}
+
+.command-bar-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 6px;
+}
+
+.command-bar-empty {
+  color: var(--muted);
+  font: 13px/1.35 var(--font-sans);
+  padding: 16px 12px;
+  text-align: center;
+}
+
+.command-bar-item {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 10px;
+  color: var(--text);
+  corner-shape: squircle;
+  cursor: pointer;
+  display: flex;
+  font: 13px/1.35 var(--font-sans);
+  gap: 12px;
+  min-height: 36px;
+  padding: 6px 12px;
+  text-align: left;
+  width: 100%;
+}
+
+.command-bar-item:hover,
+.command-bar-item.selected {
+  background: color-mix(in srgb, var(--tree-selection-focus) 16%, transparent);
+}
+
+.command-bar-item.selected {
+  background: color-mix(in srgb, var(--tree-selection-focus) 22%, transparent);
+}
+
+.command-bar-item-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-bar-item-description {
+  color: var(--muted);
+  margin-left: 6px;
+}
+
+.command-bar-item-shortcut {
+  background: rgb(127 127 127 / 0.12);
+  border: 1px solid rgb(127 127 127 / 0.14);
+  border-radius: 6px;
+  color: var(--muted);
+  corner-shape: squircle;
+  flex: none;
+  font: 11px/1 var(--font-mono);
+  padding: 3px 6px;
+}
+
 @container sidebar (max-width: 260px) {
   .sidebar-mode-toggle {
     gap: 4px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,9 @@ import {
 } from './app/components/Panels.tsx';
 import { ReviewCodeView } from './app/components/ReviewCodeView.tsx';
 import { Sidebar } from './app/components/Sidebar.tsx';
+import { defaultConfig } from './config/defaults.ts';
+import { matchesShortcut } from './config/keymap.ts';
+import type { CodiffConfig } from './config/types.ts';
 import {
   defaultLaunchOptions,
   defaultPreferences,
@@ -38,7 +41,6 @@ import { DEFAULT_PADDING } from './lib/code-view-options.ts';
 import { getDiffSearchResult } from './lib/diff-search.ts';
 import { fileHasVisibleDiff, getFirstVisibleSection, getItemId } from './lib/diff.ts';
 import { compactPath, fuzzyMatches, sortFiles } from './lib/files.ts';
-import { isDiffSearchShortcut } from './lib/keyboard.ts';
 import {
   buildReviewCommentsMarkdown,
   getCommentKey,
@@ -86,6 +88,7 @@ export default function App() {
   const [itemVersionByPath, setItemVersionByPath] = useState<Record<string, number>>({});
   const [localChangesDetected, setLocalChangesDetected] = useState(false);
   const [launchOptions, setLaunchOptions] = useState<CodiffLaunchOptions>(defaultLaunchOptions);
+  const [codiffConfig, setCodiffConfig] = useState<CodiffConfig>(defaultConfig);
   const [preferences, setPreferences] = useState<CodiffPreferences>(defaultPreferences);
   const [reviewComments, setReviewComments] = useState<ReadonlyArray<ReviewComment>>([]);
   const [pullRequestReviewSubmitting, setPullRequestReviewSubmitting] =
@@ -533,19 +536,31 @@ export default function App() {
   useEffect(() => {
     let canceled = false;
 
-    window.codiff.getPreferences().then((nextPreferences) => {
+    window.codiff.getConfig().then((nextConfig) => {
       if (!canceled) {
-        setPreferences(nextPreferences);
+        setCodiffConfig(nextConfig);
+        setPreferences({
+          copyCommentsOnClose: nextConfig.settings.copyCommentsOnClose,
+          openAIModel: nextConfig.settings.openAIModel,
+          showWhitespace: nextConfig.settings.showWhitespace,
+          theme: nextConfig.settings.theme,
+        });
       }
     });
 
-    const removeListener = window.codiff.onPreferencesChanged((nextPreferences) => {
-      setPreferences(nextPreferences);
+    const removeConfigListener = window.codiff.onConfigChanged((nextConfig) => {
+      setCodiffConfig(nextConfig);
+      setPreferences({
+        copyCommentsOnClose: nextConfig.settings.copyCommentsOnClose,
+        openAIModel: nextConfig.settings.openAIModel,
+        showWhitespace: nextConfig.settings.showWhitespace,
+        theme: nextConfig.settings.theme,
+      });
     });
 
     return () => {
       canceled = true;
-      removeListener();
+      removeConfigListener();
     };
   }, []);
 
@@ -688,7 +703,7 @@ export default function App() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (isDiffSearchShortcut(event)) {
+      if (matchesShortcut(event, codiffConfig.keymap, 'diffSearch')) {
         event.preventDefault();
         openDiffSearch();
       }
@@ -696,7 +711,7 @@ export default function App() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [openDiffSearch]);
+  }, [codiffConfig.keymap, openDiffSearch]);
 
   useEffect(() => window.codiff.onFindInDiffs(openDiffSearch), [openDiffSearch]);
 
@@ -1391,6 +1406,7 @@ export default function App() {
       <DiffSearchPanel
         activeIndex={effectiveActiveDiffSearchMatchIndex}
         focusRequest={diffSearchFocusRequest}
+        keymap={codiffConfig.keymap}
         matchCount={diffSearchMatches.length}
         onChange={updateDiffSearchQuery}
         onClose={closeDiffSearch}
@@ -1430,6 +1446,7 @@ export default function App() {
           historyEntries={historyEntries}
           historyHasMore={historyHasMore}
           historyLoading={historyLoading}
+          keymap={codiffConfig.keymap}
           mode={sidebarMode}
           onActivatePath={activatePath}
           onLoadMoreHistory={loadMoreHistory}
@@ -1495,6 +1512,7 @@ export default function App() {
             gitIdentity={gitIdentity}
             isPullRequest={isPullRequest}
             itemVersionByPath={itemVersionByPath}
+            keymap={codiffConfig.keymap}
             onAskCodex={askCodex}
             onCreateComment={createComment}
             onDeleteComment={deleteComment}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import {
 import { ReviewCodeView } from './app/components/ReviewCodeView.tsx';
 import { Sidebar } from './app/components/Sidebar.tsx';
 import { defaultConfig } from './config/defaults.ts';
-import { matchesShortcut } from './config/keymap.ts';
+import { getShortcutLabel, matchesShortcut } from './config/keymap.ts';
 import type { CodiffConfig } from './config/types.ts';
 import {
   defaultLaunchOptions,
@@ -49,7 +49,14 @@ import {
   getReviewCommentRangeProps,
   getReviewCommentsFromState,
 } from './lib/review-comments.ts';
-import { clampSidebarWidth, readSidebarWidth, writeSidebarWidth } from './lib/sidebar-width.ts';
+import {
+  SIDEBAR_COLLAPSE_THRESHOLD,
+  clampSidebarWidth,
+  readSidebarCollapsed,
+  readSidebarWidth,
+  writeSidebarCollapsed,
+  writeSidebarWidth,
+} from './lib/sidebar-width.ts';
 import { getRepositoryLoadError, getShortRef, getSourceKey, getSourceLabel } from './lib/source.ts';
 import { readViewed, writeViewed } from './lib/viewed.ts';
 import {
@@ -100,6 +107,7 @@ export default function App() {
   const [historySearchQuery, setHistorySearchQuery] = useState('');
   const [pendingSource, setPendingSource] = useState<ReviewSource | null>(null);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => readSidebarCollapsed());
   const [sidebarMode, setSidebarMode] = useState<SidebarMode>('tree');
   const [sidebarWidth, setSidebarWidth] = useState<number>(() => readSidebarWidth());
   const [state, setState] = useState<RepositoryState | null>(null);
@@ -706,6 +714,19 @@ export default function App() {
     setActiveDiffSearchMatchIndex(0);
   }, []);
 
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((current) => {
+      const next = !current;
+      writeSidebarCollapsed(next);
+      return next;
+    });
+  }, []);
+
+  const expandSidebar = useCallback(() => {
+    setSidebarCollapsed(false);
+    writeSidebarCollapsed(false);
+  }, []);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (matchesShortcut(event, codiffConfig.keymap, 'commandBar')) {
@@ -713,15 +734,27 @@ export default function App() {
         setCommandBarVisible((current) => !current);
         return;
       }
+      if (matchesShortcut(event, codiffConfig.keymap, 'toggleSidebar')) {
+        event.preventDefault();
+        toggleSidebar();
+        return;
+      }
       if (matchesShortcut(event, codiffConfig.keymap, 'diffSearch')) {
         event.preventDefault();
         openDiffSearch();
+        return;
+      }
+      if (matchesShortcut(event, codiffConfig.keymap, 'fileFilter')) {
+        if (sidebarCollapsed) {
+          event.preventDefault();
+          expandSidebar();
+        }
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [codiffConfig.keymap, openDiffSearch]);
+  }, [codiffConfig.keymap, expandSidebar, openDiffSearch, sidebarCollapsed, toggleSidebar]);
 
   useEffect(() => {
     const registry = commandRegistryRef.current;
@@ -837,6 +870,12 @@ export default function App() {
         title: 'Open File in Editor',
       }),
       registry.register({
+        execute: toggleSidebar,
+        id: 'toggle-sidebar',
+        keymapAction: 'toggleSidebar',
+        title: 'Toggle Sidebar',
+      }),
+      registry.register({
         execute: () => window.location.reload(),
         id: 'reload',
         title: 'Reload Window',
@@ -849,7 +888,7 @@ export default function App() {
         unregister();
       }
     };
-  }, [bumpItemVersion, openDiffSearch]);
+  }, [bumpItemVersion, openDiffSearch, toggleSidebar]);
 
   useEffect(() => window.codiff.onFindInDiffs(openDiffSearch), [openDiffSearch]);
 
@@ -1018,22 +1057,38 @@ export default function App() {
     handle.setPointerCapture(event.pointerId);
     handle.classList.add('dragging');
     document.body.style.cursor = 'col-resize';
+    let collapsed = false;
 
-    const handleMove = (moveEvent: PointerEvent) => {
-      setSidebarWidth(clampSidebarWidth(moveEvent.clientX - shellLeft));
-    };
-
-    const handleEnd = () => {
+    const cleanup = () => {
       handle.releasePointerCapture(event.pointerId);
       handle.removeEventListener('pointermove', handleMove);
       handle.removeEventListener('pointerup', handleEnd);
       handle.removeEventListener('pointercancel', handleEnd);
       handle.classList.remove('dragging');
       document.body.style.cursor = '';
-      setSidebarWidth((width) => {
-        writeSidebarWidth(width);
-        return width;
-      });
+    };
+
+    const handleMove = (moveEvent: PointerEvent) => {
+      const rawWidth = moveEvent.clientX - shellLeft;
+      if (rawWidth < SIDEBAR_COLLAPSE_THRESHOLD) {
+        // Collapse immediately mid-drag — no resistance, no snap on release
+        collapsed = true;
+        setSidebarCollapsed(true);
+        writeSidebarCollapsed(true);
+        cleanup();
+        return;
+      }
+      setSidebarWidth(clampSidebarWidth(rawWidth));
+    };
+
+    const handleEnd = () => {
+      cleanup();
+      if (!collapsed) {
+        setSidebarWidth((width) => {
+          writeSidebarWidth(width);
+          return width;
+        });
+      }
     };
 
     handle.addEventListener('pointermove', handleMove);
@@ -1532,12 +1587,49 @@ export default function App() {
     !walkthroughLoading &&
     walkthroughError?.code === 'CODEX_NOT_FOUND';
 
+  const sidebarLabel = `${compactPath(state.root)}${state.branch ? ` (${state.branch})` : ''}`;
+  const sidebarSourceLabel =
+    state.source.type !== 'working-tree' ? ` · ${getSourceLabel(state.source)}` : '';
+
   return (
     <div
-      className="app-shell"
-      style={{ gridTemplateColumns: `${sidebarWidth}px 6px minmax(0, 1fr)` }}
+      className={`app-shell${sidebarCollapsed ? ' sidebar-collapsed' : ''}`}
+      style={
+        sidebarCollapsed
+          ? undefined
+          : { gridTemplateColumns: `${sidebarWidth}px 6px minmax(0, 1fr)` }
+      }
     >
       <div aria-hidden className="window-drag-region" />
+      {sidebarCollapsed ? (
+        <div className="collapsed-sidebar-bar">
+          <button
+            className="sidebar-toggle-button"
+            onClick={expandSidebar}
+            title={`Expand sidebar (${getShortcutLabel(codiffConfig.keymap, 'toggleSidebar')})`}
+            type="button"
+          >
+            <svg
+              aria-hidden
+              fill="none"
+              height="16"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <rect height="18" rx="2" ry="2" width="18" x="3" y="3" />
+              <line x1="9" x2="9" y1="3" y2="21" />
+            </svg>
+          </button>
+          <div className="collapsed-sidebar-label" title={state.root}>
+            {sidebarLabel}
+            {sidebarSourceLabel}
+          </div>
+        </div>
+      ) : null}
       <RepositoryChangeBanner
         visible={localChangesDetected && (pendingSource ?? state.source).type === 'working-tree'}
       />
@@ -1578,9 +1670,30 @@ export default function App() {
       <aside className="squircle sidebar">
         <div className="sidebar-header">
           <div className="sidebar-path-row">
+            <button
+              className="sidebar-toggle-button"
+              onClick={toggleSidebar}
+              title={`Collapse sidebar (${getShortcutLabel(codiffConfig.keymap, 'toggleSidebar')})`}
+              type="button"
+            >
+              <svg
+                aria-hidden
+                fill="none"
+                height="16"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width="16"
+              >
+                <rect height="18" rx="2" ry="2" width="18" x="3" y="3" />
+                <line x1="9" x2="9" y1="3" y2="21" />
+              </svg>
+            </button>
             <div className="sidebar-path" title={state.root}>
-              {compactPath(state.root)}
-              {state.source.type !== 'working-tree' ? ` · ${getSourceLabel(state.source)}` : ''}
+              {sidebarLabel}
+              {sidebarSourceLabel}
             </div>
           </div>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
+import { CommandBar } from './app/components/CommandBar.tsx';
 import {
   CopyCommentsButton,
   CodexUnavailablePanel,
@@ -38,6 +39,7 @@ import {
   type WalkthroughError,
 } from './lib/app-types.ts';
 import { DEFAULT_PADDING } from './lib/code-view-options.ts';
+import { type Command, createCommandRegistry } from './lib/command-registry.ts';
 import { getDiffSearchResult } from './lib/diff-search.ts';
 import { fileHasVisibleDiff, getFirstVisibleSection, getItemId } from './lib/diff.ts';
 import { compactPath, fuzzyMatches, sortFiles } from './lib/files.ts';
@@ -125,6 +127,9 @@ export default function App() {
   const viewedRef = useRef<Record<string, string>>({});
   const walkthroughRef = useRef<Walkthrough | null>(null);
   const walkthroughErrorRef = useRef<WalkthroughError | null>(null);
+  const [commandBarVisible, setCommandBarVisible] = useState(false);
+  const [commandBarCommands, setCommandBarCommands] = useState<ReadonlyArray<Command>>([]);
+  const commandRegistryRef = useRef(createCommandRegistry());
 
   const bumpItemVersion = useCallback((path: string) => {
     setItemVersionByPath((current) => ({
@@ -703,6 +708,11 @@ export default function App() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (matchesShortcut(event, codiffConfig.keymap, 'commandBar')) {
+        event.preventDefault();
+        setCommandBarVisible((current) => !current);
+        return;
+      }
       if (matchesShortcut(event, codiffConfig.keymap, 'diffSearch')) {
         event.preventDefault();
         openDiffSearch();
@@ -712,6 +722,134 @@ export default function App() {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [codiffConfig.keymap, openDiffSearch]);
+
+  useEffect(() => {
+    const registry = commandRegistryRef.current;
+    const unregisterFns = [
+      registry.register({
+        execute: () => {
+          const input = document.querySelector<HTMLInputElement>('.sidebar-search');
+          input?.focus();
+          input?.select();
+        },
+        id: 'file-filter',
+        keymapAction: 'fileFilter',
+        title: 'Focus File Filter',
+      }),
+      registry.register({
+        execute: openDiffSearch,
+        id: 'diff-search',
+        keymapAction: 'diffSearch',
+        title: 'Find in Diffs',
+      }),
+      registry.register({
+        execute: () => setSidebarMode('tree'),
+        id: 'sidebar-tree',
+        title: 'Show File Tree',
+      }),
+      registry.register({
+        execute: () => setSidebarMode('history'),
+        id: 'sidebar-history',
+        title: 'Show History',
+      }),
+      registry.register({
+        execute: () => setSidebarMode('walkthrough'),
+        id: 'sidebar-walkthrough',
+        title: 'Show Walkthrough',
+      }),
+      registry.register({
+        execute: () => {
+          const currentState = stateRef.current;
+          if (!currentState) {
+            return;
+          }
+
+          const markdown = buildReviewCommentsMarkdown(
+            currentState.files,
+            reviewCommentsRef.current,
+            preferencesRef.current.showWhitespace,
+          );
+          if (markdown) {
+            void navigator.clipboard.writeText(markdown);
+          }
+        },
+        id: 'copy-comments',
+        title: 'Copy Review Comments',
+      }),
+      registry.register({
+        description: () => selectedPathRef.current,
+        execute: () => {
+          const currentState = stateRef.current;
+          const path = selectedPathRef.current;
+          if (!currentState || !path) {
+            return;
+          }
+
+          const file = currentState.files.find((f) => f.path === path);
+          if (!file) {
+            return;
+          }
+
+          const isViewed = viewedRef.current[file.path] === file.fingerprint;
+          setViewed((current) => {
+            if (isViewed) {
+              const next = { ...current };
+              delete next[file.path];
+              if (currentState.source.type === 'working-tree') {
+                writeViewed(currentState.root, next);
+              }
+              return next;
+            }
+
+            const next = {
+              ...current,
+              [file.path]: file.fingerprint,
+            };
+            if (currentState.source.type === 'working-tree') {
+              writeViewed(currentState.root, next);
+            }
+            return next;
+          });
+
+          setCollapsed((current) => {
+            const next = new Set(current);
+            if (isViewed) {
+              next.delete(file.path);
+            } else {
+              next.add(file.path);
+            }
+            return next;
+          });
+          bumpItemVersion(file.path);
+        },
+        id: 'toggle-viewed',
+        title: 'Toggle Viewed',
+      }),
+      registry.register({
+        description: () => selectedPathRef.current,
+        execute: () => {
+          const path = selectedPathRef.current;
+          if (path) {
+            void window.codiff.openFile(path).catch(() => {});
+          }
+        },
+        id: 'open-file',
+        title: 'Open File in Editor',
+      }),
+      registry.register({
+        execute: () => window.location.reload(),
+        id: 'reload',
+        title: 'Reload Window',
+      }),
+    ];
+    setCommandBarCommands(registry.commands);
+
+    return () => {
+      for (const unregister of unregisterFns) {
+        unregister();
+      }
+    };
+  }, [bumpItemVersion, openDiffSearch]);
 
   useEffect(() => window.codiff.onFindInDiffs(openDiffSearch), [openDiffSearch]);
 
@@ -1414,6 +1552,12 @@ export default function App() {
         onPrevious={() => moveDiffSearchMatch(-1)}
         query={diffSearchQuery}
         visible={diffSearchVisible}
+      />
+      <CommandBar
+        commands={commandBarCommands}
+        keymap={codiffConfig.keymap}
+        onClose={() => setCommandBarVisible(false)}
+        visible={commandBarVisible}
       />
       {!isSwitchingSource ? (
         <div className="review-action-bar">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -810,6 +810,29 @@ export default function App() {
         title: 'Copy Review Comments',
       }),
       registry.register({
+        execute: () => {
+          const currentState = stateRef.current;
+          if (!currentState) {
+            return;
+          }
+
+          const markdown = buildReviewCommentsMarkdown(
+            currentState.files,
+            reviewCommentsRef.current,
+            preferencesRef.current.showWhitespace,
+          );
+          if (markdown) {
+            void navigator.clipboard.writeText(markdown).then(() => {
+              window.close();
+            });
+          } else {
+            window.close();
+          }
+        },
+        id: 'copy-comments-and-close',
+        title: 'Copy Review Comments and Close',
+      }),
+      registry.register({
         description: () => selectedPathRef.current,
         execute: () => {
           const currentState = stateRef.current;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -747,7 +747,13 @@ export default function App() {
       if (matchesShortcut(event, codiffConfig.keymap, 'fileFilter')) {
         if (sidebarCollapsed) {
           event.preventDefault();
+          event.stopImmediatePropagation();
           expandSidebar();
+          requestAnimationFrame(() => {
+            const input = document.querySelector<HTMLInputElement>('.sidebar-search');
+            input?.focus();
+            input?.select();
+          });
         }
       }
     };
@@ -761,9 +767,12 @@ export default function App() {
     const unregisterFns = [
       registry.register({
         execute: () => {
-          const input = document.querySelector<HTMLInputElement>('.sidebar-search');
-          input?.focus();
-          input?.select();
+          expandSidebar();
+          requestAnimationFrame(() => {
+            const input = document.querySelector<HTMLInputElement>('.sidebar-search');
+            input?.focus();
+            input?.select();
+          });
         },
         id: 'file-filter',
         keymapAction: 'fileFilter',
@@ -911,7 +920,7 @@ export default function App() {
         unregister();
       }
     };
-  }, [bumpItemVersion, openDiffSearch, toggleSidebar]);
+  }, [bumpItemVersion, expandSidebar, openDiffSearch, toggleSidebar]);
 
   useEffect(() => window.codiff.onFindInDiffs(openDiffSearch), [openDiffSearch]);
 

--- a/src/app/components/CommandBar.tsx
+++ b/src/app/components/CommandBar.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { getShortcutLabel } from '../../config/keymap.ts';
+import type { CodiffKeymap } from '../../config/types.ts';
+import type { Command } from '../../lib/command-registry.ts';
+import { filterCommands } from '../../lib/command-registry.ts';
+
+export function CommandBar({
+  commands,
+  keymap,
+  onClose,
+  visible,
+}: {
+  commands: ReadonlyArray<Command>;
+  keymap: CodiffKeymap;
+  onClose: () => void;
+  visible: boolean;
+}) {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filtered = filterCommands(commands, query);
+
+  const clampedIndex = filtered.length === 0 ? -1 : Math.min(selectedIndex, filtered.length - 1);
+
+  const executeAndClose = useCallback(
+    (command: Command) => {
+      setQuery('');
+      setSelectedIndex(0);
+      onClose();
+      command.execute();
+    },
+    [onClose],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setQuery('');
+        setSelectedIndex(0);
+        onClose();
+        return;
+      }
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setSelectedIndex((current) => {
+          const next = current + 1;
+          return next >= filtered.length ? 0 : next;
+        });
+        return;
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setSelectedIndex((current) => {
+          const next = current - 1;
+          return next < 0 ? Math.max(filtered.length - 1, 0) : next;
+        });
+        return;
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        const command = filtered[clampedIndex];
+        if (command) {
+          executeAndClose(command);
+        }
+        return;
+      }
+    },
+    [clampedIndex, executeAndClose, filtered, onClose],
+  );
+
+  const handleOverlayClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget) {
+        setQuery('');
+        setSelectedIndex(0);
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const handleQueryChange = useCallback((value: string) => {
+    setQuery(value);
+    setSelectedIndex(0);
+  }, []);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="command-bar-overlay" onClick={handleOverlayClick}>
+      <div className="command-bar">
+        <input
+          autoFocus
+          className="command-bar-input"
+          onChange={(event) => handleQueryChange(event.currentTarget.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a command..."
+          ref={inputRef}
+          spellCheck={false}
+          type="text"
+          value={query}
+        />
+        <div className="command-bar-list" ref={listRef}>
+          {filtered.length === 0 ? (
+            <div className="command-bar-empty">No matching commands</div>
+          ) : (
+            filtered.map((command, index) => (
+              <button
+                className={`command-bar-item${index === clampedIndex ? ' selected' : ''}`}
+                key={command.id}
+                onClick={() => executeAndClose(command)}
+                onPointerEnter={() => setSelectedIndex(index)}
+                type="button"
+              >
+                <span className="command-bar-item-title">
+                  {command.title}
+                  {command.description ? (
+                    <span className="command-bar-item-description">{command.description()}</span>
+                  ) : null}
+                </span>
+                {command.keymapAction ? (
+                  <kbd className="command-bar-item-shortcut">
+                    {getShortcutLabel(keymap, command.keymapAction)}
+                  </kbd>
+                ) : null}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/CommandBar.tsx
+++ b/src/app/components/CommandBar.tsx
@@ -17,8 +17,8 @@ export function CommandBar({
 }) {
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   const filtered = filterCommands(commands, query);
 
@@ -34,6 +34,10 @@ export function CommandBar({
     [onClose],
   );
 
+  const scrollIndexIntoView = useCallback((index: number) => {
+    itemRefs.current[index]?.scrollIntoView({ block: 'nearest' });
+  }, []);
+
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLInputElement>) => {
       if (event.key === 'Escape') {
@@ -47,8 +51,9 @@ export function CommandBar({
       if (event.key === 'ArrowDown') {
         event.preventDefault();
         setSelectedIndex((current) => {
-          const next = current + 1;
-          return next >= filtered.length ? 0 : next;
+          const next = current + 1 >= filtered.length ? 0 : current + 1;
+          scrollIndexIntoView(next);
+          return next;
         });
         return;
       }
@@ -56,8 +61,9 @@ export function CommandBar({
       if (event.key === 'ArrowUp') {
         event.preventDefault();
         setSelectedIndex((current) => {
-          const next = current - 1;
-          return next < 0 ? Math.max(filtered.length - 1, 0) : next;
+          const next = current - 1 < 0 ? Math.max(filtered.length - 1, 0) : current - 1;
+          scrollIndexIntoView(next);
+          return next;
         });
         return;
       }
@@ -71,7 +77,7 @@ export function CommandBar({
         return;
       }
     },
-    [clampedIndex, executeAndClose, filtered, onClose],
+    [clampedIndex, executeAndClose, filtered, onClose, scrollIndexIntoView],
   );
 
   const handleOverlayClick = useCallback(
@@ -103,7 +109,6 @@ export function CommandBar({
           onChange={(event) => handleQueryChange(event.currentTarget.value)}
           onKeyDown={handleKeyDown}
           placeholder="Type a command..."
-          ref={inputRef}
           spellCheck={false}
           type="text"
           value={query}
@@ -118,6 +123,9 @@ export function CommandBar({
                 key={command.id}
                 onClick={() => executeAndClose(command)}
                 onPointerEnter={() => setSelectedIndex(index)}
+                ref={(element) => {
+                  itemRefs.current[index] = element;
+                }}
                 type="button"
               >
                 <span className="command-bar-item-title">

--- a/src/app/components/Gravatar.tsx
+++ b/src/app/components/Gravatar.tsx
@@ -1,0 +1,21 @@
+function Gravatar({
+  fallback,
+  size,
+  url,
+}: {
+  fallback: string;
+  size: 'medium' | 'small';
+  url?: string;
+}) {
+  const className = `gravatar ${size}`;
+
+  return url ? (
+    <img alt="" className={className} draggable={false} src={url} />
+  ) : (
+    <span aria-hidden className={`${className} fallback`}>
+      {fallback.trim()[0]?.toUpperCase() ?? '?'}
+    </span>
+  );
+}
+
+export { Gravatar };

--- a/src/app/components/Panels.tsx
+++ b/src/app/components/Panels.tsx
@@ -5,6 +5,8 @@ import {
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
+import { matchesShortcut } from '../../config/keymap.ts';
+import type { CodiffKeymap } from '../../config/types.ts';
 import type { RepositoryLoadError, ReviewComment } from '../../lib/app-types.ts';
 import { getReloadShortcutLabel } from '../../lib/keyboard.ts';
 import { buildReviewCommentsMarkdown } from '../../lib/review-comments.ts';
@@ -136,6 +138,7 @@ export function CodexUnavailablePanel({ onShowFiles }: { onShowFiles: () => void
 export function DiffSearchPanel({
   activeIndex,
   focusRequest,
+  keymap,
   matchCount,
   onChange,
   onClose,
@@ -146,6 +149,7 @@ export function DiffSearchPanel({
 }: {
   activeIndex: number;
   focusRequest: number;
+  keymap: CodiffKeymap;
   matchCount: number;
   onChange: (query: string) => void;
   onClose: () => void;
@@ -169,22 +173,24 @@ export function DiffSearchPanel({
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLInputElement>) => {
-      if (event.key === 'Escape') {
+      if (matchesShortcut(event, keymap, 'closeSearch')) {
         event.preventDefault();
         onClose();
         return;
       }
 
-      if (event.key === 'Enter') {
+      if (matchesShortcut(event, keymap, 'prevSearchMatch')) {
         event.preventDefault();
-        if (event.shiftKey) {
-          onPrevious();
-        } else {
-          onNext();
-        }
+        onPrevious();
+        return;
+      }
+
+      if (matchesShortcut(event, keymap, 'nextSearchMatch')) {
+        event.preventDefault();
+        onNext();
       }
     },
-    [onClose, onNext, onPrevious],
+    [keymap, onClose, onNext, onPrevious],
   );
 
   return (

--- a/src/app/components/ReviewCodeView.tsx
+++ b/src/app/components/ReviewCodeView.tsx
@@ -18,6 +18,8 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from 'react';
 import codexIconUrl from '../../assets/codex.svg';
+import { matchesShortcut } from '../../config/keymap.ts';
+import type { CodiffKeymap } from '../../config/types.ts';
 import type {
   CodeViewInstance,
   CodeViewItemMetadata,
@@ -274,6 +276,7 @@ function ReviewAnnotation({
   focusCommentRequest,
   identity,
   isPullRequest,
+  keymap,
   onAskCodex,
   onCommentBlur,
   onCommentFocus,
@@ -287,6 +290,7 @@ function ReviewAnnotation({
   focusCommentRequest: number;
   identity: GitIdentity | null;
   isPullRequest: boolean;
+  keymap: CodiffKeymap;
   onAskCodex: (commentId: string) => void;
   onCommentBlur: (comment: ReviewComment, body: string) => void;
   onCommentFocus: (comment: ReviewComment) => void;
@@ -309,7 +313,7 @@ function ReviewAnnotation({
 
   const handleCommentKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>, comment: ReviewComment) => {
-      if (event.key === 'Enter' && event.metaKey && !event.shiftKey) {
+      if (matchesShortcut(event, keymap, 'submitComment')) {
         if (isPullRequest && canSubmitCommentToGitHub(comment)) {
           event.preventDefault();
           event.stopPropagation();
@@ -325,7 +329,7 @@ function ReviewAnnotation({
         return;
       }
 
-      if (event.key !== 'Escape') {
+      if (!matchesShortcut(event, keymap, 'discardComment')) {
         return;
       }
 
@@ -340,7 +344,7 @@ function ReviewAnnotation({
         onDeleteComment(comment.id);
       }
     },
-    [isPullRequest, onAskCodex, onDeleteComment, onSubmitComment],
+    [isPullRequest, keymap, onAskCodex, onDeleteComment, onSubmitComment],
   );
 
   if (annotationComments.length === 0) {
@@ -463,6 +467,7 @@ export function ReviewCodeView({
   gitIdentity,
   isPullRequest,
   itemVersionByPath,
+  keymap,
   onAskCodex,
   onCreateComment,
   onDeleteComment,
@@ -489,6 +494,7 @@ export function ReviewCodeView({
   gitIdentity: GitIdentity | null;
   isPullRequest: boolean;
   itemVersionByPath: Readonly<Record<string, number>>;
+  keymap: CodiffKeymap;
   onAskCodex: (commentId: string) => void;
   onCreateComment: (comment: Omit<ReviewComment, 'body' | 'id'>) => void;
   onDeleteComment: (commentId: string) => void;
@@ -1060,6 +1066,7 @@ export function ReviewCodeView({
           focusCommentRequest={focusCommentRequest}
           identity={gitIdentity}
           isPullRequest={isPullRequest}
+          keymap={keymap}
           onAskCodex={onAskCodex}
           onCommentBlur={blurComment}
           onCommentFocus={focusComment}
@@ -1078,6 +1085,7 @@ export function ReviewCodeView({
       focusComment,
       gitIdentity,
       isPullRequest,
+      keymap,
       markMarkdownPreviewLayoutReady,
       onAskCodex,
       onSubmitComment,

--- a/src/app/components/ReviewCodeView.tsx
+++ b/src/app/components/ReviewCodeView.tsx
@@ -15,6 +15,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
 } from 'react';
 import codexIconUrl from '../../assets/codex.svg';
 import type {
@@ -64,6 +65,51 @@ import type {
 } from '../../types.ts';
 import { DiffLineCountBadge } from './Sidebar.tsx';
 
+function CopyFilePathButton({ path }: { path: string }) {
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copiedTimerRef.current != null) {
+        window.clearTimeout(copiedTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const handleClick = useCallback(
+    async (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      await navigator.clipboard.writeText(path);
+      setCopied(true);
+      if (copiedTimerRef.current != null) {
+        window.clearTimeout(copiedTimerRef.current);
+      }
+      copiedTimerRef.current = window.setTimeout(() => {
+        setCopied(false);
+        copiedTimerRef.current = null;
+      }, 1600);
+    },
+    [path],
+  );
+
+  return (
+    <button
+      aria-label={copied ? 'Path copied' : 'Copy file path'}
+      className={`codiff-copy-path-button${copied ? ' copied' : ''}`}
+      onClick={(event) => void handleClick(event)}
+      title={copied ? 'Path copied' : 'Copy file path'}
+      type="button"
+    >
+      <span
+        aria-hidden
+        className={copied ? 'codiff-copy-path-icon check' : 'codiff-copy-path-icon'}
+      />
+    </button>
+  );
+}
+
 function CodeViewHeader({
   meta,
   onOpenFile,
@@ -97,19 +143,29 @@ function CodeViewHeader({
         isCollapsed ? ' collapsed' : ''
       }${isSelected ? ' selected' : ''}${isViewed ? ' viewed' : ''}`}
     >
-      <button
+      <div
         aria-expanded={!isCollapsed}
         aria-label={isCollapsed ? 'Expand file' : 'Collapse file'}
         className="codiff-header-toggle"
         onClick={() => onToggleCollapsed(file, isCollapsed)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onToggleCollapsed(file, isCollapsed);
+          }
+        }}
+        role="button"
+        tabIndex={0}
         title={isCollapsed ? 'Expand' : 'Collapse'}
-        type="button"
       >
         <span className="codiff-chevron-box">
           <span className={isCollapsed ? 'codiff-chevron collapsed' : 'codiff-chevron'} />
         </span>
         <span className="codiff-file-heading">
-          <span className="codiff-file-path">{file.path}</span>
+          <span className="codiff-file-path-row">
+            <span className="codiff-file-path">{file.path}</span>
+            <CopyFilePathButton path={file.path} />
+          </span>
           {file.oldPath ? <span className="codiff-file-old-path">{file.oldPath}</span> : null}
           {walkthroughNote ? (
             <span className="codiff-file-note">{walkthroughNote.reason}</span>
@@ -120,7 +176,7 @@ function CodeViewHeader({
             {sectionLabel[section.kind]}
           </span>
         ) : null}
-      </button>
+      </div>
       <DiffLineCountBadge lineCount={lineCount} />
       <div className={`codiff-status-badge ${file.status}`}>{statusLabel[file.status]}</div>
       {canRenderMarkdown ? (

--- a/src/app/components/ReviewCodeView.tsx
+++ b/src/app/components/ReviewCodeView.tsx
@@ -63,6 +63,7 @@ import type {
   GitIdentity,
   PullRequestExistingReviewComment,
 } from '../../types.ts';
+import { Gravatar } from './Gravatar.tsx';
 import { DiffLineCountBadge } from './Sidebar.tsx';
 
 function CopyFilePathButton({ path }: { path: string }) {
@@ -222,18 +223,12 @@ function ReviewAvatar({
   const label = author?.login || identity?.name || identity?.email || 'Git user';
   const avatarUrl = author?.avatarUrl || identity?.gravatarUrl;
 
-  return avatarUrl ? (
-    <img alt="" className="review-comment-avatar" draggable={false} src={avatarUrl} />
-  ) : (
-    <span aria-hidden className="review-comment-avatar fallback">
-      {label.trim()[0]?.toUpperCase() ?? '?'}
-    </span>
-  );
+  return <Gravatar fallback={label} size="medium" url={avatarUrl} />;
 }
 
 function CodexAvatar() {
   return (
-    <img alt="" className="review-comment-avatar codex" draggable={false} src={codexIconUrl} />
+    <img alt="" className="review-comment-avatar-codex" draggable={false} src={codexIconUrl} />
   );
 }
 

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,6 +1,8 @@
 import type { FileTreeRowDecorationRenderer } from '@pierre/trees';
 import { FileTree, useFileTree } from '@pierre/trees/react';
 import { useCallback, useEffect, useMemo, useRef, type MouseEvent } from 'react';
+import { matchesShortcut } from '../../config/keymap.ts';
+import type { CodiffKeymap } from '../../config/types.ts';
 import type {
   DiffLineCount,
   PullRequestSource,
@@ -28,6 +30,7 @@ export function Sidebar({
   historyEntries,
   historyHasMore,
   historyLoading,
+  keymap,
   mode,
   onActivatePath,
   onLoadMoreHistory,
@@ -51,6 +54,7 @@ export function Sidebar({
   historyEntries: ReadonlyArray<HistoryEntry>;
   historyHasMore: boolean;
   historyLoading: boolean;
+  keymap: CodiffKeymap;
   mode: SidebarMode;
   onActivatePath: (path: string) => void;
   onLoadMoreHistory: () => void;
@@ -205,11 +209,7 @@ export function Sidebar({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        !isNativeInputTarget(event.target) &&
-        (event.metaKey || event.ctrlKey) &&
-        event.key.toLowerCase() === 'p'
-      ) {
+      if (!isNativeInputTarget(event.target) && matchesShortcut(event, keymap, 'fileFilter')) {
         event.preventDefault();
         searchInputRef.current?.focus();
         searchInputRef.current?.select();
@@ -218,7 +218,7 @@ export function Sidebar({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [keymap]);
 
   useEffect(() => {
     if (!selectedPath) {

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -20,6 +20,7 @@ import { renderInlineMarkdown } from '../../lib/markdown.tsx';
 import { getShortRef, getSourceKey } from '../../lib/source.ts';
 import { walkthroughActionLabel, walkthroughImpactLabel } from '../../lib/walkthrough.ts';
 import type { ChangedFile, HistoryEntry, ReviewSource, Walkthrough } from '../../types.ts';
+import { Gravatar } from './Gravatar.tsx';
 
 export function Sidebar({
   currentSource,
@@ -383,6 +384,7 @@ function HistorySidebar({
           ? {
               author: null,
               committedAt: null,
+              gravatarUrl: undefined,
               key: getSourceKey(pullRequestSource),
               ref: pullRequestSource.number ? `PR #${pullRequestSource.number}` : 'PR',
               source: pullRequestSource satisfies ReviewSource,
@@ -392,6 +394,7 @@ function HistorySidebar({
         {
           author: null,
           committedAt: null,
+          gravatarUrl: undefined,
           key: 'working-tree',
           ref: '',
           source: { type: 'working-tree' } satisfies ReviewSource,
@@ -400,6 +403,7 @@ function HistorySidebar({
         ...entries.map((entry) => ({
           author: entry.author,
           committedAt: entry.committedAt,
+          gravatarUrl: entry.gravatarUrl,
           key: `commit:${entry.ref}`,
           ref: entry.ref,
           source: { ref: entry.ref, type: 'commit' } satisfies ReviewSource,
@@ -436,29 +440,51 @@ function HistorySidebar({
         const selected = row.key === currentSourceKey;
         return (
           <button
-            className={`history-entry${selected ? ' selected' : ''}`}
+            className={`history-entry${selected ? ' selected' : ''}${row.gravatarUrl ? ' with-avatar' : ''}`}
             key={row.key}
             onClick={() => onSelectSource(row.source)}
             title={row.subject}
             type="button"
           >
-            <span className="history-entry-ref">
-              {row.source.type === 'commit'
-                ? getShortRef(row.source.ref)
-                : row.source.type === 'pull-request'
-                  ? row.ref
-                  : 'local'}
-            </span>
-            <span className="history-entry-subject">{row.subject}</span>
-            {row.author && row.committedAt ? (
+            {row.gravatarUrl ? (
               <>
-                <span />
-                <span className="history-entry-meta">
-                  <span>{row.author}</span>
-                  <span>{shortDate(row.committedAt)}</span>
+                <Gravatar fallback={row.author || '?'} size="small" url={row.gravatarUrl} />
+                <span className="history-entry-content">
+                  <span className="history-entry-title-row">
+                    <span className="history-entry-ref">
+                      {row.source.type === 'commit' ? getShortRef(row.source.ref) : row.ref}
+                    </span>
+                    <span className="history-entry-subject">{row.subject}</span>
+                  </span>
+                  {row.author && row.committedAt ? (
+                    <span className="history-entry-meta">
+                      <span>{row.author}</span>
+                      <span>{shortDate(row.committedAt)}</span>
+                    </span>
+                  ) : null}
                 </span>
               </>
-            ) : null}
+            ) : (
+              <>
+                <span className="history-entry-ref">
+                  {row.source.type === 'commit'
+                    ? getShortRef(row.source.ref)
+                    : row.source.type === 'pull-request'
+                      ? row.ref
+                      : 'local'}
+                </span>
+                <span className="history-entry-subject">{row.subject}</span>
+                {row.author && row.committedAt ? (
+                  <>
+                    <span />
+                    <span className="history-entry-meta">
+                      <span>{row.author}</span>
+                      <span>{shortDate(row.committedAt)}</span>
+                    </span>
+                  </>
+                ) : null}
+              </>
+            )}
           </button>
         );
       })}

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -330,6 +330,30 @@ export function Sidebar({
   );
 }
 
+const shortDate = (timestamp: number) => {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) {
+    return 'just now';
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 30) {
+    return `${days}d ago`;
+  }
+  const months = Math.floor(days / 30);
+  if (months < 12) {
+    return `${months}mo ago`;
+  }
+  return `${Math.floor(months / 12)}y ago`;
+};
+
 function HistorySidebar({
   currentSource,
   entries,
@@ -357,6 +381,7 @@ function HistorySidebar({
       [
         pullRequestSource
           ? {
+              author: null,
               committedAt: null,
               key: getSourceKey(pullRequestSource),
               ref: pullRequestSource.number ? `PR #${pullRequestSource.number}` : 'PR',
@@ -365,6 +390,7 @@ function HistorySidebar({
             }
           : null,
         {
+          author: null,
           committedAt: null,
           key: 'working-tree',
           ref: '',
@@ -372,6 +398,7 @@ function HistorySidebar({
           subject: 'Uncommitted',
         },
         ...entries.map((entry) => ({
+          author: entry.author,
           committedAt: entry.committedAt,
           key: `commit:${entry.ref}`,
           ref: entry.ref,
@@ -423,6 +450,15 @@ function HistorySidebar({
                   : 'local'}
             </span>
             <span className="history-entry-subject">{row.subject}</span>
+            {row.author && row.committedAt ? (
+              <>
+                <span />
+                <span className="history-entry-meta">
+                  <span>{row.author}</span>
+                  <span>{shortDate(row.committedAt)}</span>
+                </span>
+              </>
+            ) : null}
           </button>
         );
       })}

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -81,6 +81,11 @@
           "type": "string",
           "default": "Escape",
           "description": "Discard an empty review comment."
+        },
+        "toggleSidebar": {
+          "type": "string",
+          "default": "Mod+b",
+          "description": "Toggle the sidebar between expanded and collapsed states."
         }
       }
     }

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Codiff Configuration",
+  "description": "Configuration file for Codiff. Supports JSON and JSONC (JSON with Comments).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Path to the JSON schema for editor autocompletion."
+    },
+    "settings": {
+      "type": "object",
+      "description": "Application settings.",
+      "additionalProperties": false,
+      "properties": {
+        "copyCommentsOnClose": {
+          "type": "boolean",
+          "default": false,
+          "description": "Copy pending review comments to clipboard when closing a window."
+        },
+        "openAIModel": {
+          "type": "string",
+          "default": "gpt-5.3-codex-spark",
+          "description": "The OpenAI model to use for review assistance and walkthroughs."
+        },
+        "showWhitespace": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show whitespace characters in diffs."
+        },
+        "theme": {
+          "type": "string",
+          "enum": ["system", "light", "dark"],
+          "default": "system",
+          "description": "Application color theme. 'system' follows OS preference."
+        }
+      }
+    },
+    "keymap": {
+      "type": "object",
+      "description": "Keyboard shortcut overrides for in-app actions. Use 'Mod' for Cmd on macOS and Ctrl on other platforms.",
+      "additionalProperties": false,
+      "properties": {
+        "diffSearch": {
+          "type": "string",
+          "default": "Mod+f",
+          "description": "Open the diff search panel."
+        },
+        "fileFilter": {
+          "type": "string",
+          "default": "Mod+p",
+          "description": "Focus the file filter search input in the sidebar."
+        },
+        "nextSearchMatch": {
+          "type": "string",
+          "default": "Enter",
+          "description": "Navigate to the next search match."
+        },
+        "prevSearchMatch": {
+          "type": "string",
+          "default": "Shift+Enter",
+          "description": "Navigate to the previous search match."
+        },
+        "closeSearch": {
+          "type": "string",
+          "default": "Escape",
+          "description": "Close the search panel."
+        },
+        "submitComment": {
+          "type": "string",
+          "default": "Mod+Enter",
+          "description": "Submit a review comment to GitHub or ask Codex."
+        },
+        "discardComment": {
+          "type": "string",
+          "default": "Escape",
+          "description": "Discard an empty review comment."
+        }
+      }
+    }
+  }
+}

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -42,6 +42,11 @@
       "description": "Keyboard shortcut overrides for in-app actions. Use 'Mod' for Cmd on macOS and Ctrl on other platforms.",
       "additionalProperties": false,
       "properties": {
+        "commandBar": {
+          "type": "string",
+          "default": "Mod+Shift+p",
+          "description": "Open the command palette."
+        },
         "diffSearch": {
           "type": "string",
           "default": "Mod+f",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -9,6 +9,7 @@ export const defaultSettings: CodiffSettings = {
 
 export const defaultKeymap: CodiffKeymap = {
   closeSearch: 'Escape',
+  commandBar: 'Mod+Shift+p',
   diffSearch: 'Mod+f',
   discardComment: 'Escape',
   fileFilter: 'Mod+p',

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -16,6 +16,7 @@ export const defaultKeymap: CodiffKeymap = {
   nextSearchMatch: 'Enter',
   prevSearchMatch: 'Shift+Enter',
   submitComment: 'Mod+Enter',
+  toggleSidebar: 'Mod+b',
 };
 
 export const defaultConfig: CodiffConfig = {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,0 +1,23 @@
+import type { CodiffConfig, CodiffKeymap, CodiffSettings } from './types.ts';
+
+export const defaultSettings: CodiffSettings = {
+  copyCommentsOnClose: false,
+  openAIModel: 'gpt-5.3-codex-spark',
+  showWhitespace: false,
+  theme: 'system',
+};
+
+export const defaultKeymap: CodiffKeymap = {
+  closeSearch: 'Escape',
+  diffSearch: 'Mod+f',
+  discardComment: 'Escape',
+  fileFilter: 'Mod+p',
+  nextSearchMatch: 'Enter',
+  prevSearchMatch: 'Shift+Enter',
+  submitComment: 'Mod+Enter',
+};
+
+export const defaultConfig: CodiffConfig = {
+  keymap: defaultKeymap,
+  settings: defaultSettings,
+};

--- a/src/config/keymap.ts
+++ b/src/config/keymap.ts
@@ -75,7 +75,7 @@ export const getShortcutLabel = (keymap: CodiffKeymap, action: keyof CodiffKeyma
         return mac ? '\u21A9' : 'Enter';
       }
       if (lower === 'escape') {
-        return mac ? 'Esc' : 'Esc';
+        return 'Esc';
       }
       return part.trim().toUpperCase();
     })

--- a/src/config/keymap.ts
+++ b/src/config/keymap.ts
@@ -1,0 +1,83 @@
+import type { CodiffKeymap, KeyCombo } from './types.ts';
+
+type ParsedKeyCombo = {
+  altKey: boolean;
+  ctrlKey: boolean;
+  key: string;
+  metaKey: boolean;
+  shiftKey: boolean;
+};
+
+const isMac = () => navigator.platform.toLowerCase().includes('mac');
+
+const parseKeyCombo = (combo: KeyCombo): ParsedKeyCombo => {
+  const parts = combo.split('+').map((part) => part.trim().toLowerCase());
+  const mac = isMac();
+
+  return {
+    altKey: parts.includes('alt'),
+    ctrlKey: mac ? parts.includes('ctrl') : parts.includes('mod') || parts.includes('ctrl'),
+    key:
+      parts.find(
+        (part) =>
+          part !== 'mod' &&
+          part !== 'ctrl' &&
+          part !== 'alt' &&
+          part !== 'shift' &&
+          part !== 'meta',
+      ) ?? '',
+    metaKey: mac ? parts.includes('mod') || parts.includes('meta') : parts.includes('meta'),
+    shiftKey: parts.includes('shift'),
+  };
+};
+
+export const matchesShortcut = (
+  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
+  keymap: CodiffKeymap,
+  action: keyof CodiffKeymap,
+): boolean => {
+  const combo = keymap[action];
+  const parsed = parseKeyCombo(combo);
+
+  return (
+    event.key.toLowerCase() === parsed.key &&
+    event.altKey === parsed.altKey &&
+    event.ctrlKey === parsed.ctrlKey &&
+    event.metaKey === parsed.metaKey &&
+    event.shiftKey === parsed.shiftKey
+  );
+};
+
+export const getShortcutLabel = (keymap: CodiffKeymap, action: keyof CodiffKeymap): string => {
+  const combo = keymap[action];
+  const mac = isMac();
+
+  return combo
+    .split('+')
+    .map((part) => {
+      const lower = part.trim().toLowerCase();
+      if (lower === 'mod') {
+        return mac ? '\u2318' : 'Ctrl';
+      }
+      if (lower === 'shift') {
+        return mac ? '\u21E7' : 'Shift';
+      }
+      if (lower === 'alt') {
+        return mac ? '\u2325' : 'Alt';
+      }
+      if (lower === 'ctrl') {
+        return mac ? '\u2303' : 'Ctrl';
+      }
+      if (lower === 'meta') {
+        return mac ? '\u2318' : 'Win';
+      }
+      if (lower === 'enter') {
+        return mac ? '\u21A9' : 'Enter';
+      }
+      if (lower === 'escape') {
+        return mac ? 'Esc' : 'Esc';
+      }
+      return part.trim().toUpperCase();
+    })
+    .join(mac ? '' : '+');
+};

--- a/src/config/keymap.ts
+++ b/src/config/keymap.ts
@@ -79,5 +79,5 @@ export const getShortcutLabel = (keymap: CodiffKeymap, action: keyof CodiffKeyma
       }
       return part.trim().toUpperCase();
     })
-    .join(mac ? '' : '+');
+    .join('+');
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,0 +1,25 @@
+export type CodiffTheme = 'system' | 'light' | 'dark';
+
+export type CodiffSettings = {
+  copyCommentsOnClose: boolean;
+  openAIModel: string;
+  showWhitespace: boolean;
+  theme: CodiffTheme;
+};
+
+export type KeyCombo = string;
+
+export type CodiffKeymap = {
+  closeSearch: KeyCombo;
+  diffSearch: KeyCombo;
+  discardComment: KeyCombo;
+  fileFilter: KeyCombo;
+  nextSearchMatch: KeyCombo;
+  prevSearchMatch: KeyCombo;
+  submitComment: KeyCombo;
+};
+
+export type CodiffConfig = {
+  keymap: CodiffKeymap;
+  settings: CodiffSettings;
+};

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -11,6 +11,7 @@ export type KeyCombo = string;
 
 export type CodiffKeymap = {
   closeSearch: KeyCombo;
+  commandBar: KeyCombo;
   diffSearch: KeyCombo;
   discardComment: KeyCombo;
   fileFilter: KeyCombo;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,6 +18,7 @@ export type CodiffKeymap = {
   nextSearchMatch: KeyCombo;
   prevSearchMatch: KeyCombo;
   submitComment: KeyCombo;
+  toggleSidebar: KeyCombo;
 };
 
 export type CodiffConfig = {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -34,7 +34,6 @@ declare global {
       onConfigChanged: (callback: (config: CodiffConfig) => void) => () => void;
       onCopyPendingCommentsRequest: (callback: () => string | Promise<string>) => () => void;
       onFindInDiffs: (callback: () => void) => () => void;
-      onPreferencesChanged: (callback: (preferences: CodiffPreferences) => void) => () => void;
       onRepositoryChanged: (callback: (change: { root: string }) => void) => () => void;
       openConfigFile: () => Promise<void>;
       openFile: (path: string) => Promise<void>;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,4 @@
+import type { CodiffConfig } from './config/types.ts';
 import type {
   CodiffPreferences,
   CodiffLaunchOptions,
@@ -20,6 +21,7 @@ declare global {
   interface Window {
     codiff: {
       askReviewAssistant: (request: ReviewAssistantRequest) => Promise<ReviewAssistantResult>;
+      getConfig: () => Promise<CodiffConfig>;
       getDiffSectionContent: (request: DiffSectionContentRequest) => Promise<DiffSection>;
       getGitIdentity: () => Promise<GitIdentity>;
       getLaunchOptions: () => Promise<CodiffLaunchOptions>;
@@ -29,10 +31,12 @@ declare global {
       getTerminalHelperStatus: () => Promise<TerminalHelperStatus>;
       getWalkthrough: (source?: ReviewSource) => Promise<WalkthroughResult>;
       installTerminalHelper: () => Promise<TerminalHelperStatus>;
+      onConfigChanged: (callback: (config: CodiffConfig) => void) => () => void;
       onCopyPendingCommentsRequest: (callback: () => string | Promise<string>) => () => void;
       onFindInDiffs: (callback: () => void) => () => void;
       onPreferencesChanged: (callback: (preferences: CodiffPreferences) => void) => () => void;
       onRepositoryChanged: (callback: (change: { root: string }) => void) => () => void;
+      openConfigFile: () => Promise<void>;
       openFile: (path: string) => Promise<void>;
       showInFolder: (path: string) => Promise<void>;
       submitPullRequestComment: (

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -1,0 +1,64 @@
+import type { CodiffKeymap } from '../config/types.ts';
+
+export type Command = {
+  description?: () => string | null;
+  execute: () => void;
+  id: string;
+  keymapAction?: keyof CodiffKeymap;
+  title: string;
+};
+
+export type CommandRegistry = {
+  commands: ReadonlyArray<Command>;
+  register: (command: Command) => () => void;
+};
+
+export const createCommandRegistry = (): CommandRegistry => {
+  let commands: Array<Command> = [];
+  const listeners = new Set<() => void>();
+
+  const notify = () => {
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+
+  return {
+    get commands() {
+      return commands;
+    },
+    register(command: Command) {
+      commands = [...commands, command];
+      notify();
+
+      return () => {
+        commands = commands.filter((c) => c.id !== command.id);
+        notify();
+      };
+    },
+  };
+};
+
+export const filterCommands = (
+  commands: ReadonlyArray<Command>,
+  query: string,
+): ReadonlyArray<Command> => {
+  const trimmed = query.trim().toLowerCase();
+
+  if (!trimmed) {
+    return commands;
+  }
+
+  return commands.filter((command) => {
+    const title = command.title.toLowerCase();
+    let queryIndex = 0;
+
+    for (let i = 0; i < title.length && queryIndex < trimmed.length; i++) {
+      if (title[i] === trimmed[queryIndex]) {
+        queryIndex++;
+      }
+    }
+
+    return queryIndex === trimmed.length;
+  });
+};

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -15,13 +15,6 @@ export type CommandRegistry = {
 
 export const createCommandRegistry = (): CommandRegistry => {
   let commands: Array<Command> = [];
-  const listeners = new Set<() => void>();
-
-  const notify = () => {
-    for (const listener of listeners) {
-      listener();
-    }
-  };
 
   return {
     get commands() {
@@ -29,11 +22,9 @@ export const createCommandRegistry = (): CommandRegistry => {
     },
     register(command: Command) {
       commands = [...commands, command];
-      notify();
 
       return () => {
         commands = commands.filter((c) => c.id !== command.id);
-        notify();
       };
     },
   };

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -10,7 +10,8 @@ export const isNativeInputTarget = (target: EventTarget | null) => {
   );
 };
 
-const isMacPlatform = (platform = navigator.platform) => platform.toLowerCase().includes('mac');
+export const isMacPlatform = (platform = navigator.platform) =>
+  platform.toLowerCase().includes('mac');
 
 export const isDiffSearchShortcut = (
   event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,

--- a/src/lib/sidebar-width.ts
+++ b/src/lib/sidebar-width.ts
@@ -1,5 +1,7 @@
 const SIDEBAR_WIDTH_STORAGE_KEY = 'codiff:sidebar-width';
+const SIDEBAR_COLLAPSED_STORAGE_KEY = 'codiff:sidebar-collapsed';
 
+export const SIDEBAR_COLLAPSE_THRESHOLD = 80;
 export const SIDEBAR_DEFAULT_WIDTH = 292;
 export const SIDEBAR_MAX_WIDTH = 640;
 export const SIDEBAR_MIN_WIDTH = 220;
@@ -21,4 +23,14 @@ export const readSidebarWidth = (storage: SidebarWidthStorage = localStorage): n
 
 export const writeSidebarWidth = (width: number, storage: SidebarWidthStorage = localStorage) => {
   storage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(clampSidebarWidth(width)));
+};
+
+export const readSidebarCollapsed = (storage: SidebarWidthStorage = localStorage): boolean =>
+  storage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === 'true';
+
+export const writeSidebarCollapsed = (
+  collapsed: boolean,
+  storage: SidebarWidthStorage = localStorage,
+) => {
+  storage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, String(collapsed));
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export type ReviewSource =
 export type HistoryEntry = {
   author: string;
   committedAt: number;
+  gravatarUrl?: string;
   parents: ReadonlyArray<string>;
   ref: string;
   subject: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export type ReviewSource =
     };
 
 export type HistoryEntry = {
+  author: string;
   committedAt: number;
   parents: ReadonlyArray<string>;
   ref: string;
@@ -65,6 +66,7 @@ export type RepositoryHistory = {
 };
 
 export type RepositoryState = {
+  branch: string | null;
   files: ReadonlyArray<ChangedFile>;
   generatedAt: number;
   launchPath: string;


### PR DESCRIPTION
## Summary
This PR adds a configurable keymap, a command bar, a collapsible sidebar, and several UI polish items (history avatars/dates, copy-file-path button, copy-and-close command).
## Features
### Central config file with configurable keymaps
Introduces `~/.codiff/codiff.jsonc` as the source of truth for user settings, including a fully configurable keymap. Ships with a JSON schema for editor autocomplete and validation, hot-reloads on file change, and migrates existing preferences automatically.
### Command bar (Cmd+Shift+P)
Adds a global command registry and a VS Code-style command bar. Supports fuzzy filtering, arrow-key navigation, and displays the bound keyboard shortcut next to each command. Commands include file-filter focus, find-in-diffs, sidebar mode switching, and sidebar toggle.
### Collapsible sidebar
The sidebar can now be collapsed via a toggle button or `Cmd+B`. The collapsed state persists across launches, and the top bar animates smoothly. Activating `Cmd+P` while collapsed auto-expands and focuses the file filter.
### History avatars and metadata
History entries now show the author's Gravatar, name, and commit date. The repository's current branch is displayed in the sidebar header.
### Copy file path button
Adds a small button next to each file path in the diff view to copy the path to clipboard.

-------
**Demo:**

https://github.com/user-attachments/assets/11c33a8d-3a1f-4946-9159-18559e74d117


