### PR TITLE
fix: parse hash-prefixed PR marker values

### DIFF
--- a/bin/arguments.js
+++ b/bin/arguments.js
@@ -13,7 +13,8 @@ const parsePullRequestNumberArgument = (arg) => {
   return match ? Number(match[1]) : null;
 };
 
-const parsePullRequestNumberValue = (arg) => (/^[1-9]\d*$/.test(arg) ? Number(arg) : null);
+const parsePullRequestNumberValue = (arg) =>
+  parsePullRequestNumberArgument(arg.startsWith('#') ? arg : `#${arg}`);
 
 const isPullRequestMarkerArgument = (arg) => /^(?:pr|pull-request)$/i.test(arg);
 

--- a/electron/__tests__/command-line.test.ts
+++ b/electron/__tests__/command-line.test.ts
@@ -44,6 +44,18 @@ test('parses pull request markers without resolving the repository remote', () =
   });
 });
 
+test('parses hash-prefixed pull request marker values', () => {
+  expect(parseCommandLineArguments(['codiff', 'pr', '#12', '/repo'])).toMatchObject({
+    launchOptions: {
+      repositoryPathProvided: true,
+      source: undefined,
+      walkthrough: false,
+    },
+    pullRequestNumber: 12,
+    repositoryPath: '/repo',
+  });
+});
+
 test('parses full GitHub pull request URLs as launch sources', () => {
   expect(
     parseCommandLineArguments(['codiff', 'https://github.com/nkzw-tech/codiff/pull/11', '/repo'])

--- a/src/__tests__/codiff-cli.test.ts
+++ b/src/__tests__/codiff-cli.test.ts
@@ -75,6 +75,16 @@ test('parseArguments treats PR marker arguments as review sources', () => {
   });
 });
 
+test('parseArguments treats hash-prefixed PR marker values as review sources', () => {
+  expect(parseArguments(['pr', '#75'])).toEqual({
+    commitRef: null,
+    pullRequestNumber: 75,
+    pullRequestUrl: null,
+    requestedPath: resolve(process.cwd()),
+    walkthrough: false,
+  });
+});
+
 test('resolvePullRequestUrl builds GitHub PR URLs from the origin remote', async () => {
   const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-cli-'));
 


### PR DESCRIPTION
## Summary
- Accept hash-prefixed values in `codiff pr #123`.
- Keep packaged CLI parsing aligned with Electron command-line parsing.