### PR TITLE
Resolve Codex through the user's shell

### DIFF
--- a/electron/codex.cjs
+++ b/electron/codex.cjs
@@ -1,9 +1,10 @@
 // @ts-check
 
-const { spawn } = require('node:child_process');
+const { execFile, spawn } = require('node:child_process');
 const { existsSync, promises: fs } = require('node:fs');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
+const { promisify } = require('node:util');
 
 const CODEX_TIMEOUT_MS = 45_000;
 const DEFAULT_OPENAI_MODEL = 'gpt-5.3-codex-spark';
@@ -40,10 +41,26 @@ const OPENAI_MODELS = Object.freeze([
   },
 ]);
 const OPENAI_MODEL_IDS = new Set(OPENAI_MODELS.map((model) => model.id));
+const execFileAsync = promisify(execFile);
+/** @type {Promise<string> | null} */
+let codexCommandPromise = null;
 
-const getCodexCommand = () => {
-  if (process.env.CODIFF_CODEX_PATH) {
-    return process.env.CODIFF_CODEX_PATH;
+const resolveCodexCommand = async () => {
+  const shell = process.env.SHELL;
+  if (shell) {
+    try {
+      const { stdout } = await execFileAsync(shell, ['-lc', 'command -v codex'], {
+        encoding: 'utf8',
+        timeout: 5_000,
+      });
+      const command = stdout.trim();
+
+      if (command) {
+        return command;
+      }
+    } catch {
+      // Fall back to known locations below.
+    }
   }
 
   for (const path of ['/opt/homebrew/bin/codex', '/usr/local/bin/codex']) {
@@ -53,6 +70,15 @@ const getCodexCommand = () => {
   }
 
   return 'codex';
+};
+
+const getCodexCommand = () => {
+  if (process.env.CODIFF_CODEX_PATH) {
+    return Promise.resolve(process.env.CODIFF_CODEX_PATH);
+  }
+
+  codexCommandPromise ||= resolveCodexCommand();
+  return codexCommandPromise;
 };
 
 /**
@@ -173,6 +199,7 @@ const runCodex = async (
 
   /** @param {string} codexModel @returns {Promise<string>} */
   const invokeCodex = async (codexModel) => {
+    const codexCommand = await getCodexCommand();
     const directory = await fs.mkdtemp(join(tmpdir(), 'codiff-codex-'));
     const outputPath = join(directory, outputName);
     const schemaPath = join(directory, 'schema.json');
@@ -186,7 +213,6 @@ const runCodex = async (
         let stdout = '';
         let finished = false;
 
-        const codexCommand = getCodexCommand();
         const child = spawn(
           codexCommand,
           [


### PR DESCRIPTION
Why it crashed for me: the `codex` on my path still pointed to a global npm install that didn't exist anymore and thus it failed inside Codiff.

I've installed codex through npm which is installed through [n](https://github.com/tj/n) which is installed through brew.

I got it working with Pi and GPT-5.5, but it felt like it changed a bit too much. asked it just for a bug description and that one i then gave to `amp`, whose solution I then again reviewed with pi+gpt5.5, to me this change now looks reasonable. Also told amp to "use tmux, start it with the -w flag so that i can test it using codiff itself. That was fun, but it only created 1 card whose description wasn't too helpfull. I'll try again soon with something else.



If you end up just prompting yourself and not merging this, no worries, no hard feelings :) 



amp's PR description below:

## Summary
- resolve the Codex CLI with `/bin/zsh -lc 'command -v codex'` before falling back to hardcoded paths
- keep `CODIFF_CODEX_PATH` as the explicit override
- cache the async shell lookup so the Electron main process does not block or repeat shell startup for every Codex launch

## Testing
- `pnpm exec vp check --fix`
- `pnpm exec vp build`
- `pnpm codiff -w`