### PR TITLE
fix: restore last repository on app launch

### DIFF
--- a/electron/__tests__/command-line.test.ts
+++ b/electron/__tests__/command-line.test.ts
@@ -1,18 +1,37 @@
+import { mkdtemp, rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
 
 const require = createRequire(import.meta.url);
-const { parseCommandLineArguments, parseGitHubRemoteUrl } = require('../main/command-line.cjs') as {
-  parseCommandLineArguments: (commandLine: ReadonlyArray<string>) => {
-    launchOptions: {
-      repositoryPathProvided: boolean;
-      source?: { ref: string; type: 'commit' } | { type: 'pull-request'; url: string };
-      walkthrough: boolean;
+const { getInitialRepositoryPath, parseCommandLineArguments, parseGitHubRemoteUrl } =
+  require('../main/command-line.cjs') as {
+    getInitialRepositoryPath: (
+      launchPath: string,
+      launchOptions: {
+        repositoryPathProvided: boolean;
+        source?: { ref: string; type: 'commit' } | { type: 'pull-request'; url: string };
+        walkthrough: boolean;
+      },
+      lastRepositoryPath: string,
+      environment?: NodeJS.ProcessEnv,
+    ) => string;
+    parseCommandLineArguments: (commandLine: ReadonlyArray<string>) => {
+      launchOptions: {
+        repositoryPathProvided: boolean;
+        source?: { ref: string; type: 'commit' } | { type: 'pull-request'; url: string };
+        walkthrough: boolean;
+      };
+      pullRequestNumber: number | null;
+      repositoryPath: string | null;
     };
-    pullRequestNumber: number | null;
-    repositoryPath: string | null;
+    parseGitHubRemoteUrl: (value: string) => { owner: string; repo: string } | null;
   };
-  parseGitHubRemoteUrl: (value: string) => { owner: string; repo: string } | null;
+
+const defaultLaunchOptions = {
+  repositoryPathProvided: false,
+  walkthrough: false,
 };
 
 test('parses commit and walkthrough command-line options', () => {
@@ -104,4 +123,73 @@ test('parses GitHub remotes from ssh and https URLs', () => {
     repo: 'codiff',
   });
   expect(parseGitHubRemoteUrl('https://example.com/nkzw-tech/codiff.git')).toBeNull();
+});
+
+test('restores the last repository for plain app launches', async () => {
+  const lastRepositoryPath = await mkdtemp(join(tmpdir(), 'codiff-last-repo-'));
+
+  try {
+    expect(
+      getInitialRepositoryPath('/fallback', defaultLaunchOptions, lastRepositoryPath, {}),
+    ).toBe(lastRepositoryPath);
+  } finally {
+    await rm(lastRepositoryPath, { force: true, recursive: true });
+  }
+});
+
+test('does not restore missing last repositories', () => {
+  expect(
+    getInitialRepositoryPath('/fallback', defaultLaunchOptions, '/missing/codiff-repo', {}),
+  ).toBe('/fallback');
+});
+
+test('does not restore over explicit launch intent', async () => {
+  const lastRepositoryPath = await mkdtemp(join(tmpdir(), 'codiff-last-repo-'));
+
+  try {
+    expect(
+      getInitialRepositoryPath(
+        '/fallback',
+        {
+          repositoryPathProvided: true,
+          walkthrough: false,
+        },
+        lastRepositoryPath,
+        {},
+      ),
+    ).toBe('/fallback');
+    expect(
+      getInitialRepositoryPath(
+        '/fallback',
+        {
+          repositoryPathProvided: false,
+          source: {
+            ref: 'HEAD',
+            type: 'commit',
+          },
+          walkthrough: false,
+        },
+        lastRepositoryPath,
+        {},
+      ),
+    ).toBe('/fallback');
+    expect(
+      getInitialRepositoryPath(
+        '/fallback',
+        {
+          repositoryPathProvided: false,
+          walkthrough: true,
+        },
+        lastRepositoryPath,
+        {},
+      ),
+    ).toBe('/fallback');
+    expect(
+      getInitialRepositoryPath('/fallback', defaultLaunchOptions, lastRepositoryPath, {
+        CODIFF_REPOSITORY_PATH: '/explicit',
+      }),
+    ).toBe('/fallback');
+  } finally {
+    await rm(lastRepositoryPath, { force: true, recursive: true });
+  }
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -41,6 +41,7 @@ const { createPendingCommentsClipboardController } = require('./pending-comments
 const {
   getCommandLineLaunchOptions,
   getCommandLineRepositoryPath,
+  getInitialRepositoryPath,
   getLaunchOptions,
   getLaunchPath,
 } = require('./main/command-line.cjs');
@@ -76,6 +77,7 @@ const pendingCommentsClipboardController = createPendingCommentsClipboardControl
 /** @type {CodiffPreferences} */
 let preferences = {
   copyCommentsOnClose: false,
+  lastRepositoryPath: '',
   openAIModel: DEFAULT_OPENAI_MODEL,
   showWhitespace: false,
   theme: 'system',
@@ -94,6 +96,10 @@ const getPreferencesPath = () => join(app.getPath('userData'), 'preferences.json
 const normalizeTheme = (theme) =>
   theme === 'system' || theme === 'light' || theme === 'dark' ? theme : 'system';
 
+/** @param {unknown} path */
+const normalizeLastRepositoryPath = (path) =>
+  typeof path === 'string' && path.length > 0 ? path : '';
+
 /** @returns {CodiffPreferences} */
 const readPreferences = () => {
   try {
@@ -101,6 +107,7 @@ const readPreferences = () => {
     return {
       ...preferences,
       ...storedPreferences,
+      lastRepositoryPath: normalizeLastRepositoryPath(storedPreferences?.lastRepositoryPath),
       openAIModel: normalizeOpenAIModel(storedPreferences?.openAIModel),
       theme: normalizeTheme(storedPreferences?.theme),
     };
@@ -157,6 +164,19 @@ const getCodexOptions = () => ({
 /** @param {CodiffTheme} theme */
 const updateTheme = (theme) => {
   updatePreferences({ theme });
+};
+
+/** @param {string} repositoryPath */
+const rememberLastRepositoryPath = (repositoryPath) => {
+  if (preferences.lastRepositoryPath === repositoryPath) {
+    return;
+  }
+
+  preferences = {
+    ...preferences,
+    lastRepositoryPath: repositoryPath,
+  };
+  writePreferences();
 };
 
 /** @param {string} repositoryPath */
@@ -536,9 +556,14 @@ if (squirrelStartup || !lock) {
 
   app.on('second-instance', (event, commandLine, workingDirectory, additionalData) => {
     const data = /** @type {SingleInstanceAdditionalData} */ (additionalData || {});
+    const launchOptions =
+      data.launchOptions || getCommandLineLaunchOptions(commandLine, workingDirectory);
+    const launchPath = resolve(
+      data.repositoryPath || getCommandLineRepositoryPath(commandLine) || workingDirectory,
+    );
     focusOrCreateWindow(
-      resolve(data.repositoryPath || getCommandLineRepositoryPath(commandLine) || workingDirectory),
-      data.launchOptions || getCommandLineLaunchOptions(commandLine, workingDirectory),
+      getInitialRepositoryPath(launchPath, launchOptions, preferences.lastRepositoryPath),
+      launchOptions,
     );
   });
 
@@ -546,12 +571,20 @@ if (squirrelStartup || !lock) {
     preferences = readPreferences();
     nativeTheme.themeSource = preferences.theme;
     Menu.setApplicationMenu(buildApplicationMenu());
-    focusOrCreateWindow(getLaunchPath(), getLaunchOptions());
+    const launchOptions = getLaunchOptions();
+    focusOrCreateWindow(
+      getInitialRepositoryPath(getLaunchPath(), launchOptions, preferences.lastRepositoryPath),
+      launchOptions,
+    );
   });
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
-      focusOrCreateWindow(getLaunchPath(), getLaunchOptions());
+      const launchOptions = getLaunchOptions();
+      focusOrCreateWindow(
+        getInitialRepositoryPath(getLaunchPath(), launchOptions, preferences.lastRepositoryPath),
+        launchOptions,
+      );
     }
   });
 
@@ -592,6 +625,7 @@ ipcMain.handle('codiff:getRepositoryState', async (event, source) => {
   const state = initialState
     ? await initialState
     : await readRepositoryState(repositoryPath, source || launchOptions?.source);
+  rememberLastRepositoryPath(state.root);
   const identity = getWindowIdentityForSource(state.root, state.source);
   if (identity) {
     windowIdentities.set(event.sender.id, identity);

--- a/electron/main/command-line.cjs
+++ b/electron/main/command-line.cjs
@@ -259,9 +259,36 @@ const getCommandLineLaunchOptions = (commandLine = process.argv, fallbackPath = 
 const getLaunchPath = () =>
   resolve(process.env.CODIFF_REPOSITORY_PATH || getCommandLineRepositoryPath() || process.cwd());
 
+/**
+ * @param {string} launchPath
+ * @param {CodiffLaunchOptions} launchOptions
+ * @param {string} lastRepositoryPath
+ * @param {NodeJS.ProcessEnv} [environment]
+ */
+const getInitialRepositoryPath = (
+  launchPath,
+  launchOptions,
+  lastRepositoryPath,
+  environment = process.env,
+) => {
+  if (
+    lastRepositoryPath &&
+    existsSync(lastRepositoryPath) &&
+    !environment.CODIFF_REPOSITORY_PATH &&
+    !launchOptions.repositoryPathProvided &&
+    !launchOptions.source &&
+    !launchOptions.walkthrough
+  ) {
+    return resolve(lastRepositoryPath);
+  }
+
+  return launchPath;
+};
+
 const getLaunchOptions = () => getCommandLineLaunchOptions();
 
 module.exports = {
+  getInitialRepositoryPath,
   getCommandLineLaunchOptions,
   getCommandLineRepositoryPath,
   getLaunchOptions,

--- a/src/lib/app-constants.ts
+++ b/src/lib/app-constants.ts
@@ -15,6 +15,7 @@ export const defaultTerminalHelperStatus: TerminalHelperStatus = {
 
 export const defaultPreferences: CodiffPreferences = {
   copyCommentsOnClose: false,
+  lastRepositoryPath: '',
   openAIModel: 'gpt-5.3-codex-spark',
   showWhitespace: false,
   theme: 'system',

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,7 @@ export type CodiffTheme = 'system' | 'light' | 'dark';
 
 export type CodiffPreferences = {
   copyCommentsOnClose: boolean;
+  lastRepositoryPath: string;
   openAIModel: string;
   showWhitespace: boolean;
   theme: CodiffTheme;


### PR DESCRIPTION
## Summary
- remember the last successfully opened repository in preferences
- restore it on plain app launches without overriding explicit CLI path/source launches
- add tests for restore and explicit launch boundaries
