### PR TITLE
Make walkthrough groups collapsible

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -750,16 +750,58 @@
 }
 
 .walkthrough-group-header {
+  -webkit-app-region: no-drag;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
   color: var(--text);
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   font: 700 11px/1.25 var(--font-sans);
   gap: 2px;
   padding: 5px 6px 3px;
+  text-align: left;
+  width: 100%;
 }
 
-.walkthrough-group-header span {
+.walkthrough-group-header:hover {
+  background: rgb(127 127 127 / 0.08);
+}
+
+.walkthrough-group-title-row {
+  align-items: center;
+  display: grid;
+  gap: 6px;
+  grid-template-columns: 14px minmax(0, 1fr) max-content;
+  min-width: 0;
+}
+
+.walkthrough-group-chevron {
+  color: var(--muted);
+  transform: rotate(0deg);
+  transition: transform 160ms ease;
+}
+
+.walkthrough-group.collapsed .walkthrough-group-chevron {
+  transform: rotate(-90deg);
+}
+
+.walkthrough-group-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
   text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.walkthrough-group-count {
+  background: rgb(127 127 127 / 0.1);
+  border-radius: 999px;
+  color: var(--muted);
+  font: 700 10px/1 var(--font-mono);
+  min-width: 20px;
+  padding: 4px 6px;
+  text-align: center;
 }
 
 .walkthrough-group-header small {

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import type { FileTreeRowDecorationRenderer } from '@pierre/trees';
 import { FileTree, useFileTree } from '@pierre/trees/react';
-import { useCallback, useEffect, useMemo, useRef, type MouseEvent } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react';
 import { matchesShortcut } from '../../config/keymap.ts';
 import type { CodiffKeymap } from '../../config/types.ts';
 import type {
@@ -491,6 +492,9 @@ function WalkthroughSidebar({
   walkthroughNotes: ReadonlyMap<string, WalkthroughNote>;
   walkthroughSummary: Walkthrough['summary'] | null;
 }) {
+  const [collapsedGroupKeys, setCollapsedGroupKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const groups = useMemo(() => {
     const nextGroups: Array<{
       files: Array<{ file: ChangedFile; note?: WalkthroughNote }>;
@@ -523,6 +527,17 @@ function WalkthroughSidebar({
 
     return nextGroups;
   }, [files, walkthroughNotes]);
+  const toggleGroupCollapsed = useCallback((key: string) => {
+    setCollapsedGroupKeys((current) => {
+      const next = new Set(current);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
 
   return (
     <div className="walkthrough-list">
@@ -533,41 +548,65 @@ function WalkthroughSidebar({
           <span>{renderInlineMarkdown(walkthroughSummary.skim)}</span>
         </div>
       ) : null}
-      {groups.map((group) => (
-        <section className="walkthrough-group" key={group.key}>
-          <div className="walkthrough-group-header" title={`${group.title}. ${group.reason}`}>
-            <span>{group.title}</span>
-            <small>{renderInlineMarkdown(group.reason)}</small>
-          </div>
-          {group.files.map(({ file, note }) => {
-            const lineCount = getDiffLineCount(file, showWhitespace);
-            return (
-              <button
-                className={`walkthrough-file${selectedPath === file.path ? ' selected' : ''}`}
-                key={file.path}
-                onClick={() => onActivatePath(file.path)}
-                title={note?.reason ?? file.path}
-                type="button"
-              >
-                <span className="walkthrough-file-title">
-                  <span className="walkthrough-file-path">{file.path}</span>
-                  <DiffLineCountBadge className="walkthrough-line-count" lineCount={lineCount} />
-                </span>
-                {note ? (
-                  <span className="walkthrough-file-meta">
-                    {walkthroughImpactLabel[note.impact]} · {walkthroughActionLabel[note.action]}
-                  </span>
-                ) : null}
-                <span className="walkthrough-file-reason">
-                  {renderInlineMarkdown(
-                    note?.context ?? note?.reason ?? 'Review this changed file.',
-                  )}
-                </span>
-              </button>
-            );
-          })}
-        </section>
-      ))}
+      {groups.map((group) => {
+        const collapsed = collapsedGroupKeys.has(group.key);
+        return (
+          <section className={`walkthrough-group${collapsed ? ' collapsed' : ''}`} key={group.key}>
+            <button
+              aria-expanded={!collapsed}
+              className="walkthrough-group-header"
+              onClick={() => toggleGroupCollapsed(group.key)}
+              title={`${group.title}. ${group.reason}`}
+              type="button"
+            >
+              <span className="walkthrough-group-title-row">
+                <ChevronDown
+                  aria-hidden
+                  className="walkthrough-group-chevron"
+                  size={14}
+                  strokeWidth={2.4}
+                />
+                <span className="walkthrough-group-title">{group.title}</span>
+                <span className="walkthrough-group-count">{group.files.length}</span>
+              </span>
+              <small>{renderInlineMarkdown(group.reason)}</small>
+            </button>
+            {collapsed
+              ? null
+              : group.files.map(({ file, note }) => {
+                  const lineCount = getDiffLineCount(file, showWhitespace);
+                  return (
+                    <button
+                      className={`walkthrough-file${selectedPath === file.path ? ' selected' : ''}`}
+                      key={file.path}
+                      onClick={() => onActivatePath(file.path)}
+                      title={note?.reason ?? file.path}
+                      type="button"
+                    >
+                      <span className="walkthrough-file-title">
+                        <span className="walkthrough-file-path">{file.path}</span>
+                        <DiffLineCountBadge
+                          className="walkthrough-line-count"
+                          lineCount={lineCount}
+                        />
+                      </span>
+                      {note ? (
+                        <span className="walkthrough-file-meta">
+                          {walkthroughImpactLabel[note.impact]} ·{' '}
+                          {walkthroughActionLabel[note.action]}
+                        </span>
+                      ) : null}
+                      <span className="walkthrough-file-reason">
+                        {renderInlineMarkdown(
+                          note?.context ?? note?.reason ?? 'Review this changed file.',
+                        )}
+                      </span>
+                    </button>
+                  );
+                })}
+          </section>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds collapsible walkthrough groups in the sidebar so reviewers can focus on one review strategy at a time.

I've been enjoying codiff so far, especially the walkthroughs.  This is a small quality-of-life tweak that made walkthroughs on larger PRs a bit easier to work with.

<img width="551" height="537" alt="image" src="https://github.com/user-attachments/assets/d4ae8c25-17de-42c1-a510-9100db6236e8" />
