### PR TITLE
Show proper history when diffing a pull-request

### DIFF
--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -7,6 +7,8 @@ const {
   readCommitState,
 } = require('./git-state/commit.cjs');
 const {
+  listPullRequestHistory,
+  normalizeGitHubPullRequestCommit,
   normalizeGitHubReviewComment,
   normalizePullRequestComment,
   parseGitHubPullRequestUrl,
@@ -23,6 +25,7 @@ const {
 
 /**
  * @typedef {import('../src/types.ts').DiffSectionContentRequest} DiffSectionContentRequest
+ * @typedef {import('../src/types.ts').RepositoryHistory} RepositoryHistory
  * @typedef {import('../src/types.ts').RepositoryState} RepositoryState
  * @typedef {import('../src/types.ts').ReviewSource} ReviewSource
  */
@@ -39,6 +42,12 @@ const readRepositoryState = async (launchPath, source = { type: 'working-tree' }
   return { ...state, branch };
 };
 
+/** @param {string} launchPath @param {number} [limit] @param {ReviewSource} [source] @returns {Promise<RepositoryHistory>} */
+const readRepositoryHistory = (launchPath, limit, source) =>
+  source?.type === 'pull-request'
+    ? listPullRequestHistory(launchPath, source, limit)
+    : listRepositoryHistory(launchPath, limit);
+
 /** @param {string} launchPath @param {DiffSectionContentRequest} request */
 const readDiffSectionContent = async (launchPath, request) =>
   request.kind === 'commit' || request.source?.type === 'commit'
@@ -48,7 +57,8 @@ const readDiffSectionContent = async (launchPath, request) =>
     : readWorkingTreeDiffSectionContent(launchPath, request);
 
 module.exports = {
-  listRepositoryHistory,
+  listRepositoryHistory: readRepositoryHistory,
+  normalizeGitHubPullRequestCommit,
   normalizeGitHubReviewComment,
   normalizePullRequestComment,
   parseStatus,

--- a/electron/git-state/pull-request.cjs
+++ b/electron/git-state/pull-request.cjs
@@ -13,7 +13,8 @@ const { createSummary, getFingerprint, git, gitOrEmpty } = require('./common.cjs
  * @typedef {{number: number; owner: string; repo: string; url: string}} PullRequestReference
  * @typedef {{owner: string; repo: string}} GitHubRemote
  * @typedef {{filename: string; patch?: string; previous_filename?: string; status: string}} GitHubPullRequestFile
- * @typedef {{head?: {sha?: string}; title?: string}} GitHubPullRequestMetadata
+ * @typedef {{base?: {sha?: string}; head?: {sha?: string}; title?: string}} GitHubPullRequestMetadata
+ * @typedef {{author?: {avatar_url?: string}; commit?: {author?: {date?: string; email?: string; name?: string}; message?: string}; parents?: ReadonlyArray<{sha?: string}>; sha?: string}} GitHubCommit
  * @typedef {{[key: string]: any}} GitHubReviewComment
  */
 
@@ -222,6 +223,82 @@ const readPullRequestComments = async (repoRoot, pullRequest) => {
   return pages.flat().map(normalizeGitHubReviewComment).filter(Boolean);
 };
 
+/** @param {string} repoRoot @param {PullRequestReference} pullRequest @returns {Promise<Array<GitHubCommit>>} */
+const readPullRequestCommits = async (repoRoot, pullRequest) => {
+  const pages = JSON.parse(
+    await ghApi(repoRoot, [
+      '--paginate',
+      '--slurp',
+      `repos/${pullRequest.owner}/${pullRequest.repo}/pulls/${pullRequest.number}/commits?per_page=100`,
+    ]),
+  );
+  return pages.flat();
+};
+
+/** @param {string} repoRoot @param {PullRequestReference} pullRequest @param {string} sha @param {number} limit @returns {Promise<Array<GitHubCommit>>} */
+const readRepositoryCommits = async (repoRoot, pullRequest, sha, limit) => {
+  /** @type {Array<GitHubCommit>} */
+  const commits = [];
+  for (let page = 1; commits.length < limit; page += 1) {
+    const pageCommits = JSON.parse(
+      await ghApi(repoRoot, [
+        `repos/${pullRequest.owner}/${pullRequest.repo}/commits?sha=${encodeURIComponent(
+          sha,
+        )}&per_page=${Math.min(limit - commits.length, 100)}&page=${page}`,
+      ]),
+    );
+    if (!Array.isArray(pageCommits) || pageCommits.length === 0) {
+      break;
+    }
+    commits.push(...pageCommits);
+  }
+  return commits;
+};
+
+/** @param {GitHubCommit} commit @param {'base' | 'pull-request'} [scope] */
+const normalizeGitHubCommit = (commit, scope) => {
+  const ref = commit.sha;
+  const committedAt = Date.parse(commit.commit?.author?.date || '');
+  const message = commit.commit?.message || '';
+  if (!ref || !message || !Number.isFinite(committedAt)) {
+    return null;
+  }
+
+  return {
+    author: commit.commit?.author?.name || '',
+    committedAt,
+    gravatarUrl: commit.author?.avatar_url,
+    parents: commit.parents?.map((parent) => parent.sha).filter(Boolean) || [],
+    ref,
+    ...(scope ? { scope } : {}),
+    subject: message.split('\n')[0],
+  };
+};
+
+/** @param {GitHubCommit} commit */
+const normalizeGitHubPullRequestCommit = (commit) => normalizeGitHubCommit(commit, 'pull-request');
+
+/** @param {string} launchPath @param {Extract<ReviewSource, {type: 'pull-request'}>} source @param {number} [limit] */
+const listPullRequestHistory = async (launchPath, source, limit = 200) => {
+  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
+  const pullRequest = parseGitHubPullRequestUrl(source.url);
+  await assertPullRequestMatchesRepository(repoRoot, pullRequest);
+  const [metadata, commits] = await Promise.all([
+    readPullRequestMetadata(repoRoot, pullRequest),
+    readPullRequestCommits(repoRoot, pullRequest),
+  ]);
+  const baseCommits = metadata.base?.sha
+    ? await readRepositoryCommits(repoRoot, pullRequest, metadata.base.sha, limit)
+    : [];
+  return {
+    entries: [
+      ...commits.map(normalizeGitHubPullRequestCommit).filter(Boolean).reverse(),
+      ...baseCommits.map((commit) => normalizeGitHubCommit(commit, 'base')).filter(Boolean),
+    ],
+    root: repoRoot,
+  };
+};
+
 /** @param {string} diff @returns {Map<string, string>} */
 const splitPullRequestDiff = (diff) => {
   const chunks = diff
@@ -423,6 +500,9 @@ const submitPullRequestReview = async (launchPath, request) => {
 module.exports = {
   createPatchFromPullRequestFile,
   createPullRequestSource,
+  listPullRequestHistory,
+  normalizeGitHubCommit,
+  normalizeGitHubPullRequestCommit,
   normalizeGitHubReviewComment,
   normalizePullRequestComment,
   parseGitHubPullRequestUrl,

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -682,9 +682,9 @@ ipcMain.handle('codiff:getDiffSectionContent', async (event, request) => {
   return readDiffSectionContent(repositoryPath, request);
 });
 
-ipcMain.handle('codiff:getRepositoryHistory', async (event, limit) => {
+ipcMain.handle('codiff:getRepositoryHistory', async (event, limit, source) => {
   const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
-  return listRepositoryHistory(repositoryPath, limit);
+  return listRepositoryHistory(repositoryPath, limit, source);
 });
 
 ipcMain.handle('codiff:getGitIdentity', async (event) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -10,7 +10,8 @@ const codiff = {
   getGitIdentity: () => ipcRenderer.invoke('codiff:getGitIdentity'),
   getLaunchOptions: () => ipcRenderer.invoke('codiff:getLaunchOptions'),
   getPreferences: () => ipcRenderer.invoke('codiff:getPreferences'),
-  getRepositoryHistory: (limit) => ipcRenderer.invoke('codiff:getRepositoryHistory', limit),
+  getRepositoryHistory: (limit, source) =>
+    ipcRenderer.invoke('codiff:getRepositoryHistory', limit, source),
   getRepositoryState: (source) => ipcRenderer.invoke('codiff:getRepositoryState', source),
   getTerminalHelperStatus: () => ipcRenderer.invoke('codiff:getTerminalHelperStatus'),
   getWalkthrough: (source) => ipcRenderer.invoke('codiff:getWalkthrough', source),

--- a/src/App.css
+++ b/src/App.css
@@ -610,11 +610,18 @@
 }
 
 .history-section {
-  color: var(--muted);
-  font: 10px/1.2 var(--font-sans);
-  letter-spacing: 0.04em;
-  padding: 10px 8px 2px 82px;
+  align-items: center;
+  color: var(--text);
+  display: flex;
+  font: 700 11px/1.25 var(--font-sans);
+  min-height: 24px;
+  overflow: hidden;
+  padding: 6px 10px 2px;
+  position: relative;
+  text-overflow: ellipsis;
   text-transform: uppercase;
+  white-space: nowrap;
+  z-index: 1;
 }
 
 .history-entry-subject {

--- a/src/App.css
+++ b/src/App.css
@@ -609,6 +609,14 @@
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tree-selection-focus) 42%, transparent);
 }
 
+.history-section {
+  color: var(--muted);
+  font: 10px/1.2 var(--font-sans);
+  letter-spacing: 0.04em;
+  padding: 10px 8px 2px 82px;
+  text-transform: uppercase;
+}
+
 .history-entry-subject {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -242,10 +242,7 @@ export default function App() {
       }
       setTerminalHelperStatus(nextTerminalHelperStatus);
 
-      const [nextState, history] = await Promise.all([
-        window.codiff.getRepositoryState(),
-        window.codiff.getRepositoryHistory(HISTORY_PAGE_SIZE),
-      ]);
+      const nextState = await window.codiff.getRepositoryState();
 
       if (canceled) {
         return;
@@ -255,6 +252,15 @@ export default function App() {
         ...nextState,
         files: sortFiles(nextState.files),
       };
+      const history = await window.codiff.getRepositoryHistory(
+        HISTORY_PAGE_SIZE,
+        orderedState.source.type === 'pull-request' ? orderedState.source : undefined,
+      );
+
+      if (canceled) {
+        return;
+      }
+
       const shouldLoadWalkthrough = nextLaunchOptions.walkthrough && orderedState.files.length > 0;
       const shouldStartInHistory =
         orderedState.source.type === 'working-tree' && orderedState.files.length === 0;
@@ -844,7 +850,7 @@ export default function App() {
     historyRequestRef.current = request;
     setHistoryLoading(true);
     window.codiff
-      .getRepositoryHistory(nextLimit)
+      .getRepositoryHistory(nextLimit, historyPullRequestSource ?? undefined)
       .then((history) => {
         if (historyRequestRef.current !== request) {
           return;
@@ -864,7 +870,7 @@ export default function App() {
           setHistoryLoading(false);
         }
       });
-  }, [historyHasMore, historyLimit, historyLoading]);
+  }, [historyHasMore, historyLimit, historyLoading, historyPullRequestSource]);
 
   const moveDiffSearchMatch = useCallback(
     (direction: 1 | -1) => {

--- a/src/__tests__/git-state.test.ts
+++ b/src/__tests__/git-state.test.ts
@@ -26,6 +26,7 @@ type GitStateModule = {
     launchPath: string,
     limit?: number,
   ) => Promise<{ entries: ReadonlyArray<unknown>; root: string }>;
+  normalizeGitHubPullRequestCommit: (commit: Record<string, unknown>) => unknown;
   normalizeGitHubReviewComment: (comment: Record<string, unknown>) => unknown;
   normalizePullRequestComment: (comment: Record<string, unknown>) => Record<string, unknown>;
   parseGitHubPullRequestUrl: (value: string) => {
@@ -50,6 +51,7 @@ const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
 const {
   listRepositoryHistory,
+  normalizeGitHubPullRequestCommit,
   normalizeGitHubReviewComment,
   normalizePullRequestComment,
   parseGitHubPullRequestUrl,
@@ -140,6 +142,34 @@ test('normalizeGitHubReviewComment preserves multi-line ranges', () => {
     lineNumber: 8,
     side: 'additions',
     startLineNumber: 5,
+  });
+});
+
+test('normalizeGitHubPullRequestCommit reads GitHub PR commit metadata', () => {
+  expect(
+    normalizeGitHubPullRequestCommit({
+      author: {
+        avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+      },
+      commit: {
+        author: {
+          date: '2026-05-22T12:34:56Z',
+          email: 'author@example.com',
+          name: 'PR Author',
+        },
+        message: 'Feature commit\n\nBody',
+      },
+      parents: [{ sha: 'parent-sha' }],
+      sha: 'commit-sha',
+    }),
+  ).toEqual({
+    author: 'PR Author',
+    committedAt: Date.parse('2026-05-22T12:34:56Z'),
+    gravatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+    parents: ['parent-sha'],
+    ref: 'commit-sha',
+    scope: 'pull-request',
+    subject: 'Feature commit',
   });
 });
 

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -378,52 +378,69 @@ function HistorySidebar({
   const currentSourceKey = getSourceKey(currentSource);
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const listRef = useRef<HTMLDivElement>(null);
-  const rows = useMemo(
-    () =>
-      [
-        pullRequestSource
+  const rows = useMemo(() => {
+    const commitRows = entries.map((entry) => ({
+      author: entry.author,
+      committedAt: entry.committedAt,
+      gravatarUrl: entry.gravatarUrl,
+      key: `commit:${entry.ref}`,
+      kind: 'entry' as const,
+      ref: entry.ref,
+      scope: entry.scope,
+      source: { ref: entry.ref, type: 'commit' } satisfies ReviewSource,
+      subject: entry.subject,
+    }));
+    const matchesQuery = (row: (typeof commitRows)[number]) =>
+      !normalizedQuery ||
+      row.subject.toLowerCase().includes(normalizedQuery) ||
+      row.ref.toLowerCase().includes(normalizedQuery);
+
+    if (pullRequestSource) {
+      const pullRequestRows = commitRows
+        .filter((row) => row.scope === 'pull-request')
+        .filter(matchesQuery);
+      const baseRows = commitRows.filter((row) => row.scope === 'base').filter(matchesQuery);
+      return [
+        !normalizedQuery
           ? {
               author: null,
               committedAt: null,
               gravatarUrl: undefined,
               key: getSourceKey(pullRequestSource),
+              kind: 'entry' as const,
               ref: pullRequestSource.number ? `PR #${pullRequestSource.number}` : 'PR',
               source: pullRequestSource satisfies ReviewSource,
               subject: pullRequestSource.title || 'Pull Request',
             }
           : null,
-        {
-          author: null,
-          committedAt: null,
-          gravatarUrl: undefined,
-          key: 'working-tree',
-          ref: '',
-          source: { type: 'working-tree' } satisfies ReviewSource,
-          subject: 'Uncommitted',
-        },
-        ...entries.map((entry) => ({
-          author: entry.author,
-          committedAt: entry.committedAt,
-          gravatarUrl: entry.gravatarUrl,
-          key: `commit:${entry.ref}`,
-          ref: entry.ref,
-          source: { ref: entry.ref, type: 'commit' } satisfies ReviewSource,
-          subject: entry.subject,
-        })),
-      ].filter((row): row is NonNullable<typeof row> => row != null),
-    [entries, pullRequestSource],
-  );
-  const visibleRows = useMemo(
-    () =>
-      normalizedQuery
-        ? rows.filter(
-            (row) =>
-              row.subject.toLowerCase().includes(normalizedQuery) ||
-              row.ref.toLowerCase().includes(normalizedQuery),
-          )
-        : rows,
-    [normalizedQuery, rows],
-  );
+        pullRequestRows.length > 0
+          ? { key: 'history-section:pull-request', kind: 'section' as const, label: 'In this PR' }
+          : null,
+        ...pullRequestRows,
+        baseRows.length > 0
+          ? { key: 'history-section:base', kind: 'section' as const, label: 'Base history' }
+          : null,
+        ...baseRows,
+      ].filter((row): row is NonNullable<typeof row> => row != null);
+    }
+
+    const localRows = commitRows.filter(matchesQuery);
+    return [
+      !normalizedQuery
+        ? {
+            author: null,
+            committedAt: null,
+            gravatarUrl: undefined,
+            key: 'working-tree',
+            kind: 'entry' as const,
+            ref: '',
+            source: { type: 'working-tree' } satisfies ReviewSource,
+            subject: 'Uncommitted',
+          }
+        : null,
+      ...localRows,
+    ].filter((row): row is NonNullable<typeof row> => row != null);
+  }, [entries, normalizedQuery, pullRequestSource]);
   const maybeLoadMore = useCallback(() => {
     const element = listRef.current;
     if (!element || loading || !hasMore || normalizedQuery) {
@@ -437,7 +454,15 @@ function HistorySidebar({
 
   return (
     <div className="history-list" onScroll={maybeLoadMore} ref={listRef}>
-      {visibleRows.map((row) => {
+      {rows.map((row) => {
+        if (row.kind === 'section') {
+          return (
+            <div className="history-section" key={row.key}>
+              {row.label}
+            </div>
+          );
+        }
+
         const selected = row.key === currentSourceKey;
         const hasMetadata = Boolean(row.author && row.committedAt);
         return (

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -396,10 +396,13 @@ function HistorySidebar({
       row.ref.toLowerCase().includes(normalizedQuery);
 
     if (pullRequestSource) {
+      const hasScopedRows = commitRows.some((row) => row.scope != null);
       const pullRequestRows = commitRows
-        .filter((row) => row.scope === 'pull-request')
+        .filter((row) => (hasScopedRows ? row.scope === 'pull-request' : row.scope == null))
         .filter(matchesQuery);
-      const baseRows = commitRows.filter((row) => row.scope === 'base').filter(matchesQuery);
+      const baseRows = hasScopedRows
+        ? commitRows.filter((row) => row.scope === 'base').filter(matchesQuery)
+        : [];
       return [
         !normalizedQuery
           ? {
@@ -413,13 +416,13 @@ function HistorySidebar({
               subject: pullRequestSource.title || 'Pull Request',
             }
           : null,
-        pullRequestRows.length > 0
-          ? { key: 'history-section:pull-request', kind: 'section' as const, label: 'In this PR' }
-          : null,
+        {
+          key: 'history-section:pull-request',
+          kind: 'section' as const,
+          label: hasScopedRows ? 'Pull request commits' : 'Branch history',
+        },
         ...pullRequestRows,
-        baseRows.length > 0
-          ? { key: 'history-section:base', kind: 'section' as const, label: 'Base history' }
-          : null,
+        { key: 'history-section:base', kind: 'section' as const, label: 'Base history' },
         ...baseRows,
       ].filter((row): row is NonNullable<typeof row> => row != null);
     }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -26,7 +26,7 @@ declare global {
       getGitIdentity: () => Promise<GitIdentity>;
       getLaunchOptions: () => Promise<CodiffLaunchOptions>;
       getPreferences: () => Promise<CodiffPreferences>;
-      getRepositoryHistory: (limit?: number) => Promise<RepositoryHistory>;
+      getRepositoryHistory: (limit?: number, source?: ReviewSource) => Promise<RepositoryHistory>;
       getRepositoryState: (source?: ReviewSource) => Promise<RepositoryState>;
       getTerminalHelperStatus: () => Promise<TerminalHelperStatus>;
       getWalkthrough: (source?: ReviewSource) => Promise<WalkthroughResult>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export type HistoryEntry = {
   gravatarUrl?: string;
   parents: ReadonlyArray<string>;
   ref: string;
+  scope?: 'base' | 'pull-request';
   subject: string;
 };
 


### PR DESCRIPTION
`codiff https://github.com/nkzw-tech/codiff/pull/14`

I'm not totally sold on the headers like "In this PR", but I do kind of like it. I also like that I can select the top of the history and diff all the files in the PR

**Before:**
<img width="448" height="555" alt="Screenshot 2026-05-22 at 11 23 52 AM" src="https://github.com/user-attachments/assets/7a2a58b5-a420-4f79-ab49-91ffcae9d724" />


**After:**
<img width="477" height="816" alt="Screenshot 2026-05-22 at 11 31 48 AM" src="https://github.com/user-attachments/assets/1d5ef78e-6120-46f8-ba7b-b6a3e4ca7080" />

Note: used gpt 5.5 for this