### PR TITLE
Add --help and --version flags to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ codiff -w
 codiff -w a1b2c3d
 ```
 
+Show all available options:
+
+```bash
+codiff --help
+```
+
 Launching Codiff in multiple repositories opens a separate native window for each repository.
 
 ## Command Bar

--- a/bin/arguments.js
+++ b/bin/arguments.js
@@ -3,6 +3,64 @@ import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
+export const flagDefinitions = [
+  { argument: '<ref>', description: 'Review a specific commit.', name: 'commit', type: 'string' },
+  { description: 'Show this help message and exit.', name: 'help', short: 'h', type: 'boolean' },
+  {
+    description: 'Show version number and exit.',
+    name: 'version',
+    short: 'v',
+    type: 'boolean',
+  },
+  {
+    description: 'Start with an LLM-generated review walkthrough.',
+    name: 'walkthrough',
+    short: 'w',
+    type: 'boolean',
+  },
+];
+
+export const usageExamples = [
+  { command: 'codiff', description: 'Review staged and unstaged changes.' },
+  { command: 'codiff /path/to/repo', description: 'Review changes in a specific repository.' },
+  { command: 'codiff a1b2c3d', description: 'Review a specific commit.' },
+  { command: "codiff '#75'", description: 'Review pull request #75.' },
+  { command: 'codiff pr 75', description: 'Review pull request #75 (alternate syntax).' },
+  { command: 'codiff -w', description: 'Start with an LLM walkthrough.' },
+  { command: 'codiff -w a1b2c3d', description: 'Walkthrough a specific commit.' },
+];
+
+const parseArgsOptions = Object.fromEntries(
+  flagDefinitions.map(({ name, short, type }) => [name, { type, ...(short ? { short } : {}) }]),
+);
+
+export const formatHelpText = (version) => {
+  const flagLines = flagDefinitions.map(({ argument, description, name, short }) => {
+    const label = `--${name}${argument ? ` ${argument}` : ''}${short ? `, -${short}` : ''}`;
+    return { description, label };
+  });
+  const flagPad = Math.max(...flagLines.map(({ label }) => label.length)) + 2;
+
+  const examplePad = Math.max(...usageExamples.map(({ command }) => command.length)) + 2;
+
+  const lines = [
+    `codiff v${version} — A fast local diff viewer.`,
+    '',
+    'Usage: codiff [options] [<ref> | <pr> | <url>] [path]',
+    '',
+    'Options:',
+    ...flagLines.map(({ description, label }) => `  ${label.padEnd(flagPad)}${description}`),
+    '',
+    'Examples:',
+    ...usageExamples.map(
+      ({ command, description }) => `  ${command.padEnd(examplePad)}${description}`,
+    ),
+    '',
+  ];
+
+  return lines.join('\n');
+};
+
 const commitHashPattern = /^[0-9a-f]{4,64}$/i;
 const headCommitRefPattern = /^(?:HEAD|@)(?:(?:[~^]\d*)|\^\{[^}]+\}|@\{[^}]+\})*$/;
 const pullRequestNumberPattern = /^#([1-9]\d*)$/;
@@ -123,15 +181,7 @@ export const parseArguments = (args) => {
   const { positionals, values } = parseArgs({
     allowPositionals: true,
     args,
-    options: {
-      commit: {
-        type: 'string',
-      },
-      walkthrough: {
-        short: 'w',
-        type: 'boolean',
-      },
-    },
+    options: parseArgsOptions,
     strict: false,
   });
 
@@ -173,9 +223,11 @@ export const parseArguments = (args) => {
 
   return {
     commitRef,
+    help: values.help === true,
     pullRequestNumber,
     pullRequestUrl,
     requestedPath: resolve(requestedPath ?? process.cwd()),
+    version: values.version === true,
     walkthrough: values.walkthrough === true,
   };
 };

--- a/bin/codiff-app
+++ b/bin/codiff-app
@@ -15,6 +15,35 @@ done
 
 script_dir="$(CDPATH= cd -P "$(dirname "$source_path")" >/dev/null 2>&1 && pwd)"
 app_path="$(CDPATH= cd -P "$script_dir/../../../.." >/dev/null 2>&1 && pwd)"
+
+codiff_version() {
+  sed -n 's/^  "version": "\([^"]*\)".*/\1/p' "$script_dir/../package.json"
+}
+
+show_help() {
+  version="$(codiff_version)"
+  cat <<EOF
+codiff v${version} — A fast local diff viewer.
+
+Usage: codiff [options] [<ref> | <pr> | <url>] [path]
+
+Options:
+  --commit <ref>        Review a specific commit.
+  --help, -h            Show this help message and exit.
+  --version, -v         Show version number and exit.
+  --walkthrough, -w     Start with an LLM-generated review walkthrough.
+
+Examples:
+  codiff                Review staged and unstaged changes.
+  codiff /path/to/repo  Review changes in a specific repository.
+  codiff a1b2c3d        Review a specific commit.
+  codiff '#75'          Review pull request #75.
+  codiff pr 75          Review pull request #75 (alternate syntax).
+  codiff -w             Start with an LLM walkthrough.
+  codiff -w a1b2c3d     Walkthrough a specific commit.
+EOF
+}
+
 repository_path=""
 commit_ref=""
 pull_request_source=""
@@ -61,6 +90,14 @@ for arg in "$@"; do
   fi
 
   case "$arg" in
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    --version|-v)
+      printf 'codiff v%s\n' "$(codiff_version)"
+      exit 0
+      ;;
     --walkthrough|-w)
       walkthrough=1
       ;;

--- a/bin/codiff.js
+++ b/bin/codiff.js
@@ -5,12 +5,24 @@ import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import electron from 'electron';
-import { parseArguments, resolvePullRequestUrl } from './arguments.js';
+import packageJson from '../package.json' with { type: 'json' };
+import { formatHelpText, parseArguments, resolvePullRequestUrl } from './arguments.js';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 const run = () => {
   const parsedArguments = parseArguments(process.argv.slice(2));
+
+  if (parsedArguments.help) {
+    process.stdout.write(formatHelpText(packageJson.version));
+    return;
+  }
+
+  if (parsedArguments.version) {
+    process.stdout.write(`codiff v${packageJson.version}\n`);
+    return;
+  }
+
   const { commitRef, pullRequestNumber, requestedPath, walkthrough } = parsedArguments;
   let { pullRequestUrl } = parsedArguments;
 

--- a/src/__tests__/codiff-cli.test.ts
+++ b/src/__tests__/codiff-cli.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
-import { parseArguments, resolvePullRequestUrl } from '../../bin/arguments.js';
+import { formatHelpText, parseArguments, resolvePullRequestUrl } from '../../bin/arguments.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -17,9 +17,11 @@ test('parseArguments treats a hash positional as a commit ref', () => {
 
   expect(parseArguments(['-w', commitRef])).toEqual({
     commitRef,
+    help: false,
     pullRequestNumber: null,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
+    version: false,
     walkthrough: true,
   });
 });
@@ -27,17 +29,21 @@ test('parseArguments treats a hash positional as a commit ref', () => {
 test('parseArguments treats HEAD positional revisions as commit refs', () => {
   expect(parseArguments(['HEAD'])).toEqual({
     commitRef: 'HEAD',
+    help: false,
     pullRequestNumber: null,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
+    version: false,
     walkthrough: false,
   });
 
   expect(parseArguments(['HEAD^1'])).toEqual({
     commitRef: 'HEAD^1',
+    help: false,
     pullRequestNumber: null,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
+    version: false,
     walkthrough: false,
   });
 });
@@ -51,9 +57,11 @@ test('parseArguments keeps existing hash-like paths as repository paths', async 
 
     expect(parseArguments([repositoryPath])).toEqual({
       commitRef: null,
+      help: false,
       pullRequestNumber: null,
       pullRequestUrl: null,
       requestedPath: repositoryPath,
+      version: false,
       walkthrough: false,
     });
   } finally {
@@ -66,9 +74,11 @@ test('parseArguments treats GitHub pull request URLs as review sources', () => {
 
   expect(parseArguments([pullRequestUrl])).toEqual({
     commitRef: null,
+    help: false,
     pullRequestNumber: null,
     pullRequestUrl,
     requestedPath: resolve(process.cwd()),
+    version: false,
     walkthrough: false,
   });
 });
@@ -76,9 +86,11 @@ test('parseArguments treats GitHub pull request URLs as review sources', () => {
 test('parseArguments treats PR number shorthands as review sources', () => {
   expect(parseArguments(['#75'])).toEqual({
     commitRef: null,
+    help: false,
     pullRequestNumber: 75,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
+    version: false,
     walkthrough: false,
   });
 });
@@ -86,9 +98,11 @@ test('parseArguments treats PR number shorthands as review sources', () => {
 test('parseArguments treats PR marker arguments as review sources', () => {
   expect(parseArguments(['pr', '75'])).toEqual({
     commitRef: null,
+    help: false,
     pullRequestNumber: 75,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
+    version: false,
     walkthrough: false,
   });
 });
@@ -96,9 +110,11 @@ test('parseArguments treats PR marker arguments as review sources', () => {
 test('parseArguments treats hash-prefixed PR marker values as review sources', () => {
   expect(parseArguments(['pr', '#75'])).toEqual({
     commitRef: null,
+    help: false,
     pullRequestNumber: 75,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
+    version: false,
     walkthrough: false,
   });
 });
@@ -243,4 +259,63 @@ test('packaged terminal helper forwards relative repository paths as absolute pa
   } finally {
     await rm(directory, { force: true, recursive: true });
   }
+});
+
+test('parseArguments recognizes --help and -h flags', () => {
+  expect(parseArguments(['--help']).help).toBe(true);
+  expect(parseArguments(['-h']).help).toBe(true);
+});
+
+test('parseArguments recognizes --version and -v flags', () => {
+  expect(parseArguments(['--version']).version).toBe(true);
+  expect(parseArguments(['-v']).version).toBe(true);
+});
+
+test('parseArguments defaults help and version to false', () => {
+  const result = parseArguments([]);
+  expect(result.help).toBe(false);
+  expect(result.version).toBe(false);
+});
+
+test('formatHelpText includes version and all flags', () => {
+  const text = formatHelpText('1.2.3');
+  expect(text).toContain('codiff v1.2.3');
+  expect(text).toContain('Usage:');
+  expect(text).toContain('--help');
+  expect(text).toContain('--version');
+  expect(text).toContain('--commit');
+  expect(text).toContain('--walkthrough');
+  expect(text).toContain('-h');
+  expect(text).toContain('-v');
+  expect(text).toContain('-w');
+});
+
+test('codiff-app --help prints help text and exits 0', async () => {
+  const { stdout } = await execFileAsync(resolve('bin/codiff-app'), ['--help'], {
+    encoding: 'utf8',
+  });
+  expect(stdout).toContain('codiff v');
+  expect(stdout).toContain('Usage:');
+  expect(stdout).toContain('--help');
+});
+
+test('codiff-app -h prints help text and exits 0', async () => {
+  const { stdout } = await execFileAsync(resolve('bin/codiff-app'), ['-h'], {
+    encoding: 'utf8',
+  });
+  expect(stdout).toContain('Usage:');
+});
+
+test('codiff-app --version prints version and exits 0', async () => {
+  const { stdout } = await execFileAsync(resolve('bin/codiff-app'), ['--version'], {
+    encoding: 'utf8',
+  });
+  expect(stdout).toMatch(/^codiff v\d+\.\d+\.\d+\n$/);
+});
+
+test('codiff-app -v prints version and exits 0', async () => {
+  const { stdout } = await execFileAsync(resolve('bin/codiff-app'), ['-v'], {
+    encoding: 'utf8',
+  });
+  expect(stdout).toMatch(/^codiff v\d+\.\d+\.\d+\n$/);
 });


### PR DESCRIPTION
## Context

Thank you for building codiff, it's already become part of my standard workflow ❤️ 

A current struggle for me as a user is that there isn't a `--help` command or similar on the CLI, making discoverability difficult beyond going to the repo's README and checking. Goal was to implement this in a straightforward and maintainable way.

E.g. I wasn't even aware you could do `codiff pr <pr-number>` until I saw this tweet: https://x.com/cnakazawa/status/2057208130229223886

## Summary

- Adds `--help` / `-h` and `--version` / `-v` to both CLI entry points
  (`bin/codiff.js` and `bin/codiff-app`)
- Flag definitions live in a single structured array in `arguments.js` so
  adding future flags only requires one addition
- Prints usage info and exits before launching Electron
- Includes unit and integration tests for the new flags