### PR TITLE
fix: persist window dimensions across sessions

### DIFF
--- a/electron/__tests__/window-state.test.ts
+++ b/electron/__tests__/window-state.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, test } from 'vite-plus/test';
+
+const require = createRequire(import.meta.url);
+const { readWindowState, validateWindowStateOnScreen, writeWindowState } =
+  require('../window-state.cjs') as {
+    readWindowState: (configDir?: string) => {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      isMaximized: boolean;
+      isFullScreen: boolean;
+    } | null;
+    validateWindowStateOnScreen: (
+      state: { x: number; y: number; width: number; height: number },
+      displays: ReadonlyArray<{
+        workArea: { x: number; y: number; width: number; height: number };
+      }>,
+    ) => { x: number; y: number; width: number; height: number } | null;
+    writeWindowState: (
+      state: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+        isMaximized: boolean;
+        isFullScreen: boolean;
+      },
+      configDir?: string,
+    ) => void;
+  };
+
+const validState = {
+  height: 720,
+  isFullScreen: false,
+  isMaximized: false,
+  width: 1120,
+  x: 100,
+  y: 50,
+};
+
+const primaryDisplay = { workArea: { height: 900, width: 1440, x: 0, y: 0 } };
+
+test('readWindowState returns null when file does not exist', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
+  try {
+    expect(readWindowState(dir)).toBeNull();
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test('readWindowState returns null for corrupt JSON', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
+  try {
+    await writeFile(join(dir, 'window-state.json'), '{not valid json');
+    expect(readWindowState(dir)).toBeNull();
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test('readWindowState returns null for invalid fields', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
+  try {
+    await writeFile(join(dir, 'window-state.json'), JSON.stringify({ x: 'not a number' }));
+    expect(readWindowState(dir)).toBeNull();
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test('readWindowState returns null when width is below minimum', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
+  try {
+    await writeFile(join(dir, 'window-state.json'), JSON.stringify({ ...validState, width: 500 }));
+    expect(readWindowState(dir)).toBeNull();
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test('readWindowState returns null when height is below minimum', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
+  try {
+    await writeFile(join(dir, 'window-state.json'), JSON.stringify({ ...validState, height: 400 }));
+    expect(readWindowState(dir)).toBeNull();
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test('readWindowState returns valid state', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
+  try {
+    await writeFile(join(dir, 'window-state.json'), JSON.stringify(validState));
+    expect(readWindowState(dir)).toEqual(validState);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test('readWindowState defaults isMaximized and isFullScreen to false when missing', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
+  try {
+    const { isMaximized: _, isFullScreen: __, ...partial } = validState;
+    await writeFile(join(dir, 'window-state.json'), JSON.stringify(partial));
+    const result = readWindowState(dir);
+    expect(result?.isMaximized).toBe(false);
+    expect(result?.isFullScreen).toBe(false);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test('writeWindowState creates directory and file', async () => {
+  const dir = join(await mkdtemp(join(tmpdir(), 'codiff-ws-')), 'nested');
+  try {
+    writeWindowState(validState, dir);
+    expect(readWindowState(dir)).toEqual(validState);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test('write then read round-trips correctly', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
+  try {
+    const state = { ...validState, isFullScreen: true, isMaximized: true };
+    writeWindowState(state, dir);
+    expect(readWindowState(dir)).toEqual(state);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+});
+
+test('validateWindowStateOnScreen returns state when visible on primary display', () => {
+  const state = { ...validState, x: 100, y: 50 };
+  expect(validateWindowStateOnScreen(state, [primaryDisplay])).toEqual(state);
+});
+
+test('validateWindowStateOnScreen returns null when off all displays', () => {
+  const state = { ...validState, x: 5000, y: 5000 };
+  expect(validateWindowStateOnScreen(state, [primaryDisplay])).toBeNull();
+});
+
+test('validateWindowStateOnScreen returns state when partially overlapping', () => {
+  const state = { ...validState, x: 1440 - 150, y: 0 };
+  expect(validateWindowStateOnScreen(state, [primaryDisplay])).toEqual(state);
+});
+
+test('validateWindowStateOnScreen returns null when overlap is too small', () => {
+  const state = { ...validState, x: 1440 - 50, y: 0 };
+  expect(validateWindowStateOnScreen(state, [primaryDisplay])).toBeNull();
+});
+
+test('validateWindowStateOnScreen finds window on secondary display', () => {
+  const secondary = { workArea: { height: 1080, width: 1920, x: 1440, y: 0 } };
+  const state = { ...validState, x: 1500, y: 100 };
+  expect(validateWindowStateOnScreen(state, [primaryDisplay, secondary])).toEqual(state);
+});
+
+test('validateWindowStateOnScreen returns null with no displays', () => {
+  expect(validateWindowStateOnScreen(validState, [])).toBeNull();
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -53,6 +53,11 @@ const {
 } = require('./main/command-line.cjs');
 const { createEditorOpener } = require('./main/editor.cjs');
 const { createTerminalHelper } = require('./main/terminal-helper.cjs');
+const {
+  readWindowState,
+  validateWindowStateOnScreen,
+  writeWindowState,
+} = require('./window-state.cjs');
 const { readWalkthrough } = require('./walkthrough.cjs');
 
 /**
@@ -423,13 +428,17 @@ const createWindow = (
   launchOptions = { repositoryPathProvided: true, walkthrough: false },
   identity = getWindowIdentity(repositoryPath, launchOptions),
 ) => {
+  const savedState = readWindowState();
+  const validatedState = savedState
+    ? validateWindowStateOnScreen(savedState, screen.getAllDisplays())
+    : null;
+
   const display = screen.getPrimaryDisplay();
   const { height, width } = display.workAreaSize;
   const window = new BrowserWindow({
     autoHideMenuBar: true,
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#141414' : '#ffffff',
-    center: true,
-    height: Math.max(720, Math.floor(height * 0.86)),
+    height: validatedState?.height ?? Math.max(720, Math.floor(height * 0.86)),
     minHeight: 520,
     minWidth: 880,
     show: false,
@@ -441,7 +450,34 @@ const createWindow = (
       nodeIntegration: false,
       preload: join(__dirname, 'preload.cjs'),
     },
-    width: Math.max(1120, Math.floor(width * 0.86)),
+    width: validatedState?.width ?? Math.max(1120, Math.floor(width * 0.86)),
+    ...(validatedState ? { x: validatedState.x, y: validatedState.y } : { center: true }),
+  });
+
+  if (validatedState?.isMaximized) {
+    window.maximize();
+  }
+  if (validatedState?.isFullScreen) {
+    window.setFullScreen(true);
+  }
+
+  let normalBounds = validatedState
+    ? {
+        x: validatedState.x,
+        y: validatedState.y,
+        width: validatedState.width,
+        height: validatedState.height,
+      }
+    : window.getBounds();
+  window.on('resize', () => {
+    if (!window.isMaximized() && !window.isFullScreen()) {
+      normalBounds = window.getBounds();
+    }
+  });
+  window.on('move', () => {
+    if (!window.isMaximized() && !window.isFullScreen()) {
+      normalBounds = window.getBounds();
+    }
   });
 
   const webContentsId = window.webContents.id;
@@ -460,6 +496,17 @@ const createWindow = (
   let allowClose = false;
   let copyingPendingCommentsBeforeClose = false;
   window.on('close', (event) => {
+    try {
+      writeWindowState({
+        height: normalBounds.height,
+        isFullScreen: window.isFullScreen(),
+        isMaximized: window.isMaximized(),
+        width: normalBounds.width,
+        x: normalBounds.x,
+        y: normalBounds.y,
+      });
+    } catch {}
+
     if (allowClose || quitting || !config.settings.copyCommentsOnClose) {
       return;
     }

--- a/electron/window-state.cjs
+++ b/electron/window-state.cjs
@@ -1,0 +1,123 @@
+// @ts-check
+
+const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('node:fs');
+const { homedir } = require('node:os');
+const { join } = require('node:path');
+
+const MIN_WIDTH = 880;
+const MIN_HEIGHT = 520;
+const MIN_OVERLAP = 100;
+
+const getDefaultConfigDir = () => join(homedir(), '.codiff');
+
+/**
+ * @typedef {{
+ *   x: number;
+ *   y: number;
+ *   width: number;
+ *   height: number;
+ *   isMaximized: boolean;
+ *   isFullScreen: boolean;
+ * }} WindowState
+ */
+
+/**
+ * @param {unknown} raw
+ * @returns {WindowState | null}
+ */
+const parseWindowState = (raw) => {
+  if (typeof raw !== 'object' || raw === null) {
+    return null;
+  }
+
+  const obj = /** @type {Record<string, unknown>} */ (raw);
+  const { x, y, width, height, isMaximized, isFullScreen } = obj;
+
+  if (
+    typeof x !== 'number' ||
+    typeof y !== 'number' ||
+    typeof width !== 'number' ||
+    typeof height !== 'number' ||
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width < MIN_WIDTH ||
+    height < MIN_HEIGHT
+  ) {
+    return null;
+  }
+
+  return {
+    height,
+    isFullScreen: typeof isFullScreen === 'boolean' ? isFullScreen : false,
+    isMaximized: typeof isMaximized === 'boolean' ? isMaximized : false,
+    width,
+    x,
+    y,
+  };
+};
+
+/**
+ * @param {string} [configDir]
+ * @returns {WindowState | null}
+ */
+const readWindowState = (configDir) => {
+  const filePath = join(configDir ?? getDefaultConfigDir(), 'window-state.json');
+
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const raw = JSON.parse(readFileSync(filePath, 'utf8'));
+    return parseWindowState(raw);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * @param {WindowState} state
+ * @param {string} [configDir]
+ */
+const writeWindowState = (state, configDir) => {
+  const dir = configDir ?? getDefaultConfigDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  writeFileSync(join(dir, 'window-state.json'), JSON.stringify(state, null, 2) + '\n');
+};
+
+/**
+ * @param {WindowState} state
+ * @param {ReadonlyArray<{ workArea: { x: number; y: number; width: number; height: number } }>} displays
+ * @returns {WindowState | null}
+ */
+const validateWindowStateOnScreen = (state, displays) => {
+  for (const display of displays) {
+    const { workArea } = display;
+    const overlapX = Math.max(
+      0,
+      Math.min(state.x + state.width, workArea.x + workArea.width) - Math.max(state.x, workArea.x),
+    );
+    const overlapY = Math.max(
+      0,
+      Math.min(state.y + state.height, workArea.y + workArea.height) -
+        Math.max(state.y, workArea.y),
+    );
+
+    if (overlapX >= MIN_OVERLAP && overlapY >= MIN_OVERLAP) {
+      return state;
+    }
+  }
+
+  return null;
+};
+
+module.exports = {
+  readWindowState,
+  validateWindowStateOnScreen,
+  writeWindowState,
+};


### PR DESCRIPTION
## Context
Offering another small QoL improvement here: currently window dimensions are not persisted in the app, which means the user needs to resize windows manually (e.g. to full screen, half width, etc) from the default dimensions everytime `codiff` is called fresh. This breaks up flow state when wanting to jump straight into the code diff.

## Summary
- Save window size, position, maximized, and fullscreen state to `~/.codiff/window-state.json` on close
- Restore saved state on next launch, with off-screen validation (100px overlap threshold against all displays)
- Fall back to centered 86%-of-screen defaults when no state exists, file is corrupt, or saved position is off-screen
- Track pre-maximized/pre-fullscreen bounds so closing while maximized preserves the user's preferred windowed dimensions
- 12 new unit tests in `window-state.test.ts` covering read/write/validation logic
- Tested manually on macOS across resize, maximize, fullscreen, and corrupt/missing state file scenarios

## Demo
https://github.com/user-attachments/assets/599f49a4-a1fa-4c4b-a295-8c594ae26699

