### PR TITLE
feat: hide resolved and outdated review comments

### DIFF
--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -27,6 +27,7 @@ const defaultSettings = {
   copyCommentsOnClose: false,
   lastRepositoryPath: '',
   openAIModel: 'gpt-5.3-codex-spark',
+  showOutdated: false,
   showWhitespace: false,
   theme: 'system',
 };
@@ -196,6 +197,10 @@ const mergeConfig = (raw) => {
         typeof rawSettings.openAIModel === 'string'
           ? rawSettings.openAIModel
           : defaultSettings.openAIModel,
+      showOutdated:
+        typeof rawSettings.showOutdated === 'boolean'
+          ? rawSettings.showOutdated
+          : defaultSettings.showOutdated,
       showWhitespace:
         typeof rawSettings.showWhitespace === 'boolean'
           ? rawSettings.showWhitespace
@@ -347,6 +352,7 @@ const configToPreferences = (config) => ({
   copyCommentsOnClose: config.settings.copyCommentsOnClose,
   lastRepositoryPath: config.settings.lastRepositoryPath,
   openAIModel: config.settings.openAIModel,
+  showOutdated: config.settings.showOutdated,
   showWhitespace: config.settings.showWhitespace,
   theme: config.settings.theme,
 });

--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -8,6 +8,7 @@ const {
   readCommitState,
 } = require('./git-state/commit.cjs');
 const {
+  collectResolvedReviewCommentIds,
   createPullRequestHistoryFetchRefspecs,
   getPullRequestHeadImageSource,
   listPullRequestHistory,
@@ -17,6 +18,7 @@ const {
   parseGitHubPullRequestUrl,
   readPullRequestImageContent,
   readPullRequestState,
+  selectUnresolvedReviewComments,
   submitPullRequestComment,
   submitPullRequestReview,
 } = require('./git-state/pull-request.cjs');
@@ -72,6 +74,7 @@ const readDiffImageContent = (launchPath, request) =>
       : readWorkingTreeDiffImageContent(launchPath, request);
 
 module.exports = {
+  collectResolvedReviewCommentIds,
   createPullRequestHistoryFetchRefspecs,
   getPullRequestHeadImageSource,
   listRepositoryHistory: readRepositoryHistory,
@@ -80,6 +83,7 @@ module.exports = {
   normalizePullRequestComment,
   parseStatus,
   parseGitHubPullRequestUrl,
+  selectUnresolvedReviewComments,
   readDiffSectionContent,
   readDiffImageContent,
   readGitIdentity,

--- a/electron/git-state/pull-request.cjs
+++ b/electron/git-state/pull-request.cjs
@@ -29,6 +29,7 @@ const {
  * @typedef {{base?: {ref?: string; repo?: GitHubRepositoryMetadata | null; sha?: string}; head?: {ref?: string; repo?: GitHubRepositoryMetadata | null; sha?: string}; title?: string}} GitHubPullRequestMetadata
  * @typedef {{author?: {avatar_url?: string}; commit?: {author?: {date?: string; email?: string; name?: string}; message?: string}; parents?: ReadonlyArray<{sha?: string}>; sha?: string}} GitHubCommit
  * @typedef {{[key: string]: any}} GitHubReviewComment
+ * @typedef {{comments?: {nodes?: ReadonlyArray<{databaseId?: number | null}>} | null; isResolved?: boolean}} GitHubReviewThread
  */
 
 /** @param {string} value @returns {PullRequestReference} */
@@ -352,6 +353,7 @@ const normalizeGitHubReviewComment = (comment) => {
     body: comment.body,
     filePath: comment.path,
     id: `github:${comment.id}`,
+    ...(typeof comment.line !== 'number' ? { isOutdated: true } : {}),
     lineNumber,
     side,
     ...(hasRange ? { startLineNumber } : {}),
@@ -361,16 +363,101 @@ const normalizeGitHubReviewComment = (comment) => {
   };
 };
 
+/** @param {ReadonlyArray<GitHubReviewThread>} threads @returns {Set<number>} */
+const collectResolvedReviewCommentIds = (threads) => {
+  /** @type {Set<number>} */
+  const ids = new Set();
+  for (const thread of threads) {
+    if (!thread?.isResolved) {
+      continue;
+    }
+    for (const comment of thread.comments?.nodes ?? []) {
+      if (typeof comment?.databaseId === 'number') {
+        ids.add(comment.databaseId);
+      }
+    }
+  }
+  return ids;
+};
+
+/** @param {ReadonlyArray<GitHubReviewComment>} comments @param {ReadonlySet<number>} resolvedCommentIds */
+const selectUnresolvedReviewComments = (comments, resolvedCommentIds) =>
+  comments
+    .filter((comment) => !resolvedCommentIds.has(comment.id))
+    .map(normalizeGitHubReviewComment)
+    .filter(Boolean);
+
+const RESOLVED_REVIEW_THREADS_QUERY = `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        nodes {
+          comments(first: 100) {
+            nodes {
+              databaseId
+            }
+          }
+          isResolved
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  }
+}`;
+
+/** @param {string} repoRoot @param {PullRequestReference} pullRequest @returns {Promise<Set<number>>} */
+const readResolvedReviewCommentIds = async (repoRoot, pullRequest) => {
+  try {
+    /** @type {Array<GitHubReviewThread>} */
+    const threads = [];
+    /** @type {string | undefined} */
+    let cursor;
+    let hasNextPage = true;
+    while (hasNextPage) {
+      const response = JSON.parse(
+        await ghApi(repoRoot, [
+          'graphql',
+          '-f',
+          `query=${RESOLVED_REVIEW_THREADS_QUERY}`,
+          '-f',
+          `owner=${pullRequest.owner}`,
+          '-f',
+          `repo=${pullRequest.repo}`,
+          '-F',
+          `number=${pullRequest.number}`,
+          ...(cursor ? ['-f', `cursor=${cursor}`] : []),
+        ]),
+      );
+      const reviewThreads = response?.data?.repository?.pullRequest?.reviewThreads;
+      if (!reviewThreads) {
+        break;
+      }
+      if (Array.isArray(reviewThreads.nodes)) {
+        threads.push(...reviewThreads.nodes);
+      }
+      cursor = reviewThreads.pageInfo?.endCursor ?? undefined;
+      hasNextPage = Boolean(reviewThreads.pageInfo?.hasNextPage && cursor);
+    }
+    return collectResolvedReviewCommentIds(threads);
+  } catch {
+    return new Set();
+  }
+};
+
 /** @param {string} repoRoot @param {PullRequestReference} pullRequest */
 const readPullRequestComments = async (repoRoot, pullRequest) => {
-  const pages = JSON.parse(
-    await ghApi(repoRoot, [
+  const [pages, resolvedCommentIds] = await Promise.all([
+    ghApi(repoRoot, [
       '--paginate',
       '--slurp',
       `repos/${pullRequest.owner}/${pullRequest.repo}/pulls/${pullRequest.number}/comments?per_page=100`,
-    ]),
-  );
-  return pages.flat().map(normalizeGitHubReviewComment).filter(Boolean);
+    ]).then((output) => JSON.parse(output)),
+    readResolvedReviewCommentIds(repoRoot, pullRequest),
+  ]);
+  return selectUnresolvedReviewComments(pages.flat(), resolvedCommentIds);
 };
 
 /** @param {string} repoRoot @param {PullRequestReference} pullRequest @returns {Promise<Array<GitHubCommit>>} */
@@ -704,6 +791,7 @@ const submitPullRequestReview = async (launchPath, request) => {
 };
 
 module.exports = {
+  collectResolvedReviewCommentIds,
   createPatchFromPullRequestFile,
   createPullRequestHistoryFetchRefspecs,
   createPullRequestSource,
@@ -716,6 +804,7 @@ module.exports = {
   parseGitHubPullRequestUrl,
   readPullRequestImageContent,
   readPullRequestState,
+  selectUnresolvedReviewComments,
   submitPullRequestComment,
   submitPullRequestReview,
 };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -360,6 +360,16 @@ const buildApplicationMenu = () =>
             type: 'checkbox',
           },
           {
+            checked: config.settings.showOutdated,
+            click: (menuItem) => {
+              updateConfig({
+                settings: { ...config.settings, showOutdated: menuItem.checked },
+              });
+            },
+            label: 'Show Outdated Comments',
+            type: 'checkbox',
+          },
+          {
             checked: config.settings.copyCommentsOnClose,
             click: (menuItem) => {
               updateConfig({
@@ -759,6 +769,10 @@ ipcMain.handle('codiff:getGitIdentity', async (event) => {
 ipcMain.handle('codiff:getPreferences', () => configToPreferences(config));
 
 ipcMain.handle('codiff:getConfig', () => config);
+
+ipcMain.handle('codiff:setShowOutdated', (_event, value) => {
+  updateConfig({ settings: { ...config.settings, showOutdated: Boolean(value) } });
+});
 
 ipcMain.handle('codiff:openConfigFile', () => openConfigFile());
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -55,6 +55,7 @@ const codiff = {
   },
   openConfigFile: () => ipcRenderer.invoke('codiff:openConfigFile'),
   openFile: (path) => ipcRenderer.invoke('codiff:openFile', path),
+  setShowOutdated: (value) => ipcRenderer.invoke('codiff:setShowOutdated', value),
   showInFolder: (path) => ipcRenderer.invoke('codiff:showInFolder', path),
   submitPullRequestComment: (request) =>
     ipcRenderer.invoke('codiff:submitPullRequestComment', request),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ import {
   getCommentKey,
   getReviewCommentRangeProps,
   getReviewCommentsFromState,
+  getVisibleReviewComments,
 } from './lib/review-comments.ts';
 import {
   SIDEBAR_COLLAPSE_THRESHOLD,
@@ -569,6 +570,7 @@ export default function App() {
           copyCommentsOnClose: nextConfig.settings.copyCommentsOnClose,
           lastRepositoryPath: nextConfig.settings.lastRepositoryPath,
           openAIModel: nextConfig.settings.openAIModel,
+          showOutdated: nextConfig.settings.showOutdated,
           showWhitespace: nextConfig.settings.showWhitespace,
           theme: nextConfig.settings.theme,
         });
@@ -581,6 +583,7 @@ export default function App() {
         copyCommentsOnClose: nextConfig.settings.copyCommentsOnClose,
         lastRepositoryPath: nextConfig.settings.lastRepositoryPath,
         openAIModel: nextConfig.settings.openAIModel,
+        showOutdated: nextConfig.settings.showOutdated,
         showWhitespace: nextConfig.settings.showWhitespace,
         theme: nextConfig.settings.theme,
       });
@@ -663,6 +666,11 @@ export default function App() {
   }, [walkthroughError]);
 
   const showWhitespace = preferences.showWhitespace;
+  const showOutdated = preferences.showOutdated;
+  const visibleReviewComments = useMemo(
+    () => getVisibleReviewComments(reviewComments, showOutdated),
+    [reviewComments, showOutdated],
+  );
   const walkthroughNotes = useMemo(() => getWalkthroughNotes(walkthrough), [walkthrough]);
   const orderedFiles = useMemo(
     () =>
@@ -1198,6 +1206,13 @@ export default function App() {
         id: 'toggle-sidebar',
         keymapAction: 'toggleSidebar',
         title: 'Toggle Sidebar',
+      }),
+      registry.register({
+        execute: () => {
+          void window.codiff.setShowOutdated(!preferencesRef.current.showOutdated).catch(() => {});
+        },
+        id: 'toggle-outdated-comments',
+        title: 'Toggle Outdated Comments',
       }),
       registry.register({
         execute: () => window.location.reload(),
@@ -1814,7 +1829,7 @@ export default function App() {
           <ReviewCodeView
             activeSearchMatch={activeDiffSearchMatch}
             collapsed={collapsed}
-            comments={reviewComments}
+            comments={visibleReviewComments}
             files={visibleFiles}
             focusCommentId={focusCommentId}
             focusCommentRequest={focusCommentRequest}

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -70,6 +70,7 @@ test('repository changes show the update banner without refreshing the working t
       copyCommentsOnClose: true,
       lastRepositoryPath: '/repo',
       openAIModel: defaultConfig.settings.openAIModel,
+      showOutdated: false,
       showWhitespace: false,
       theme: 'system' as const,
     })),
@@ -103,6 +104,7 @@ test('repository changes show the update banner without refreshing the working t
     }),
     openConfigFile: vi.fn(async () => {}),
     openFile: vi.fn(async () => {}),
+    setShowOutdated: vi.fn(async () => {}),
     showInFolder: vi.fn(async () => {}),
     submitPullRequestComment: vi.fn(async () => {
       throw new Error('Unexpected pull request comment submit.');

--- a/src/__tests__/git-state.test.ts
+++ b/src/__tests__/git-state.test.ts
@@ -22,6 +22,12 @@ type StatusEntry = {
 };
 
 type GitStateModule = {
+  collectResolvedReviewCommentIds: (
+    threads: ReadonlyArray<{
+      comments?: { nodes?: ReadonlyArray<{ databaseId?: number | null }> } | null;
+      isResolved?: boolean;
+    }>,
+  ) => Set<number>;
   createPullRequestHistoryFetchRefspecs: (
     pullRequest: { number: number; owner: string; repo: string; url: string },
     metadata: { base?: { ref?: string; sha?: string } },
@@ -59,11 +65,16 @@ type GitStateModule = {
   ) => Promise<{ root: string; signature: string }>;
   readRepositoryState: (launchPath: string, source?: ReviewSource) => Promise<RepositoryState>;
   readWorkingTreeState: (launchPath: string) => Promise<RepositoryState>;
+  selectUnresolvedReviewComments: (
+    comments: ReadonlyArray<Record<string, unknown>>,
+    resolvedCommentIds: ReadonlySet<number>,
+  ) => Array<Record<string, unknown>>;
 };
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
 const {
+  collectResolvedReviewCommentIds,
   createPullRequestHistoryFetchRefspecs,
   getPullRequestHeadImageSource,
   listRepositoryHistory,
@@ -76,6 +87,7 @@ const {
   readRepositoryChangeSignature,
   readRepositoryState,
   readWorkingTreeState,
+  selectUnresolvedReviewComments,
 } = require('../../electron/git-state.cjs') as GitStateModule;
 
 const git = async (repo: string, args: ReadonlyArray<string>) => {
@@ -231,6 +243,117 @@ test('normalizeGitHubReviewComment preserves multi-line ranges', () => {
     side: 'additions',
     startLineNumber: 5,
   });
+});
+
+test('normalizeGitHubReviewComment flags comments anchored to outdated lines', () => {
+  expect(
+    normalizeGitHubReviewComment({
+      body: 'This moved.',
+      created_at: '2026-05-19T00:00:00Z',
+      html_url: 'https://github.com/nkzw-tech/codiff/pull/1#discussion_r7',
+      id: 7,
+      line: null,
+      original_line: 12,
+      path: 'src/file.ts',
+      side: 'RIGHT',
+      user: {
+        login: 'reviewer',
+      },
+    }),
+  ).toMatchObject({
+    body: 'This moved.',
+    isOutdated: true,
+    lineNumber: 12,
+  });
+});
+
+test('normalizeGitHubReviewComment leaves current comments unflagged', () => {
+  const comment = normalizeGitHubReviewComment({
+    body: 'Still current.',
+    created_at: '2026-05-19T00:00:00Z',
+    html_url: 'https://github.com/nkzw-tech/codiff/pull/1#discussion_r8',
+    id: 8,
+    line: 20,
+    path: 'src/file.ts',
+    side: 'RIGHT',
+    user: {
+      login: 'reviewer',
+    },
+  });
+
+  expect(comment).toMatchObject({ lineNumber: 20 });
+  expect(comment).not.toHaveProperty('isOutdated');
+});
+
+test('collectResolvedReviewCommentIds gathers comment ids from resolved threads only', () => {
+  expect(
+    collectResolvedReviewCommentIds([
+      {
+        comments: { nodes: [{ databaseId: 1 }, { databaseId: 2 }] },
+        isResolved: true,
+      },
+      {
+        comments: { nodes: [{ databaseId: 3 }] },
+        isResolved: false,
+      },
+      {
+        comments: { nodes: [{ databaseId: 4 }, { databaseId: null }] },
+        isResolved: true,
+      },
+    ]),
+  ).toEqual(new Set([1, 2, 4]));
+});
+
+test('collectResolvedReviewCommentIds tolerates missing thread and comment data', () => {
+  expect(
+    collectResolvedReviewCommentIds([
+      { isResolved: true },
+      { comments: null, isResolved: true },
+      { comments: { nodes: undefined }, isResolved: true },
+    ]),
+  ).toEqual(new Set());
+});
+
+test('selectUnresolvedReviewComments drops comments that belong to resolved threads', () => {
+  const comments = [
+    {
+      body: 'This is resolved already.',
+      id: 1,
+      line: 5,
+      path: 'src/a.ts',
+      side: 'RIGHT',
+      user: { login: 'reviewer' },
+    },
+    {
+      body: 'This still needs attention.',
+      id: 2,
+      line: 8,
+      path: 'src/b.ts',
+      side: 'RIGHT',
+      user: { login: 'reviewer' },
+    },
+  ];
+
+  const result = selectUnresolvedReviewComments(comments, new Set([1]));
+
+  expect(result).toHaveLength(1);
+  expect(result[0]).toMatchObject({
+    body: 'This still needs attention.',
+    filePath: 'src/b.ts',
+    id: 'github:2',
+  });
+});
+
+test('selectUnresolvedReviewComments keeps every comment when nothing is resolved', () => {
+  const comments = [
+    { body: 'One.', id: 10, line: 1, path: 'src/a.ts', side: 'RIGHT', user: { login: 'reviewer' } },
+    { body: 'Two.', id: 11, line: 2, path: 'src/a.ts', side: 'RIGHT', user: { login: 'reviewer' } },
+  ];
+
+  expect(selectUnresolvedReviewComments(comments, new Set()).map((comment) => comment.id)).toEqual([
+    'github:10',
+    'github:11',
+  ]);
 });
 
 test('normalizeGitHubPullRequestCommit reads GitHub PR commit metadata', () => {

--- a/src/__tests__/review-comments.test.ts
+++ b/src/__tests__/review-comments.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from 'vite-plus/test';
+import type { ReviewComment } from '../lib/app-types.ts';
+import { getReviewCommentsFromState, getVisibleReviewComments } from '../lib/review-comments.ts';
+import type { RepositoryState } from '../types.ts';
+
+const createReviewComment = (overrides: Partial<ReviewComment>): ReviewComment => ({
+  body: 'A comment.',
+  filePath: 'src/a.ts',
+  id: 'github:1',
+  lineNumber: 5,
+  sectionId: 'src/a.ts:pull-request:1',
+  side: 'additions',
+  ...overrides,
+});
+
+const createPullRequestState = (): RepositoryState => ({
+  branch: null,
+  files: [
+    {
+      fingerprint: 'fingerprint',
+      path: 'src/a.ts',
+      sections: [
+        {
+          binary: false,
+          id: 'src/a.ts:pull-request:1',
+          kind: 'pull-request',
+          patch: '',
+        },
+      ],
+      status: 'modified',
+    },
+  ],
+  generatedAt: 0,
+  launchPath: '/repo',
+  reviewComments: [
+    {
+      author: { login: 'reviewer' },
+      body: 'Outdated comment.',
+      filePath: 'src/a.ts',
+      id: 'github:1',
+      isOutdated: true,
+      lineNumber: 5,
+      side: 'additions',
+    },
+    {
+      author: { login: 'reviewer' },
+      body: 'Current comment.',
+      filePath: 'src/a.ts',
+      id: 'github:2',
+      lineNumber: 6,
+      side: 'additions',
+    },
+  ],
+  root: '/repo',
+  source: {
+    type: 'pull-request',
+    url: 'https://github.com/nkzw-tech/codiff/pull/1',
+  },
+});
+
+test('getReviewCommentsFromState carries the outdated flag through to review comments', () => {
+  const comments = getReviewCommentsFromState(createPullRequestState());
+
+  expect(comments).toHaveLength(2);
+  expect(comments.find((comment) => comment.id === 'github:1')?.isOutdated).toBe(true);
+  expect(comments.find((comment) => comment.id === 'github:2')?.isOutdated).toBeUndefined();
+});
+
+test('getVisibleReviewComments hides outdated comments unless they are shown', () => {
+  const comments = [
+    createReviewComment({ id: 'github:1', isOutdated: true }),
+    createReviewComment({ id: 'github:2' }),
+  ];
+
+  expect(getVisibleReviewComments(comments, false).map((comment) => comment.id)).toEqual([
+    'github:2',
+  ]);
+  expect(getVisibleReviewComments(comments, true).map((comment) => comment.id)).toEqual([
+    'github:1',
+    'github:2',
+  ]);
+});
+
+test('getVisibleReviewComments keeps user-authored comments that are never outdated', () => {
+  const comments = [createReviewComment({ id: 'draft', isReadOnly: false })];
+
+  expect(getVisibleReviewComments(comments, false)).toHaveLength(1);
+});

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -29,6 +29,11 @@
           "default": "gpt-5.3-codex-spark",
           "description": "The OpenAI model to use for review assistance and walkthroughs."
         },
+        "showOutdated": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show review comments anchored to outdated diff lines. Hidden by default, matching GitHub's review UI."
+        },
         "showWhitespace": {
           "type": "boolean",
           "default": false,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -4,6 +4,7 @@ export const defaultSettings: CodiffSettings = {
   copyCommentsOnClose: false,
   lastRepositoryPath: '',
   openAIModel: 'gpt-5.3-codex-spark',
+  showOutdated: false,
   showWhitespace: false,
   theme: 'system',
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -4,6 +4,7 @@ export type CodiffSettings = {
   copyCommentsOnClose: boolean;
   lastRepositoryPath: string;
   openAIModel: string;
+  showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -40,6 +40,7 @@ declare global {
       onRepositoryChanged: (callback: (change: { root: string }) => void) => () => void;
       openConfigFile: () => Promise<void>;
       openFile: (path: string) => Promise<void>;
+      setShowOutdated: (value: boolean) => Promise<void>;
       showInFolder: (path: string) => Promise<void>;
       submitPullRequestComment: (
         request: SubmitPullRequestCommentRequest,

--- a/src/lib/app-constants.ts
+++ b/src/lib/app-constants.ts
@@ -17,6 +17,7 @@ export const defaultPreferences: CodiffPreferences = {
   copyCommentsOnClose: false,
   lastRepositoryPath: '',
   openAIModel: 'gpt-5.3-codex-spark',
+  showOutdated: false,
   showWhitespace: false,
   theme: 'system',
 };

--- a/src/lib/app-types.ts
+++ b/src/lib/app-types.ts
@@ -72,6 +72,7 @@ export type ReviewComment = {
     status: 'error' | 'submitting';
   };
   id: string;
+  isOutdated?: boolean;
   isReadOnly?: boolean;
   lineNumber: number;
   sectionId: string;

--- a/src/lib/review-comments.ts
+++ b/src/lib/review-comments.ts
@@ -274,6 +274,7 @@ export const getReviewCommentsFromState = (state: RepositoryState): ReadonlyArra
                 body: comment.body,
                 filePath: comment.filePath,
                 id: comment.id,
+                ...(comment.isOutdated ? { isOutdated: true } : {}),
                 isReadOnly: true,
                 lineNumber: comment.lineNumber,
                 sectionId: section.id,
@@ -286,6 +287,12 @@ export const getReviewCommentsFromState = (state: RepositoryState): ReadonlyArra
           : [];
       })
     : [];
+
+export const getVisibleReviewComments = (
+  comments: ReadonlyArray<ReviewComment>,
+  showOutdated: boolean,
+): ReadonlyArray<ReviewComment> =>
+  showOutdated ? comments : comments.filter((comment) => !comment.isOutdated);
 
 export const shouldDiscardReviewCommentOnEscape = (
   body: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,6 +198,7 @@ export type CodiffPreferences = {
   copyCommentsOnClose: boolean;
   lastRepositoryPath: string;
   openAIModel: string;
+  showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
 };
@@ -218,6 +219,7 @@ export type PullRequestExistingReviewComment = PullRequestReviewComment & {
     url?: string;
   };
   id: string;
+  isOutdated?: boolean;
   submittedAt?: string;
   url?: string;
 };


### PR DESCRIPTION
On an active PR it's common for review threads to be resolved or anchored to lines that have since changed. GitHub's review UI tucks both away, and this implements the same filtering for codiff.

Resolved threads are filtered out entirely. Outdated comments are hidden by default behind a persisted "show outdated" setting, toggled from the View menu and the "Toggle Outdated Comments" command.

Implements #30