### PR TITLE
Add unified diff layout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The command bar includes actions for common review workflows:
 - Copy Review Comments
 - Copy Review Comments and Close
 - Toggle Viewed for the currently selected file
+- Toggle Diff Layout, with the target layout action shown as the hint
 - Open the currently selected file in your editor
 - Toggle Sidebar
 - Reload Window
@@ -86,6 +87,7 @@ is running so changes apply to open windows.
   "$schema": "https://raw.githubusercontent.com/nkzw-tech/codiff/main/src/config/codiff-config.schema.json",
   "settings": {
     "copyCommentsOnClose": false,
+    "diffStyle": "split",
     "lastRepositoryPath": "",
     "openAIModel": "gpt-5.3-codex-spark",
     "showWhitespace": false,
@@ -105,6 +107,8 @@ is running so changes apply to open windows.
 }
 ```
 
+Choose `View > Split Diff` or `View > Unified Diff`, use Toggle Diff Layout in the command bar,
+or set `settings.diffStyle` to `split` for side-by-side diffs or `unified` for unified diffs.
 Use `Mod` for <kbd>Cmd</kbd> on macOS and <kbd>Ctrl</kbd> on other platforms. Shortcut strings can
 combine `Mod`, `Ctrl`, `Alt`, `Shift`, or `Meta` with a key, for example `Mod+Shift+p` or
 `Alt+Enter`.

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -13,6 +13,7 @@ const { join } = require('node:path');
 
 /**
  * @typedef {import('../src/config/types.ts').CodiffConfig} CodiffConfig
+ * @typedef {import('../src/config/types.ts').CodiffDiffStyle} CodiffDiffStyle
  * @typedef {import('../src/config/types.ts').CodiffKeymap} CodiffKeymap
  * @typedef {import('../src/config/types.ts').CodiffSettings} CodiffSettings
  * @typedef {import('../src/config/types.ts').CodiffTheme} CodiffTheme
@@ -25,6 +26,7 @@ const SCHEMA_URL =
 /** @type {CodiffSettings} */
 const defaultSettings = {
   copyCommentsOnClose: false,
+  diffStyle: 'split',
   lastRepositoryPath: '',
   openAIModel: 'gpt-5.3-codex-spark',
   showOutdated: false,
@@ -130,6 +132,10 @@ const parseJsonc = (text) => JSON.parse(stripTrailingCommas(stripJsoncComments(t
 const normalizeTheme = (theme) =>
   theme === 'system' || theme === 'light' || theme === 'dark' ? theme : 'system';
 
+/** @param {unknown} diffStyle @returns {CodiffDiffStyle} */
+const normalizeDiffStyle = (diffStyle) =>
+  diffStyle === 'split' || diffStyle === 'unified' ? diffStyle : 'split';
+
 /** @param {unknown} path */
 const normalizeLastRepositoryPath = (path) =>
   typeof path === 'string' && path.length > 0 ? path : '';
@@ -192,6 +198,7 @@ const mergeConfig = (raw) => {
         typeof rawSettings.copyCommentsOnClose === 'boolean'
           ? rawSettings.copyCommentsOnClose
           : defaultSettings.copyCommentsOnClose,
+      diffStyle: normalizeDiffStyle(rawSettings.diffStyle),
       lastRepositoryPath: normalizeLastRepositoryPath(rawSettings.lastRepositoryPath),
       openAIModel:
         typeof rawSettings.openAIModel === 'string'
@@ -350,6 +357,7 @@ const watchConfig = (onChange) => {
  */
 const configToPreferences = (config) => ({
   copyCommentsOnClose: config.settings.copyCommentsOnClose,
+  diffStyle: config.settings.diffStyle,
   lastRepositoryPath: config.settings.lastRepositoryPath,
   openAIModel: config.settings.openAIModel,
   showOutdated: config.settings.showOutdated,

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -401,6 +401,27 @@ const buildApplicationMenu = () =>
         label: 'View',
         submenu: [
           {
+            checked: config.settings.diffStyle === 'split',
+            click: () => {
+              updateConfig({
+                settings: { ...config.settings, diffStyle: 'split' },
+              });
+            },
+            label: 'Split Diff',
+            type: 'radio',
+          },
+          {
+            checked: config.settings.diffStyle === 'unified',
+            click: () => {
+              updateConfig({
+                settings: { ...config.settings, diffStyle: 'unified' },
+              });
+            },
+            label: 'Unified Diff',
+            type: 'radio',
+          },
+          { type: 'separator' },
+          {
             checked: config.settings.showWhitespace,
             click: (menuItem) => {
               updateConfig({
@@ -813,6 +834,15 @@ ipcMain.handle('codiff:getGitIdentity', async (event) => {
 ipcMain.handle('codiff:getPreferences', () => configToPreferences(config));
 
 ipcMain.handle('codiff:getConfig', () => config);
+
+ipcMain.handle('codiff:setDiffStyle', (_event, value) => {
+  updateConfig({
+    settings: {
+      ...config.settings,
+      diffStyle: value === 'unified' ? 'unified' : 'split',
+    },
+  });
+});
 
 ipcMain.handle('codiff:setShowOutdated', (_event, value) => {
   updateConfig({ settings: { ...config.settings, showOutdated: Boolean(value) } });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -57,6 +57,7 @@ const codiff = {
   },
   openConfigFile: () => ipcRenderer.invoke('codiff:openConfigFile'),
   openFile: (path) => ipcRenderer.invoke('codiff:openFile', path),
+  setDiffStyle: (value) => ipcRenderer.invoke('codiff:setDiffStyle', value),
   setShowOutdated: (value) => ipcRenderer.invoke('codiff:setShowOutdated', value),
   showInFolder: (path) => ipcRenderer.invoke('codiff:showInFolder', path),
   submitPullRequestComment: (request) =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -578,6 +578,7 @@ export default function App() {
         setCodiffConfig(nextConfig);
         setPreferences({
           copyCommentsOnClose: nextConfig.settings.copyCommentsOnClose,
+          diffStyle: nextConfig.settings.diffStyle,
           lastRepositoryPath: nextConfig.settings.lastRepositoryPath,
           openAIModel: nextConfig.settings.openAIModel,
           showOutdated: nextConfig.settings.showOutdated,
@@ -591,6 +592,7 @@ export default function App() {
       setCodiffConfig(nextConfig);
       setPreferences({
         copyCommentsOnClose: nextConfig.settings.copyCommentsOnClose,
+        diffStyle: nextConfig.settings.diffStyle,
         lastRepositoryPath: nextConfig.settings.lastRepositoryPath,
         openAIModel: nextConfig.settings.openAIModel,
         showOutdated: nextConfig.settings.showOutdated,
@@ -677,6 +679,7 @@ export default function App() {
 
   const showWhitespace = preferences.showWhitespace;
   const showOutdated = preferences.showOutdated;
+  const diffStyle = preferences.diffStyle;
   const visibleReviewComments = useMemo(
     () => getVisibleReviewComments(reviewComments, showOutdated),
     [reviewComments, showOutdated],
@@ -1217,6 +1220,16 @@ export default function App() {
         },
         id: 'toggle-outdated-comments',
         title: 'Toggle Outdated Comments',
+      }),
+      registry.register({
+        description: () =>
+          preferencesRef.current.diffStyle === 'split' ? 'Switch to Unified' : 'Switch to Split',
+        execute: () => {
+          const nextDiffStyle = preferencesRef.current.diffStyle === 'split' ? 'unified' : 'split';
+          void window.codiff.setDiffStyle(nextDiffStyle).catch(() => {});
+        },
+        id: 'toggle-diff-layout',
+        title: 'Toggle Diff Layout',
       }),
       registry.register({
         execute: () => window.location.reload(),
@@ -1850,6 +1863,7 @@ export default function App() {
             activeSearchMatch={activeDiffSearchMatch}
             collapsed={collapsed}
             comments={visibleReviewComments}
+            diffStyle={diffStyle}
             files={visibleFiles}
             focusCommentId={focusCommentId}
             focusCommentRequest={focusCommentRequest}

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -89,6 +89,7 @@ test('repository changes show the update banner without refreshing the working t
     })),
     getPreferences: vi.fn(async () => ({
       copyCommentsOnClose: true,
+      diffStyle: 'split' as const,
       lastRepositoryPath: '/repo',
       openAIModel: defaultConfig.settings.openAIModel,
       showOutdated: false,
@@ -129,6 +130,7 @@ test('repository changes show the update banner without refreshing the working t
     }),
     openConfigFile: vi.fn(async () => {}),
     openFile: vi.fn(async () => {}),
+    setDiffStyle: vi.fn(async () => {}),
     setShowOutdated: vi.fn(async () => {}),
     showInFolder: vi.fn(async () => {}),
     submitPullRequestComment: vi.fn(async () => {
@@ -216,6 +218,7 @@ test('walkthrough launch errors stay on the walkthrough tab without automatic re
     })),
     getPreferences: vi.fn(async () => ({
       copyCommentsOnClose: true,
+      diffStyle: 'split' as const,
       lastRepositoryPath: '/repo',
       openAIModel: defaultConfig.settings.openAIModel,
       showOutdated: false,
@@ -251,6 +254,7 @@ test('walkthrough launch errors stay on the walkthrough tab without automatic re
     onRepositoryChanged: vi.fn(() => () => {}),
     openConfigFile: vi.fn(async () => {}),
     openFile: vi.fn(async () => {}),
+    setDiffStyle: vi.fn(async () => {}),
     setShowOutdated: vi.fn(async () => {}),
     showInFolder: vi.fn(async () => {}),
     submitPullRequestComment: vi.fn(async () => {

--- a/src/app/components/ReviewCodeView.tsx
+++ b/src/app/components/ReviewCodeView.tsx
@@ -29,7 +29,7 @@ import {
 } from 'react';
 import codexIconUrl from '../../assets/codex.svg';
 import { matchesShortcut } from '../../config/keymap.ts';
-import type { CodiffKeymap } from '../../config/types.ts';
+import type { CodiffDiffStyle, CodiffKeymap } from '../../config/types.ts';
 import type {
   CodeViewInstance,
   CodeViewItemMetadata,
@@ -763,6 +763,7 @@ export function ReviewCodeView({
   activeSearchMatch,
   collapsed,
   comments,
+  diffStyle,
   files,
   focusCommentId,
   focusCommentRequest,
@@ -791,6 +792,7 @@ export function ReviewCodeView({
   activeSearchMatch: DiffSearchMatch | null;
   collapsed: ReadonlySet<string>;
   comments: ReadonlyArray<ReviewComment>;
+  diffStyle: CodiffDiffStyle;
   files: ReadonlyArray<ChangedFile>;
   focusCommentId: string | null;
   focusCommentRequest: number;
@@ -1000,7 +1002,7 @@ export function ReviewCodeView({
               selectedPath === file.path ? 'selected' : 'idle'
             }:${walkthroughNotes.get(file.path)?.reason ?? ''}:${
               showWhitespace ? 'ws' : 'ignore-ws'
-            }:${getReviewCommentsDigest(commentsBySection.get(section.id) ?? [])}`,
+            }:${diffStyle}:${getReviewCommentsDigest(commentsBySection.get(section.id) ?? [])}`,
           ),
         });
       }
@@ -1014,6 +1016,7 @@ export function ReviewCodeView({
   }, [
     collapsed,
     commentsBySection,
+    diffStyle,
     files,
     forceExpandedPaths,
     imagePreviewLayoutPassBySection,
@@ -1064,7 +1067,7 @@ export function ReviewCodeView({
       const startSide = range.side ?? range.endSide ?? 'additions';
       const endSide = range.endSide ?? startSide;
       if (startSide !== endSide) {
-        window.alert('Review comments cannot span both sides of a split diff.');
+        window.alert('Review comments cannot span added and deleted lines.');
         return;
       }
 
@@ -1093,7 +1096,7 @@ export function ReviewCodeView({
       ({
         collapsedContextThreshold: diffCollapsedContextThreshold,
         diffIndicators: 'bars',
-        diffStyle: 'split',
+        diffStyle,
         enableGutterUtility: true,
         enableLineSelection: true,
         expandUnchanged: false,
@@ -1162,7 +1165,13 @@ export function ReviewCodeView({
         tokenizeMaxLength: 100_000,
         unsafeCSS: codeViewUnsafeCSS,
       }) satisfies CodeViewOptions<ReviewAnnotationMetadata>,
-    [cancelPendingEmptyCommentDeletes, createCommentForRange, itemMetadata, onCreateComment],
+    [
+      cancelPendingEmptyCommentDeletes,
+      createCommentForRange,
+      diffStyle,
+      itemMetadata,
+      onCreateComment,
+    ],
   );
 
   const focusComment = useCallback((comment: ReviewComment) => {

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -19,6 +19,12 @@
           "default": false,
           "description": "Copy pending review comments to clipboard when closing a window."
         },
+        "diffStyle": {
+          "type": "string",
+          "enum": ["split", "unified"],
+          "default": "split",
+          "description": "Diff layout style. 'split' shows deleted and added lines side by side; 'unified' shows them in one column."
+        },
         "lastRepositoryPath": {
           "type": "string",
           "default": "",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -2,6 +2,7 @@ import type { CodiffConfig, CodiffKeymap, CodiffSettings } from './types.ts';
 
 export const defaultSettings: CodiffSettings = {
   copyCommentsOnClose: false,
+  diffStyle: 'split',
   lastRepositoryPath: '',
   openAIModel: 'gpt-5.3-codex-spark',
   showOutdated: false,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,7 +1,9 @@
+export type CodiffDiffStyle = 'split' | 'unified';
 export type CodiffTheme = 'system' | 'light' | 'dark';
 
 export type CodiffSettings = {
   copyCommentsOnClose: boolean;
+  diffStyle: CodiffDiffStyle;
   lastRepositoryPath: string;
   openAIModel: string;
   showOutdated: boolean;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -43,6 +43,7 @@ declare global {
       onRepositoryChanged: (callback: (change: { root: string }) => void) => () => void;
       openConfigFile: () => Promise<void>;
       openFile: (path: string) => Promise<void>;
+      setDiffStyle: (value: CodiffPreferences['diffStyle']) => Promise<void>;
       setShowOutdated: (value: boolean) => Promise<void>;
       showInFolder: (path: string) => Promise<void>;
       submitPullRequestComment: (

--- a/src/lib/app-constants.ts
+++ b/src/lib/app-constants.ts
@@ -25,6 +25,7 @@ export const defaultTerminalHelperStatus: TerminalHelperStatus = {
 
 export const defaultPreferences: CodiffPreferences = {
   copyCommentsOnClose: false,
+  diffStyle: 'split',
   lastRepositoryPath: '',
   openAIModel: 'gpt-5.3-codex-spark',
   showOutdated: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { CodiffDiffStyle } from './config/types.ts';
+
 export type DiffSection = {
   binary: boolean;
   id: string;
@@ -227,6 +229,7 @@ export type CodiffTheme = 'system' | 'light' | 'dark';
 
 export type CodiffPreferences = {
   copyCommentsOnClose: boolean;
+  diffStyle: CodiffDiffStyle;
   lastRepositoryPath: string;
   openAIModel: string;
   showOutdated: boolean;


### PR DESCRIPTION
## Summary

Adds a diff layout setting so users can switch between split and unified diffs.

Users can change the layout from:
- View menu
- command bar: Toggle Diff Layout
- config: `settings.diffStyle`

The command bar action shows the target layout, for example `Switch to Unified`.

## Verification

- `vp check --fix`
- `vp build`
- `vp run --no-cache test:all`
