### PR TITLE
Fallback when avatar images fail to load

### DIFF
--- a/src/__tests__/Gravatar.test.tsx
+++ b/src/__tests__/Gravatar.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { expect, test } from 'vite-plus/test';
+import { Gravatar } from '../app/components/Gravatar.tsx';
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+
+test('Gravatar falls back to the initial when the image fails to load', async () => {
+  const container = document.createElement('div');
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Gravatar fallback="Reviewer" size="medium" url="https://example.com/avatar" />);
+    });
+
+    const image = container.querySelector('img');
+    expect(image?.getAttribute('src')).toBe('https://example.com/avatar');
+
+    await act(async () => {
+      image?.dispatchEvent(new Event('error', { bubbles: true }));
+    });
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toBe('R');
+  } finally {
+    await act(async () => root?.unmount());
+  }
+});
+
+test('Gravatar retries rendering when the avatar URL changes', async () => {
+  const container = document.createElement('div');
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Gravatar fallback="Reviewer" size="medium" url="https://example.com/first" />);
+    });
+
+    await act(async () => {
+      container.querySelector('img')?.dispatchEvent(new Event('error', { bubbles: true }));
+    });
+
+    expect(container.textContent).toBe('R');
+
+    await act(async () => {
+      root?.render(<Gravatar fallback="Reviewer" size="medium" url="https://example.com/second" />);
+    });
+
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('https://example.com/second');
+  } finally {
+    await act(async () => root?.unmount());
+  }
+});

--- a/src/app/components/Gravatar.tsx
+++ b/src/app/components/Gravatar.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 function Gravatar({
   fallback,
   size,
@@ -8,9 +10,17 @@ function Gravatar({
   url?: string;
 }) {
   const className = `gravatar ${size}`;
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+  const showImage = url && failedUrl !== url;
 
-  return url ? (
-    <img alt="" className={className} draggable={false} src={url} />
+  return showImage ? (
+    <img
+      alt=""
+      className={className}
+      draggable={false}
+      onError={() => setFailedUrl(url)}
+      src={url}
+    />
   ) : (
     <span aria-hidden className={`${className} fallback`}>
       {fallback.trim()[0]?.toUpperCase() ?? '?'}


### PR DESCRIPTION
## Summary

Adds a fallback for broken avatar images.

If a Gravatar or GitHub avatar URL fails to load, Codiff now shows the existing initial fallback instead of a broken image icon.

## Verification

- `vp check --fix`
- `vp build`
- `vp run --no-cache test:all`
