### PR TITLE
Center macOS traffic lights in the sidebar header

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -526,7 +526,7 @@ const createWindow = (
     show: false,
     title: `Codiff - ${repositoryPath}`,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
-    ...(process.platform === 'darwin' ? { trafficLightPosition: { x: 25, y: 24 } } : {}),
+    ...(process.platform === 'darwin' ? { trafficLightPosition: { x: 25, y: 22 } } : {}),
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,


### PR DESCRIPTION
## Summary

Adjust the macOS `trafficLightPosition` so the native close/minimize/zoom
controls sit vertically centered in the sidebar header. (sorry lol)

## Testing

- `vp check --fix`
- `vp build`
