### PR TITLE
Add word wrap setting for diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ is running so changes apply to open windows.
     "openAIModel": "gpt-5.3-codex-spark",
     "showWhitespace": false,
     "theme": "system",
+    "wordWrap": false,
   },
   "keymap": {
     "commandBar": "Mod+Shift+p",
@@ -109,6 +110,8 @@ is running so changes apply to open windows.
 
 Choose `View > Split Diff` or `View > Unified Diff`, use Toggle Diff Layout in the command bar,
 or set `settings.diffStyle` to `split` for side-by-side diffs or `unified` for unified diffs.
+Choose `View > Word Wrap`, use Toggle Word Wrap in the command bar, or set `settings.wordWrap`
+to `true` to wrap long diff lines.
 Use `Mod` for <kbd>Cmd</kbd> on macOS and <kbd>Ctrl</kbd> on other platforms. Shortcut strings can
 combine `Mod`, `Ctrl`, `Alt`, `Shift`, or `Meta` with a key, for example `Mod+Shift+p` or
 `Alt+Enter`.

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -32,6 +32,7 @@ const defaultSettings = {
   showOutdated: false,
   showWhitespace: false,
   theme: 'system',
+  wordWrap: false,
 };
 
 /** @type {CodiffKeymap} */
@@ -213,6 +214,8 @@ const mergeConfig = (raw) => {
           ? rawSettings.showWhitespace
           : defaultSettings.showWhitespace,
       theme: normalizeTheme(rawSettings.theme),
+      wordWrap:
+        typeof rawSettings.wordWrap === 'boolean' ? rawSettings.wordWrap : defaultSettings.wordWrap,
     },
   };
 };
@@ -356,13 +359,7 @@ const watchConfig = (onChange) => {
  * @returns {CodiffPreferences}
  */
 const configToPreferences = (config) => ({
-  copyCommentsOnClose: config.settings.copyCommentsOnClose,
-  diffStyle: config.settings.diffStyle,
-  lastRepositoryPath: config.settings.lastRepositoryPath,
-  openAIModel: config.settings.openAIModel,
-  showOutdated: config.settings.showOutdated,
-  showWhitespace: config.settings.showWhitespace,
-  theme: config.settings.theme,
+  ...config.settings,
 });
 
 module.exports = {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -422,6 +422,16 @@ const buildApplicationMenu = () =>
           },
           { type: 'separator' },
           {
+            checked: config.settings.wordWrap,
+            click: (menuItem) => {
+              updateConfig({
+                settings: { ...config.settings, wordWrap: menuItem.checked },
+              });
+            },
+            label: 'Word Wrap',
+            type: 'checkbox',
+          },
+          {
             checked: config.settings.showWhitespace,
             click: (menuItem) => {
               updateConfig({
@@ -846,6 +856,10 @@ ipcMain.handle('codiff:setDiffStyle', (_event, value) => {
 
 ipcMain.handle('codiff:setShowOutdated', (_event, value) => {
   updateConfig({ settings: { ...config.settings, showOutdated: Boolean(value) } });
+});
+
+ipcMain.handle('codiff:setWordWrap', (_event, value) => {
+  updateConfig({ settings: { ...config.settings, wordWrap: Boolean(value) } });
 });
 
 ipcMain.handle('codiff:openConfigFile', () => openConfigFile());

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -59,6 +59,7 @@ const codiff = {
   openFile: (path) => ipcRenderer.invoke('codiff:openFile', path),
   setDiffStyle: (value) => ipcRenderer.invoke('codiff:setDiffStyle', value),
   setShowOutdated: (value) => ipcRenderer.invoke('codiff:setShowOutdated', value),
+  setWordWrap: (value) => ipcRenderer.invoke('codiff:setWordWrap', value),
   showInFolder: (path) => ipcRenderer.invoke('codiff:showInFolder', path),
   submitPullRequestComment: (request) =>
     ipcRenderer.invoke('codiff:submitPullRequestComment', request),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,10 @@ const getFailedSectionLoadState = (section: DiffSection): DiffSection =>
         },
       };
 
+const getPreferencesFromConfig = ({ settings }: CodiffConfig): CodiffPreferences => ({
+  ...settings,
+});
+
 export default function App() {
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
   const [activeDiffSearchMatchIndex, setActiveDiffSearchMatchIndex] = useState(0);
@@ -591,29 +595,13 @@ export default function App() {
     window.codiff.getConfig().then((nextConfig) => {
       if (!canceled) {
         setCodiffConfig(nextConfig);
-        setPreferences({
-          copyCommentsOnClose: nextConfig.settings.copyCommentsOnClose,
-          diffStyle: nextConfig.settings.diffStyle,
-          lastRepositoryPath: nextConfig.settings.lastRepositoryPath,
-          openAIModel: nextConfig.settings.openAIModel,
-          showOutdated: nextConfig.settings.showOutdated,
-          showWhitespace: nextConfig.settings.showWhitespace,
-          theme: nextConfig.settings.theme,
-        });
+        setPreferences(getPreferencesFromConfig(nextConfig));
       }
     });
 
     const removeConfigListener = window.codiff.onConfigChanged((nextConfig) => {
       setCodiffConfig(nextConfig);
-      setPreferences({
-        copyCommentsOnClose: nextConfig.settings.copyCommentsOnClose,
-        diffStyle: nextConfig.settings.diffStyle,
-        lastRepositoryPath: nextConfig.settings.lastRepositoryPath,
-        openAIModel: nextConfig.settings.openAIModel,
-        showOutdated: nextConfig.settings.showOutdated,
-        showWhitespace: nextConfig.settings.showWhitespace,
-        theme: nextConfig.settings.theme,
-      });
+      setPreferences(getPreferencesFromConfig(nextConfig));
     });
 
     return () => {
@@ -695,6 +683,7 @@ export default function App() {
   const showWhitespace = preferences.showWhitespace;
   const showOutdated = preferences.showOutdated;
   const diffStyle = preferences.diffStyle;
+  const wordWrap = preferences.wordWrap;
   const visibleReviewComments = useMemo(
     () => getVisibleReviewComments(reviewComments, showOutdated),
     [reviewComments, showOutdated],
@@ -1248,6 +1237,15 @@ export default function App() {
         },
         id: 'toggle-diff-layout',
         title: 'Toggle Diff Layout',
+      }),
+      registry.register({
+        description: () =>
+          preferencesRef.current.wordWrap ? 'Disable Word Wrap' : 'Enable Word Wrap',
+        execute: () => {
+          void window.codiff.setWordWrap(!preferencesRef.current.wordWrap).catch(() => {});
+        },
+        id: 'toggle-word-wrap',
+        title: 'Toggle Word Wrap',
       }),
       registry.register({
         execute: () => window.location.reload(),
@@ -1917,6 +1915,7 @@ export default function App() {
             walkthroughNotes={
               sidebarMode === 'walkthrough' ? walkthroughNotes : emptyWalkthroughNotes
             }
+            wordWrap={wordWrap}
           />
         )}
       </main>

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -88,13 +88,9 @@ test('repository changes show the update banner without refreshing the working t
       walkthrough: false,
     })),
     getPreferences: vi.fn(async () => ({
+      ...defaultConfig.settings,
       copyCommentsOnClose: true,
-      diffStyle: 'split' as const,
       lastRepositoryPath: '/repo',
-      openAIModel: defaultConfig.settings.openAIModel,
-      showOutdated: false,
-      showWhitespace: false,
-      theme: 'system' as const,
     })),
     getRepositoryHistory: vi.fn(async () => ({
       entries: [],
@@ -132,6 +128,7 @@ test('repository changes show the update banner without refreshing the working t
     openFile: vi.fn(async () => {}),
     setDiffStyle: vi.fn(async () => {}),
     setShowOutdated: vi.fn(async () => {}),
+    setWordWrap: vi.fn(async () => {}),
     showInFolder: vi.fn(async () => {}),
     submitPullRequestComment: vi.fn(async () => {
       throw new Error('Unexpected pull request comment submit.');
@@ -217,13 +214,9 @@ test('walkthrough launch errors stay on the walkthrough tab without automatic re
       walkthrough: true,
     })),
     getPreferences: vi.fn(async () => ({
+      ...defaultConfig.settings,
       copyCommentsOnClose: true,
-      diffStyle: 'split' as const,
       lastRepositoryPath: '/repo',
-      openAIModel: defaultConfig.settings.openAIModel,
-      showOutdated: false,
-      showWhitespace: false,
-      theme: 'system' as const,
     })),
     getRepositoryHistory: vi.fn(async () => ({
       entries: [],
@@ -256,6 +249,7 @@ test('walkthrough launch errors stay on the walkthrough tab without automatic re
     openFile: vi.fn(async () => {}),
     setDiffStyle: vi.fn(async () => {}),
     setShowOutdated: vi.fn(async () => {}),
+    setWordWrap: vi.fn(async () => {}),
     showInFolder: vi.fn(async () => {}),
     submitPullRequestComment: vi.fn(async () => {
       throw new Error('Unexpected pull request comment submit.');

--- a/src/app/components/ReviewCodeView.tsx
+++ b/src/app/components/ReviewCodeView.tsx
@@ -807,6 +807,7 @@ export function ReviewCodeView({
   source,
   viewed,
   walkthroughNotes,
+  wordWrap,
 }: {
   activeSearchMatch: DiffSearchMatch | null;
   collapsed: ReadonlySet<string>;
@@ -838,6 +839,7 @@ export function ReviewCodeView({
   source: ReviewSource;
   viewed: Record<string, string>;
   walkthroughNotes: ReadonlyMap<string, WalkthroughNote>;
+  wordWrap: boolean;
 }) {
   const codeViewRef = useRef<CodeViewHandle<ReviewAnnotationMetadata>>(null);
   const deferredTimersRef = useRef<Set<number>>(new Set());
@@ -1194,6 +1196,7 @@ export function ReviewCodeView({
             Boolean(metadata && loadingSectionIds.has(metadata.section.id)),
           );
         },
+        overflow: wordWrap ? 'wrap' : 'scroll',
         stickyHeaders: true,
         theme: {
           dark: 'Dunkel',
@@ -1211,6 +1214,7 @@ export function ReviewCodeView({
       loadingSectionIds,
       onCreateComment,
       onLoadSection,
+      wordWrap,
     ],
   );
 

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -50,6 +50,11 @@
           "enum": ["system", "light", "dark"],
           "default": "system",
           "description": "Application color theme. 'system' follows OS preference."
+        },
+        "wordWrap": {
+          "type": "boolean",
+          "default": false,
+          "description": "Wrap long diff lines instead of using horizontal scrolling."
         }
       }
     },

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -8,6 +8,7 @@ export const defaultSettings: CodiffSettings = {
   showOutdated: false,
   showWhitespace: false,
   theme: 'system',
+  wordWrap: false,
 };
 
 export const defaultKeymap: CodiffKeymap = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -9,6 +9,7 @@ export type CodiffSettings = {
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
+  wordWrap: boolean;
 };
 
 export type KeyCombo = string;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -45,6 +45,7 @@ declare global {
       openFile: (path: string) => Promise<void>;
       setDiffStyle: (value: CodiffPreferences['diffStyle']) => Promise<void>;
       setShowOutdated: (value: boolean) => Promise<void>;
+      setWordWrap: (value: boolean) => Promise<void>;
       showInFolder: (path: string) => Promise<void>;
       submitPullRequestComment: (
         request: SubmitPullRequestCommentRequest,

--- a/src/lib/app-constants.ts
+++ b/src/lib/app-constants.ts
@@ -31,4 +31,5 @@ export const defaultPreferences: CodiffPreferences = {
   showOutdated: false,
   showWhitespace: false,
   theme: 'system',
+  wordWrap: false,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,6 +239,7 @@ export type CodiffPreferences = {
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
+  wordWrap: boolean;
 };
 
 export type PullRequestReviewComment = {


### PR DESCRIPTION
Adds a word wrap setting for the diff view.

This makes docs and other long lines easier to read without horizontal scrolling.

Users can toggle it from `View > Word Wrap`, use `Toggle Word Wrap` in the command bar, or set `settings.wordWrap` in `~/.codiff/codiff.jsonc`.

The setting is saved through the existing config flow and passed to the diff renderer as `overflow: 'wrap'` when enabled.

The renderer now derives preferences from the settings object directly instead of copying each setting field by hand.

Validation:
- `vp check --fix`
- `vp build`
