### PR TITLE
Expand unmodified context in pull request diffs

### DIFF
--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -11,6 +11,7 @@ const {
 const {
   collectResolvedReviewCommentIds,
   createPullRequestHistoryFetchRefspecs,
+  createPullRequestSection,
   getPullRequestHeadImageSource,
   listPullRequestHistory,
   normalizeGitHubPullRequestCommit,
@@ -19,6 +20,7 @@ const {
   parseGitHubPullRequestUrl,
   readPullRequestImageContent,
   readPullRequestState,
+  resolvePullRequestContentRefs,
   selectUnresolvedReviewComments,
   submitPullRequestComment,
   submitPullRequestReview,
@@ -79,6 +81,7 @@ const readDiffImageContent = (launchPath, request) =>
 module.exports = {
   collectResolvedReviewCommentIds,
   createPullRequestHistoryFetchRefspecs,
+  createPullRequestSection,
   getPullRequestHeadImageSource,
   listRepositoryHistory: readRepositoryHistory,
   normalizeGitHubPullRequestCommit,
@@ -96,6 +99,7 @@ module.exports = {
   readPullRequestState,
   readRepositoryState,
   readWorkingTreeState,
+  resolvePullRequestContentRefs,
   submitPullRequestComment,
   submitPullRequestReview,
   validateRepositoryPath,

--- a/electron/git-state/pull-request.cjs
+++ b/electron/git-state/pull-request.cjs
@@ -10,6 +10,8 @@ const {
   getImageMimeType,
   git,
   gitOrEmpty,
+  readGitFile,
+  summarizeContent,
   validateRepositoryPath,
 } = require('./common.cjs');
 
@@ -598,6 +600,152 @@ const createPullRequestSource = (pullRequest, metadata) => ({
   url: pullRequest.url,
 });
 
+/**
+ * Make sure the pull request head and base branch are available as local refs
+ * and resolve the two commits to diff against. GitHub computes the pull request
+ * diff against the merge base of the base branch and the head, so mirror that to
+ * keep line numbers and changes aligned with the GitHub review.
+ *
+ * Returns `null` when the full file contents cannot be resolved, in which case
+ * callers fall back to the GitHub-provided patch (which cannot expand
+ * unmodified context).
+ *
+ * @param {string} repoRoot
+ * @param {PullRequestReference} pullRequest
+ * @param {GitHubPullRequestMetadata} metadata
+ * @returns {Promise<{base: string; head: string} | null>}
+ */
+const resolvePullRequestContentRefs = async (repoRoot, pullRequest, metadata) => {
+  if (!metadata.base?.ref) {
+    return null;
+  }
+
+  const headRef = `refs/codiff/pull-requests/${pullRequest.number}/head`;
+  const baseRef = `refs/codiff/pull-requests/${pullRequest.number}/base`;
+  const headSha = metadata.head?.sha;
+  const baseSha = metadata.base?.sha;
+  const localHead = (
+    await gitOrEmpty(repoRoot, ['rev-parse', '--verify', '--quiet', headRef])
+  ).trim();
+  const localBase = (
+    await gitOrEmpty(repoRoot, ['rev-parse', '--verify', '--quiet', baseRef])
+  ).trim();
+
+  // Refetch when a ref is missing or has moved -- including when the base branch
+  // advanced or the pull request was retargeted (localBase !== base sha) -- so
+  // the merge base is always resolved against the current base and head rather
+  // than stale contents.
+  if (
+    localBase === '' ||
+    localHead === '' ||
+    (headSha != null && localHead !== headSha) ||
+    (baseSha != null && localBase !== baseSha)
+  ) {
+    try {
+      const remote = await selectPullRequestRemote(repoRoot, pullRequest);
+      await fetchPullRequestHistoryRefs(repoRoot, remote, pullRequest, metadata);
+    } catch {
+      return null;
+    }
+  }
+
+  const mergeBase = (await gitOrEmpty(repoRoot, ['merge-base', baseRef, headRef])).trim();
+  return mergeBase ? { base: mergeBase, head: headRef } : null;
+};
+
+/**
+ * git/GitHub emit `Binary files a/x and b/x differ` as a diff metadata line.
+ * Anchor to the start of a line so the same text appearing inside a patch's
+ * added/removed/context lines (which are prefixed with `+`/`-`/space) does not
+ * misclassify a text file as binary.
+ */
+const BINARY_DIFF_MARKER = /^Binary files .* differ/m;
+
+/**
+ * Build a diff section for a pull request file. When the full base and head
+ * contents are available the section carries `oldFile`/`newFile` so Codiff
+ * renders a recomputed diff with expandable unmodified context (matching commits
+ * and the working tree). Otherwise it falls back to the GitHub patch.
+ *
+ * @param {PullRequestReference} pullRequest
+ * @param {GitHubPullRequestFile} file
+ * @param {string} patch
+ * @param {import('./common.cjs').FileContentResult} [oldFile]
+ * @param {import('./common.cjs').FileContentResult} [newFile]
+ * @returns {import('../../src/types.ts').DiffSection}
+ */
+const createPullRequestSection = (pullRequest, file, patch, oldFile, newFile) => {
+  const id = `${file.filename}:pull-request:${pullRequest.number}`;
+  const patchBinary = !patch || BINARY_DIFF_MARKER.test(patch);
+  // Expandable context can only be rendered when both sides' contents are present.
+  const attemptedContent = oldFile != null && newFile != null;
+
+  if (attemptedContent && !patchBinary) {
+    const summary = summarizeContent(oldFile, newFile);
+    const status = normalizePullRequestFileStatus(file.status);
+    const oldContents = oldFile.file?.contents ?? '';
+    const newContents = newFile.file?.contents ?? '';
+    // A modification that reads empty on both sides means the content failed to
+    // load; keep the patch instead of rendering it as an empty (no-op) diff.
+    const contentMissing =
+      (status === 'modified' || status === 'renamed') && oldContents === '' && newContents === '';
+
+    if (!summary.binary && summary.loadState === 'ready' && !contentMissing) {
+      return {
+        binary: false,
+        id,
+        kind: 'pull-request',
+        loadState: 'ready',
+        newFile: newFile.file,
+        oldFile: oldFile.file,
+        patch,
+      };
+    }
+  }
+
+  // Pull request contents are loaded up front, so a file that falls back to its
+  // patch (binary, oversized, or refs unavailable) cannot be loaded on demand.
+  return {
+    binary: patchBinary,
+    id,
+    kind: 'pull-request',
+    loadState: patchBinary ? 'binary' : 'ready',
+    patch,
+    summary: createSummary(
+      patchBinary ? 'Binary file changed.' : 'Showing the pull request patch for this file.',
+      { canLoad: false },
+    ),
+  };
+};
+
+const PULL_REQUEST_CONTENT_CONCURRENCY = 16;
+
+/**
+ * Run an async mapper over `items` with a bounded number of concurrent calls so
+ * loading every file's contents does not spawn one git process per file at once.
+ *
+ * @template T, R
+ * @param {ReadonlyArray<T>} items
+ * @param {number} limit
+ * @param {(item: T) => Promise<R>} mapper
+ * @returns {Promise<Array<R>>}
+ */
+const mapWithConcurrency = async (items, limit, mapper) => {
+  /** @type {Array<R>} */
+  const results = new Array(items.length);
+  let cursor = 0;
+  const run = async () => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await mapper(items[index]);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, run));
+  return results;
+};
+
 /** @param {string} launchPath @param {Extract<ReviewSource, {type: 'pull-request'}>} source @returns {Promise<RepositoryState>} */
 const readPullRequestState = async (launchPath, source) => {
   const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
@@ -611,39 +759,48 @@ const readPullRequestState = async (launchPath, source) => {
     readPullRequestComments(repoRoot, pullRequest),
   ]);
   const diffByPath = splitPullRequestDiff(diff);
+  // Load every file's base and head contents up front from the local refs, so
+  // each diff renders in its final collapsed layout immediately and never shifts
+  // as expandable context becomes available. Files larger than the eager limit
+  // stay patch-only.
+  const contentRefs = await resolvePullRequestContentRefs(repoRoot, pullRequest, metadata).catch(
+    () => null,
+  );
 
   /** @type {Array<ChangedFile>} */
-  const files = [...apiFiles]
-    .sort((left, right) => left.filename.localeCompare(right.filename))
-    .map((file) => {
+  const files = (
+    await mapWithConcurrency([...apiFiles], PULL_REQUEST_CONTENT_CONCURRENCY, async (file) => {
       const patch = diffByPath.get(file.filename) || createPatchFromPullRequestFile(file);
-      const binary = !patch || /Binary files .* differ/.test(patch);
+      const oldPath = file.previous_filename || file.filename;
+      const [oldFile, newFile] =
+        contentRefs && !BINARY_DIFF_MARKER.test(patch)
+          ? await Promise.all([
+              readGitFile(repoRoot, contentRefs.base, oldPath),
+              readGitFile(repoRoot, contentRefs.head, file.filename),
+            ])
+          : [undefined, undefined];
+      const section = createPullRequestSection(pullRequest, file, patch, oldFile, newFile);
 
       return {
         fingerprint: getFingerprint(
-          `${metadata.head?.sha || ''}\n${file.status}\n${file.previous_filename || ''}\n${
-            file.filename
-          }\n${patch}`,
+          [
+            metadata.head?.sha || '',
+            file.status,
+            file.previous_filename || '',
+            file.filename,
+            section.loadState || 'ready',
+            section.oldFile?.cacheKey || '',
+            section.newFile?.cacheKey || '',
+            patch,
+          ].join('\n'),
         ),
         oldPath: file.previous_filename,
         path: file.filename,
-        sections: [
-          {
-            binary,
-            id: `${file.filename}:pull-request:${pullRequest.number}`,
-            kind: 'pull-request',
-            loadState: binary ? 'binary' : 'ready',
-            patch,
-            summary: binary
-              ? createSummary('Binary file changed.', {
-                  canLoad: false,
-                })
-              : undefined,
-          },
-        ],
+        sections: [section],
         status: normalizePullRequestFileStatus(file.status),
       };
-    });
+    })
+  ).sort((left, right) => left.path.localeCompare(right.path));
 
   return {
     files,
@@ -794,6 +951,7 @@ module.exports = {
   collectResolvedReviewCommentIds,
   createPatchFromPullRequestFile,
   createPullRequestHistoryFetchRefspecs,
+  createPullRequestSection,
   createPullRequestSource,
   getPullRequestHeadImageSource,
   listPullRequestHistory,
@@ -804,6 +962,7 @@ module.exports = {
   parseGitHubPullRequestUrl,
   readPullRequestImageContent,
   readPullRequestState,
+  resolvePullRequestContentRefs,
   selectUnresolvedReviewComments,
   submitPullRequestComment,
   submitPullRequestReview,

--- a/src/__tests__/git-state.test.ts
+++ b/src/__tests__/git-state.test.ts
@@ -21,6 +21,14 @@ type StatusEntry = {
   untracked: boolean;
 };
 
+type PullRequestFileContent = {
+  binary: boolean;
+  file?: { cacheKey?: string; contents: string; name: string };
+  fingerprint?: string;
+  loadState?: string;
+  summary?: unknown;
+};
+
 type GitStateModule = {
   collectResolvedReviewCommentIds: (
     threads: ReadonlyArray<{
@@ -32,6 +40,13 @@ type GitStateModule = {
     pullRequest: { number: number; owner: string; repo: string; url: string },
     metadata: { base?: { ref?: string; sha?: string } },
   ) => ReadonlyArray<string>;
+  createPullRequestSection: (
+    pullRequest: { number: number; owner: string; repo: string; url: string },
+    file: { filename: string; patch?: string; previous_filename?: string; status: string },
+    patch: string,
+    oldFile?: PullRequestFileContent,
+    newFile?: PullRequestFileContent,
+  ) => DiffSection;
   getPullRequestHeadImageSource: (
     pullRequest: { number: number; owner: string; repo: string; url: string },
     metadata: {
@@ -66,6 +81,11 @@ type GitStateModule = {
   ) => Promise<{ root: string; signature: string }>;
   readRepositoryState: (launchPath: string, source?: ReviewSource) => Promise<RepositoryState>;
   readWorkingTreeState: (launchPath: string) => Promise<RepositoryState>;
+  resolvePullRequestContentRefs: (
+    repoRoot: string,
+    pullRequest: { number: number; owner: string; repo: string; url: string },
+    metadata: { base?: { ref?: string; sha?: string }; head?: { ref?: string; sha?: string } },
+  ) => Promise<{ base: string; head: string } | null>;
   selectUnresolvedReviewComments: (
     comments: ReadonlyArray<Record<string, unknown>>,
     resolvedCommentIds: ReadonlySet<number>,
@@ -77,6 +97,7 @@ const require = createRequire(import.meta.url);
 const {
   collectResolvedReviewCommentIds,
   createPullRequestHistoryFetchRefspecs,
+  createPullRequestSection,
   getPullRequestHeadImageSource,
   listRepositoryHistory,
   normalizeGitHubPullRequestCommit,
@@ -88,6 +109,7 @@ const {
   readRepositoryChangeSignature,
   readRepositoryState,
   readWorkingTreeState,
+  resolvePullRequestContentRefs,
   selectUnresolvedReviewComments,
 } = require('../../electron/git-state.cjs') as GitStateModule;
 
@@ -169,6 +191,171 @@ test('createPullRequestHistoryFetchRefspecs fetches PR and base refs into Codiff
     '+refs/pull/25/head:refs/codiff/pull-requests/25/head',
     '+refs/heads/main:refs/codiff/pull-requests/25/base',
   ]);
+});
+
+const pullRequestFixture = {
+  number: 7,
+  owner: 'nkzw-tech',
+  repo: 'codiff',
+  url: 'https://github.com/nkzw-tech/codiff/pull/7',
+};
+
+test('createPullRequestSection renders full contents so pull request diffs can expand context', () => {
+  const section = createPullRequestSection(
+    pullRequestFixture,
+    { filename: 'src/app.ts', status: 'modified' },
+    'diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n',
+    { binary: false, file: { cacheKey: 'base:src/app.ts', contents: 'old\n', name: 'src/app.ts' } },
+    { binary: false, file: { cacheKey: 'head:src/app.ts', contents: 'new\n', name: 'src/app.ts' } },
+  );
+
+  expect(section.id).toBe('src/app.ts:pull-request:7');
+  expect(section.binary).toBe(false);
+  expect(section.loadState).toBe('ready');
+  expect(section.oldFile?.contents).toBe('old\n');
+  expect(section.newFile?.contents).toBe('new\n');
+});
+
+test('createPullRequestSection falls back to a non-loadable patch section without contents', () => {
+  const section = createPullRequestSection(
+    pullRequestFixture,
+    { filename: 'src/app.ts', status: 'modified' },
+    'diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n',
+  );
+
+  expect(section.oldFile).toBeUndefined();
+  expect(section.newFile).toBeUndefined();
+  expect(section.loadState).toBe('ready');
+  // Pull request contents load up front, so a patch-only fallback is not
+  // loadable on demand (there is no pull-request section-content loader).
+  expect(section.summary?.canLoad).toBe(false);
+});
+
+test('createPullRequestSection treats the binary marker as a diff line, not patch content', () => {
+  // The patch's content adds a line that contains the binary-marker text. It
+  // must not be mistaken for an actual binary diff.
+  const patch =
+    'diff --git a/re.ts b/re.ts\n@@ -1 +1 @@\n-const a = 1;\n+const re = /Binary files .* differ/;\n';
+  const section = createPullRequestSection(
+    pullRequestFixture,
+    { filename: 're.ts', status: 'modified' },
+    patch,
+    { binary: false, file: { cacheKey: 'old', contents: 'const a = 1;\n', name: 're.ts' } },
+    {
+      binary: false,
+      file: { cacheKey: 'new', contents: 'const re = /Binary files .* differ/;\n', name: 're.ts' },
+    },
+  );
+
+  expect(section.binary).toBe(false);
+  expect(section.loadState).toBe('ready');
+  expect(section.oldFile?.contents).toBe('const a = 1;\n');
+  expect(section.newFile?.contents).toBe('const re = /Binary files .* differ/;\n');
+});
+
+test('createPullRequestSection keeps full contents for added files', () => {
+  const section = createPullRequestSection(
+    pullRequestFixture,
+    { filename: 'new.ts', status: 'added' },
+    'diff --git a/new.ts b/new.ts\n--- /dev/null\n+++ b/new.ts\n@@ -0,0 +1 @@\n+hello\n',
+    { binary: false, file: { cacheKey: 'base:new.ts:empty', contents: '', name: 'new.ts' } },
+    { binary: false, file: { cacheKey: 'head:new.ts', contents: 'hello\n', name: 'new.ts' } },
+  );
+
+  expect(section.oldFile?.contents).toBe('');
+  expect(section.newFile?.contents).toBe('hello\n');
+  expect(section.loadState).toBe('ready');
+});
+
+test('createPullRequestSection falls back to the patch for binary files', () => {
+  const section = createPullRequestSection(
+    pullRequestFixture,
+    { filename: 'logo.png', status: 'modified' },
+    'diff --git a/logo.png b/logo.png\nBinary files a/logo.png and b/logo.png differ\n',
+  );
+
+  expect(section.binary).toBe(true);
+  expect(section.loadState).toBe('binary');
+  expect(section.oldFile).toBeUndefined();
+  expect(section.newFile).toBeUndefined();
+});
+
+test('createPullRequestSection falls back to the patch when modified contents fail to load', () => {
+  const patch = 'diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n';
+  const section = createPullRequestSection(
+    pullRequestFixture,
+    { filename: 'src/app.ts', status: 'modified' },
+    patch,
+    { binary: false, file: { cacheKey: 'base:empty', contents: '', name: 'src/app.ts' } },
+    { binary: false, file: { cacheKey: 'head:empty', contents: '', name: 'src/app.ts' } },
+  );
+
+  expect(section.oldFile).toBeUndefined();
+  expect(section.newFile).toBeUndefined();
+  expect(section.loadState).toBe('ready');
+  expect(section.patch).toBe(patch);
+  // Once a load has been attempted but could not produce usable contents, the
+  // section is marked non-loadable so it is not requested again.
+  expect(section.summary?.canLoad).toBe(false);
+});
+
+test('resolvePullRequestContentRefs resolves the diff against the merge base', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(repo, 'file.txt', 'base\n');
+    await commitAll(repo, 'base');
+    const mergeBase = (await git(repo, ['rev-parse', 'HEAD'])).trim();
+
+    // The pull request head branches off the merge base.
+    await writeRepoFile(repo, 'file.txt', 'head change\n');
+    await commitAll(repo, 'head');
+    const headSha = (await git(repo, ['rev-parse', 'HEAD'])).trim();
+    await git(repo, ['update-ref', 'refs/codiff/pull-requests/7/head', headSha]);
+
+    // The base branch advances past the merge base after the PR was opened.
+    await git(repo, ['checkout', '-q', mergeBase]);
+    await writeRepoFile(repo, 'file.txt', 'base advanced\n');
+    await commitAll(repo, 'base advanced');
+    const baseTip = (await git(repo, ['rev-parse', 'HEAD'])).trim();
+    await git(repo, ['update-ref', 'refs/codiff/pull-requests/7/base', baseTip]);
+
+    const refs = await resolvePullRequestContentRefs(repo, pullRequestFixture, {
+      base: { ref: 'main' },
+      head: { sha: headSha },
+    });
+
+    expect(refs).toEqual({ base: mergeBase, head: 'refs/codiff/pull-requests/7/head' });
+    // The base tip is intentionally not used; only the PR's own changes show.
+    expect(refs?.base).not.toBe(baseTip);
+  });
+});
+
+test('resolvePullRequestContentRefs refetches when the fetched base no longer matches the base sha', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(repo, 'file.txt', 'base\n');
+    await commitAll(repo, 'base');
+    const mergeBase = (await git(repo, ['rev-parse', 'HEAD'])).trim();
+
+    await writeRepoFile(repo, 'file.txt', 'head change\n');
+    await commitAll(repo, 'head');
+    const headSha = (await git(repo, ['rev-parse', 'HEAD'])).trim();
+    await git(repo, ['update-ref', 'refs/codiff/pull-requests/7/head', headSha]);
+    await git(repo, ['checkout', '-q', mergeBase]);
+    await writeRepoFile(repo, 'file.txt', 'base advanced\n');
+    await commitAll(repo, 'base advanced');
+    const baseTip = (await git(repo, ['rev-parse', 'HEAD'])).trim();
+    await git(repo, ['update-ref', 'refs/codiff/pull-requests/7/base', baseTip]);
+
+    // GitHub reports a base sha that no longer matches the fetched base ref (the
+    // base branch moved or the pull request was retargeted). Resolution must
+    // refetch rather than diff against the stale local base; with no remote
+    // configured here the refetch fails and resolution reports it cannot resolve.
+    const refs = await resolvePullRequestContentRefs(repo, pullRequestFixture, {
+      base: { ref: 'main', sha: '0'.repeat(40) },
+      head: { sha: headSha },
+    });
+
+    expect(refs).toBeNull();
+  });
 });
 
 test('getPullRequestHeadImageSource uses fork repository metadata', () => {


### PR DESCRIPTION
Pull request diffs only rendered the GitHub-provided patch -- a partial diff with no way to reveal the surrounding unmodified lines. This brings the same GitHub-style "expand unmodified lines" context expansion that the working tree and commits already have to pull requests.

How it works:

- Each pull request file's base and head contents are read from the local refs (the pull request is already fetched), diffing the head against the merge base of the base branch and head -- the same comparison GitHub uses -- so line numbers and existing review comments stay aligned. With both sides present the diff is recomputed locally and the expand controls light up.

- Contents are loaded up front, batched, when the pull request state is read, so every diff renders in its final collapsed layout immediately and never shifts as you scroll or as a file's contents settle. Files past the eager size limit stay patch-only and load on demand.

- Loaded diffs are parsed from the existing patch with the full contents attached rather than recomputed from scratch, so the collapsed layout matches the patch-only view, and the collapse threshold is aligned with the context git/GitHub patches emit (-U3). As a result the collapsed view shows a small, consistent amount of context (expand for more) and only expanding a section yourself changes its height.

On-demand section loading for the working tree and commits now runs from a visibility-based loader that loads whatever is on screen once scrolling settles.

Includes tests for pull request section building (full-content vs patch fallback) and for resolving the diff against the merge base.