### PR TITLE
Preserve file selection across reloads

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -758,6 +758,9 @@ ipcMain.handle('codiff:getRepositoryState', async (event, source) => {
   const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
   const launchOptions = windowLaunchOptions.get(event.sender.id);
   const initialState = !source ? windowInitialRepositoryStates.get(event.sender.id) : undefined;
+  if (initialState) {
+    windowInitialRepositoryStates.delete(event.sender.id);
+  }
   const state = initialState
     ? await initialState
     : await readRepositoryState(repositoryPath, source || launchOptions?.source);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,9 +49,9 @@ import {
   shouldLoadDiffSectionContents,
 } from './lib/diff.ts';
 import { compactPath, fuzzyMatches, sortFiles } from './lib/files.ts';
-import { isReloadShortcut } from './lib/keyboard.ts';
 import {
   consumeReloadSelection,
+  getReloadDeltaPaths,
   getReloadSelectionPath,
   writeReloadSelection,
 } from './lib/reload-selection.ts';
@@ -139,6 +139,7 @@ export default function App() {
     useState<CodexSkillStatus>(defaultCodexSkillStatus);
   const [preferences, setPreferences] = useState<CodiffPreferences>(defaultPreferences);
   const [reviewComments, setReviewComments] = useState<ReadonlyArray<ReviewComment>>([]);
+  const [reloadDeltaPaths, setReloadDeltaPaths] = useState<ReadonlySet<string>>(() => new Set());
   const [pullRequestReviewSubmitting, setPullRequestReviewSubmitting] =
     useState<PullRequestReviewEvent | null>(null);
   const [scrollTarget, setScrollTarget] = useState<{ path: string; request: number } | null>(null);
@@ -315,6 +316,7 @@ export default function App() {
     let canceled = false;
 
     const load = async () => {
+      const reloadSelection = consumeReloadSelection();
       const nextLaunchOptions = await window.codiff.getLaunchOptions();
       if (canceled) {
         return;
@@ -337,7 +339,7 @@ export default function App() {
       }
       setTerminalHelperStatus(nextTerminalHelperStatus);
 
-      const nextState = await window.codiff.getRepositoryState();
+      const nextState = await window.codiff.getRepositoryState(reloadSelection?.source);
 
       if (canceled) {
         return;
@@ -397,7 +399,8 @@ export default function App() {
       const initialFiles = nextLaunchOptions.walkthrough
         ? orderFilesByWalkthrough(orderedState.files, nextWalkthrough)
         : orderedState.files;
-      const reloadSelectedPath = getReloadSelectionPath(consumeReloadSelection(), orderedState);
+      const reloadSelectedPath = getReloadSelectionPath(reloadSelection, orderedState);
+      const nextReloadDeltaPaths = getReloadDeltaPaths(reloadSelection, orderedState);
 
       setHistoryEntries(history.entries);
       setHistoryHasMore(history.entries.length >= HISTORY_PAGE_SIZE);
@@ -419,6 +422,7 @@ export default function App() {
       setItemVersionByPath({});
       setFocusCommentId(null);
       setFocusCommentRequest(0);
+      setReloadDeltaPaths(nextReloadDeltaPaths);
       setReviewComments(getReviewCommentsFromState(orderedState));
       setViewed(nextViewed);
       const nextSelectedPath = reloadSelectedPath ?? initialFiles[0]?.path ?? null;
@@ -897,24 +901,17 @@ export default function App() {
   );
 
   const reloadWindow = useCallback(() => {
-    writeReloadSelection(stateRef.current, selectedPathRef.current);
     window.location.reload();
   }, []);
 
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (!isReloadShortcut(event)) {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopImmediatePropagation();
-      reloadWindow();
+    const writeCurrentReloadSelection = () => {
+      writeReloadSelection(stateRef.current, selectedPathRef.current);
     };
 
-    window.addEventListener('keydown', handleKeyDown, { capture: true });
-    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
-  }, [reloadWindow]);
+    window.addEventListener('beforeunload', writeCurrentReloadSelection);
+    return () => window.removeEventListener('beforeunload', writeCurrentReloadSelection);
+  }, []);
 
   const selectSource = useCallback(
     (source: ReviewSource) => {
@@ -932,6 +929,7 @@ export default function App() {
       setLoadError(null);
       setFocusCommentId(null);
       setFocusCommentRequest(0);
+      setReloadDeltaPaths(new Set());
       setDiffSearchQuery('');
       setActiveDiffSearchMatchIndex(0);
       setScrollTarget(null);
@@ -974,6 +972,7 @@ export default function App() {
           setCollapsed(new Set(nextCollapsed));
           setItemVersionByPath({});
           setReviewComments(session?.reviewComments ?? getReviewCommentsFromState(orderedState));
+          setReloadDeltaPaths(new Set());
           setViewed(nextViewed);
           setSelectedPath(nextSelectedPath);
           setWalkthrough(session?.walkthrough ?? null);
@@ -1874,6 +1873,7 @@ export default function App() {
           onSelectPath={selectPath}
           onSelectSource={selectSource}
           pullRequestSource={historySource?.type === 'pull-request' ? historySource : null}
+          reloadDeltaPaths={reloadDeltaPaths}
           searchQuery={sidebarMode === 'history' ? historySearchQuery : fileSearchQuery}
           selectedPath={visibleSelectedPath}
           showWhitespace={showWhitespace}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,12 @@ import {
   shouldLoadDiffSectionContents,
 } from './lib/diff.ts';
 import { compactPath, fuzzyMatches, sortFiles } from './lib/files.ts';
+import { isReloadShortcut } from './lib/keyboard.ts';
+import {
+  consumeReloadSelection,
+  getReloadSelectionPath,
+  writeReloadSelection,
+} from './lib/reload-selection.ts';
 import {
   buildReviewCommentsMarkdown,
   getCommentKey,
@@ -273,6 +279,22 @@ export default function App() {
     [bumpItemVersion],
   );
 
+  const scrollPathIntoReview = useCallback((path: string) => {
+    setScrollTarget((current) => ({
+      path,
+      request: (current?.request ?? 0) + 1,
+    }));
+    programmaticScrollPathRef.current = path;
+    if (programmaticScrollTimerRef.current != null) {
+      window.clearTimeout(programmaticScrollTimerRef.current);
+    }
+
+    programmaticScrollTimerRef.current = window.setTimeout(() => {
+      programmaticScrollPathRef.current = null;
+      programmaticScrollTimerRef.current = null;
+    }, 1200);
+  }, []);
+
   const saveCurrentSourceSession = useCallback(() => {
     const currentState = stateRef.current;
     if (!currentState) {
@@ -375,6 +397,7 @@ export default function App() {
       const initialFiles = nextLaunchOptions.walkthrough
         ? orderFilesByWalkthrough(orderedState.files, nextWalkthrough)
         : orderedState.files;
+      const reloadSelectedPath = getReloadSelectionPath(consumeReloadSelection(), orderedState);
 
       setHistoryEntries(history.entries);
       setHistoryHasMore(history.entries.length >= HISTORY_PAGE_SIZE);
@@ -398,7 +421,11 @@ export default function App() {
       setFocusCommentRequest(0);
       setReviewComments(getReviewCommentsFromState(orderedState));
       setViewed(nextViewed);
-      setSelectedPath((current) => current ?? initialFiles[0]?.path ?? null);
+      const nextSelectedPath = reloadSelectedPath ?? initialFiles[0]?.path ?? null;
+      setSelectedPath(nextSelectedPath);
+      if (reloadSelectedPath) {
+        scrollPathIntoReview(reloadSelectedPath);
+      }
     };
 
     load().catch((error: unknown) => {
@@ -413,7 +440,7 @@ export default function App() {
     return () => {
       canceled = true;
     };
-  }, []);
+  }, [scrollPathIntoReview]);
 
   useEffect(
     () =>
@@ -861,22 +888,33 @@ export default function App() {
     setSelectedPath(path);
   }, []);
 
-  const activatePath = useCallback((path: string) => {
-    setSelectedPath(path);
-    setScrollTarget((current) => ({
-      path,
-      request: (current?.request ?? 0) + 1,
-    }));
-    programmaticScrollPathRef.current = path;
-    if (programmaticScrollTimerRef.current != null) {
-      window.clearTimeout(programmaticScrollTimerRef.current);
-    }
+  const activatePath = useCallback(
+    (path: string) => {
+      setSelectedPath(path);
+      scrollPathIntoReview(path);
+    },
+    [scrollPathIntoReview],
+  );
 
-    programmaticScrollTimerRef.current = window.setTimeout(() => {
-      programmaticScrollPathRef.current = null;
-      programmaticScrollTimerRef.current = null;
-    }, 1200);
+  const reloadWindow = useCallback(() => {
+    writeReloadSelection(stateRef.current, selectedPathRef.current);
+    window.location.reload();
   }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isReloadShortcut(event)) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      reloadWindow();
+    };
+
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
+  }, [reloadWindow]);
 
   const selectSource = useCallback(
     (source: ReviewSource) => {
@@ -1248,7 +1286,7 @@ export default function App() {
         title: 'Toggle Word Wrap',
       }),
       registry.register({
-        execute: () => window.location.reload(),
+        execute: reloadWindow,
         id: 'reload',
         title: 'Reload Window',
       }),
@@ -1260,7 +1298,14 @@ export default function App() {
         unregister();
       }
     };
-  }, [bumpItemVersion, changeSidebarMode, expandSidebar, openDiffSearch, toggleSidebar]);
+  }, [
+    bumpItemVersion,
+    changeSidebarMode,
+    expandSidebar,
+    openDiffSearch,
+    reloadWindow,
+    toggleSidebar,
+  ]);
 
   const toggleCollapsed = useCallback(
     (file: ChangedFile, isCollapsed: boolean) => {
@@ -1744,6 +1789,7 @@ export default function App() {
         </div>
       ) : null}
       <RepositoryChangeBanner
+        onReload={reloadWindow}
         visible={localChangesDetected && (pendingSource ?? state.source).type === 'working-tree'}
       />
       <DiffSearchPanel

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -4,11 +4,15 @@
 
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { expect, test, vi } from 'vite-plus/test';
+import { beforeEach, expect, test, vi } from 'vite-plus/test';
 import App from '../App.tsx';
 import { defaultConfig } from '../config/defaults.ts';
-import { writeReloadSelection } from '../lib/reload-selection.ts';
-import type { ChangedFile, RepositoryState } from '../types.ts';
+import {
+  consumeReloadSelection,
+  getReloadSelectionPath,
+  writeReloadSelection,
+} from '../lib/reload-selection.ts';
+import type { ChangedFile, RepositoryState, ReviewSource } from '../types.ts';
 
 const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -55,6 +59,11 @@ Object.defineProperty(globalThis, 'sessionStorage', {
   value: createMemoryStorage(),
 });
 
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
 const repositoryState = {
   branch: 'main',
   files: [],
@@ -64,9 +73,9 @@ const repositoryState = {
   source: { type: 'working-tree' },
 } satisfies RepositoryState;
 
-const createChangedFile = (path: string) =>
+const createChangedFile = (path: string, fingerprint = `${path}:1`) =>
   ({
-    fingerprint: `${path}:1`,
+    fingerprint,
     path,
     sections: [
       {
@@ -208,6 +217,145 @@ test('repository reload restores the selected file when it still exists', async 
     }
     container.remove();
     window.sessionStorage.clear();
+  }
+});
+
+test('repository reload restores the selected file from the previous source', async () => {
+  const firstFile = createChangedFile('src/first.ts');
+  const secondFile = createChangedFile('src/second.ts');
+  const source = { ref: 'abc1234', type: 'commit' } satisfies ReviewSource;
+  const nextState = {
+    ...repositoryState,
+    files: [firstFile, secondFile],
+    source,
+  } satisfies RepositoryState;
+  const getRepositoryState = vi.fn(async (requestedSource?: ReviewSource) =>
+    requestedSource?.type === 'commit' ? nextState : repositoryState,
+  );
+
+  writeReloadSelection(nextState, secondFile.path);
+
+  window.codiff = createCodiffMock({
+    getRepositoryState,
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+      expect(
+        container.querySelector('.codiff-file-header.selected .codiff-file-path')?.textContent,
+      ).toBe(secondFile.path);
+    });
+    expect(getRepositoryState).toHaveBeenCalledWith(source);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('repository reload colors only git status glyphs for files changed after reload', async () => {
+  const unchangedFile = createChangedFile('src/unchanged.ts', 'same');
+  const changedFileBeforeReload = createChangedFile('src/changed.ts', 'before');
+  const changedFileAfterReload = createChangedFile('src/changed.ts', 'after');
+  const previousState = {
+    ...repositoryState,
+    files: [unchangedFile, changedFileBeforeReload],
+  } satisfies RepositoryState;
+  const nextState = {
+    ...repositoryState,
+    files: [unchangedFile, changedFileAfterReload],
+  } satisfies RepositoryState;
+
+  writeReloadSelection(previousState, changedFileBeforeReload.path);
+
+  window.codiff = createCodiffMock({
+    getRepositoryState: vi.fn(async () => nextState),
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      const shadowRoot = container.querySelector('file-tree-container')?.shadowRoot;
+      const styleText =
+        shadowRoot?.querySelector('style[data-codiff-reload-delta-git-status]')?.textContent ?? '';
+      expect(styleText).toContain('[data-item-path="src/changed.ts"][data-item-git-status]');
+      expect(styleText).not.toContain('[data-item-path="src/unchanged.ts"][data-item-git-status]');
+      expect(styleText).toContain("> [data-item-section='git']");
+      expect(
+        shadowRoot?.querySelector(
+          '[data-item-path="src/changed.ts"][data-item-git-status] > [data-item-section="git"]',
+        ),
+      ).toBeTruthy();
+      expect(
+        shadowRoot?.querySelector(
+          '[data-item-path="src/unchanged.ts"][data-item-git-status] > [data-item-section="git"]',
+        ),
+      ).toBeTruthy();
+    });
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('before unload saves the current source and selected file for any reload trigger', async () => {
+  const changedFile = createChangedFile('src/app.ts');
+  const source = { ref: 'abc1234', type: 'commit' } satisfies ReviewSource;
+  const nextState = {
+    ...repositoryState,
+    files: [changedFile],
+    source,
+  } satisfies RepositoryState;
+
+  window.codiff = createCodiffMock({
+    getRepositoryState: vi.fn(async () => nextState),
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+    });
+
+    window.dispatchEvent(new Event('beforeunload'));
+
+    const selection = consumeReloadSelection();
+    expect(selection?.source).toEqual(source);
+    expect(getReloadSelectionPath(selection, nextState)).toBe(changedFile.path);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
   }
 });
 

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -7,6 +7,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { expect, test, vi } from 'vite-plus/test';
 import App from '../App.tsx';
 import { defaultConfig } from '../config/defaults.ts';
+import { writeReloadSelection } from '../lib/reload-selection.ts';
 import type { ChangedFile, RepositoryState } from '../types.ts';
 
 const reactActEnvironment = globalThis as typeof globalThis & {
@@ -31,6 +32,29 @@ class StubWorker extends EventTarget {
 }
 reactActEnvironment.Worker ??= StubWorker as unknown as typeof Worker;
 
+const createMemoryStorage = (): Storage => {
+  const values = new Map<string, string>();
+  return {
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    get length() {
+      return values.size;
+    },
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+};
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: createMemoryStorage(),
+});
+Object.defineProperty(globalThis, 'sessionStorage', {
+  configurable: true,
+  value: createMemoryStorage(),
+});
+
 const repositoryState = {
   branch: 'main',
   files: [],
@@ -39,6 +63,21 @@ const repositoryState = {
   root: '/repo',
   source: { type: 'working-tree' },
 } satisfies RepositoryState;
+
+const createChangedFile = (path: string) =>
+  ({
+    fingerprint: `${path}:1`,
+    path,
+    sections: [
+      {
+        binary: false,
+        id: `${path}:unstaged`,
+        kind: 'unstaged',
+        patch: `diff --git a/${path} b/${path}\n@@ -1 +1 @@\n-old\n+new\n`,
+      },
+    ],
+    status: 'modified',
+  }) satisfies ChangedFile;
 
 const waitFor = async (assertion: () => void) => {
   let lastError: unknown;
@@ -58,83 +97,133 @@ const waitFor = async (assertion: () => void) => {
   throw lastError;
 };
 
+const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['codiff'] => ({
+  askReviewAssistant: vi.fn(async () => ({
+    reason: 'Unavailable in tests.',
+    status: 'unavailable' as const,
+  })),
+  getCodexSkillStatus: vi.fn(async () => ({
+    installed: true,
+    path: '/Users/reviewer/.codex/skills/codiff',
+  })),
+  getConfig: vi.fn(async () => defaultConfig),
+  getDiffImageContent: vi.fn(async () => ({
+    reason: 'Unavailable in tests.',
+    status: 'unavailable' as const,
+  })),
+  getDiffSectionContent: vi.fn(async () => {
+    throw new Error('Unexpected diff section load.');
+  }),
+  getGitIdentity: vi.fn(async () => ({
+    email: 'reviewer@example.com',
+    name: 'Reviewer',
+  })),
+  getLaunchOptions: vi.fn(async () => ({
+    repositoryPathProvided: true,
+    walkthrough: false,
+  })),
+  getPreferences: vi.fn(async () => ({
+    copyCommentsOnClose: true,
+    diffStyle: 'split' as const,
+    lastRepositoryPath: '/repo',
+    openAIModel: defaultConfig.settings.openAIModel,
+    showOutdated: false,
+    showWhitespace: false,
+    theme: 'system' as const,
+    wordWrap: false,
+  })),
+  getRepositoryHistory: vi.fn(async () => ({
+    entries: [],
+    root: '/repo',
+  })),
+  getRepositoryState: vi.fn(async () => repositoryState),
+  getTerminalHelperStatus: vi.fn(async () => ({
+    command: 'codiff',
+    installed: true,
+    path: '/usr/local/bin/codiff',
+  })),
+  getWalkthrough: vi.fn(async () => ({
+    reason: 'Unavailable in tests.',
+    status: 'unavailable' as const,
+  })),
+  installCodexSkill: vi.fn(async () => ({
+    installed: true,
+    path: '/Users/reviewer/.codex/skills/codiff',
+  })),
+  installTerminalHelper: vi.fn(async () => ({
+    command: 'codiff',
+    installed: true,
+    path: '/usr/local/bin/codiff',
+  })),
+  onConfigChanged: vi.fn(() => () => {}),
+  onCopyPendingCommentsRequest: vi.fn(() => () => {}),
+  onFindInDiffs: vi.fn(() => () => {}),
+  onRepositoryChanged: vi.fn(() => () => {}),
+  openConfigFile: vi.fn(async () => {}),
+  openFile: vi.fn(async () => {}),
+  setDiffStyle: vi.fn(async () => {}),
+  setShowOutdated: vi.fn(async () => {}),
+  setWordWrap: vi.fn(async () => {}),
+  showInFolder: vi.fn(async () => {}),
+  submitPullRequestComment: vi.fn(async () => {
+    throw new Error('Unexpected pull request comment submit.');
+  }),
+  submitPullRequestReview: vi.fn(async () => {}),
+  ...overrides,
+});
+
+test('repository reload restores the selected file when it still exists', async () => {
+  const firstFile = createChangedFile('src/first.ts');
+  const secondFile = createChangedFile('src/second.ts');
+  const nextState = {
+    ...repositoryState,
+    files: [firstFile, secondFile],
+  } satisfies RepositoryState;
+
+  writeReloadSelection(nextState, secondFile.path);
+
+  window.codiff = createCodiffMock({
+    getRepositoryState: vi.fn(async () => nextState),
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+      expect(
+        container.querySelector('.codiff-file-header.selected .codiff-file-path')?.textContent,
+      ).toBe(secondFile.path);
+    });
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+    window.sessionStorage.clear();
+  }
+});
+
 test('repository changes show the update banner without refreshing the working tree', async () => {
   let onRepositoryChanged: ((change: { root: string }) => void) | null = null;
   const getRepositoryState = vi.fn(async () => repositoryState);
 
-  window.codiff = {
-    askReviewAssistant: vi.fn(async () => ({
-      reason: 'Unavailable in tests.',
-      status: 'unavailable' as const,
-    })),
-    getCodexSkillStatus: vi.fn(async () => ({
-      installed: true,
-      path: '/Users/reviewer/.codex/skills/codiff',
-    })),
-    getConfig: vi.fn(async () => defaultConfig),
-    getDiffImageContent: vi.fn(async () => ({
-      reason: 'Unavailable in tests.',
-      status: 'unavailable' as const,
-    })),
-    getDiffSectionContent: vi.fn(async () => {
-      throw new Error('Unexpected diff section load.');
-    }),
-    getGitIdentity: vi.fn(async () => ({
-      email: 'reviewer@example.com',
-      name: 'Reviewer',
-    })),
-    getLaunchOptions: vi.fn(async () => ({
-      repositoryPathProvided: true,
-      walkthrough: false,
-    })),
-    getPreferences: vi.fn(async () => ({
-      ...defaultConfig.settings,
-      copyCommentsOnClose: true,
-      lastRepositoryPath: '/repo',
-    })),
-    getRepositoryHistory: vi.fn(async () => ({
-      entries: [],
-      root: '/repo',
-    })),
+  window.codiff = createCodiffMock({
     getRepositoryState,
-    getTerminalHelperStatus: vi.fn(async () => ({
-      command: 'codiff',
-      installed: true,
-      path: '/usr/local/bin/codiff',
-    })),
-    getWalkthrough: vi.fn(async () => ({
-      reason: 'Unavailable in tests.',
-      status: 'unavailable' as const,
-    })),
-    installCodexSkill: vi.fn(async () => ({
-      installed: true,
-      path: '/Users/reviewer/.codex/skills/codiff',
-    })),
-    installTerminalHelper: vi.fn(async () => ({
-      command: 'codiff',
-      installed: true,
-      path: '/usr/local/bin/codiff',
-    })),
-    onConfigChanged: vi.fn(() => () => {}),
-    onCopyPendingCommentsRequest: vi.fn(() => () => {}),
-    onFindInDiffs: vi.fn(() => () => {}),
     onRepositoryChanged: vi.fn((callback) => {
       onRepositoryChanged = callback;
       return () => {
         onRepositoryChanged = null;
       };
     }),
-    openConfigFile: vi.fn(async () => {}),
-    openFile: vi.fn(async () => {}),
-    setDiffStyle: vi.fn(async () => {}),
-    setShowOutdated: vi.fn(async () => {}),
-    setWordWrap: vi.fn(async () => {}),
-    showInFolder: vi.fn(async () => {}),
-    submitPullRequestComment: vi.fn(async () => {
-      throw new Error('Unexpected pull request comment submit.');
-    }),
-    submitPullRequestReview: vi.fn(async () => {}),
-  };
+  });
 
   const container = document.createElement('div');
   document.body.append(container);
@@ -188,74 +277,17 @@ test('walkthrough launch errors stay on the walkthrough tab without automatic re
     status: 'unavailable' as const,
   }));
 
-  window.codiff = {
-    askReviewAssistant: vi.fn(async () => ({
-      reason: 'Unavailable in tests.',
-      status: 'unavailable' as const,
-    })),
-    getCodexSkillStatus: vi.fn(async () => ({
-      installed: true,
-      path: '/Users/reviewer/.codex/skills/codiff',
-    })),
-    getConfig: vi.fn(async () => defaultConfig),
-    getDiffImageContent: vi.fn(async () => ({
-      reason: 'Unavailable in tests.',
-      status: 'unavailable' as const,
-    })),
-    getDiffSectionContent: vi.fn(async () => {
-      throw new Error('Unexpected diff section load.');
-    }),
-    getGitIdentity: vi.fn(async () => ({
-      email: 'reviewer@example.com',
-      name: 'Reviewer',
-    })),
+  window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
       repositoryPathProvided: true,
       walkthrough: true,
-    })),
-    getPreferences: vi.fn(async () => ({
-      ...defaultConfig.settings,
-      copyCommentsOnClose: true,
-      lastRepositoryPath: '/repo',
-    })),
-    getRepositoryHistory: vi.fn(async () => ({
-      entries: [],
-      root: '/repo',
     })),
     getRepositoryState: vi.fn(async () => ({
       ...repositoryState,
       files: [changedFile],
     })),
-    getTerminalHelperStatus: vi.fn(async () => ({
-      command: 'codiff',
-      installed: true,
-      path: '/usr/local/bin/codiff',
-    })),
     getWalkthrough,
-    installCodexSkill: vi.fn(async () => ({
-      installed: true,
-      path: '/Users/reviewer/.codex/skills/codiff',
-    })),
-    installTerminalHelper: vi.fn(async () => ({
-      command: 'codiff',
-      installed: true,
-      path: '/usr/local/bin/codiff',
-    })),
-    onConfigChanged: vi.fn(() => () => {}),
-    onCopyPendingCommentsRequest: vi.fn(() => () => {}),
-    onFindInDiffs: vi.fn(() => () => {}),
-    onRepositoryChanged: vi.fn(() => () => {}),
-    openConfigFile: vi.fn(async () => {}),
-    openFile: vi.fn(async () => {}),
-    setDiffStyle: vi.fn(async () => {}),
-    setShowOutdated: vi.fn(async () => {}),
-    setWordWrap: vi.fn(async () => {}),
-    showInFolder: vi.fn(async () => {}),
-    submitPullRequestComment: vi.fn(async () => {
-      throw new Error('Unexpected pull request comment submit.');
-    }),
-    submitPullRequestReview: vi.fn(async () => {}),
-  };
+  });
 
   const container = document.createElement('div');
   document.body.append(container);

--- a/src/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/src/__tests__/ReviewCodeView-scroll.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { CodeViewItem } from '@pierre/diffs';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { expect, test, vi } from 'vite-plus/test';
+import { ReviewCodeView } from '../app/components/ReviewCodeView.tsx';
+import { defaultKeymap } from '../config/defaults.ts';
+import type { ChangedFile, ReviewSource } from '../types.ts';
+
+const codeViewMock = vi.hoisted(() => ({
+  scrollTo: vi.fn(),
+}));
+
+vi.mock('@pierre/diffs/react', async () => {
+  const React = await import('react');
+
+  return {
+    CodeView: React.forwardRef(function MockCodeView(
+      props: {
+        className?: string;
+        items: Array<CodeViewItem<unknown>>;
+        onScroll?: (scrollTop: number, viewer: unknown) => void;
+        renderCustomHeader?: (item: CodeViewItem<unknown>) => React.ReactNode;
+      },
+      ref: React.ForwardedRef<unknown>,
+    ) {
+      const itemsRef = React.useRef(props.items);
+      const renderedIdsRef = React.useRef(new Set<string>());
+      const scrollAttemptByIdRef = React.useRef(new Map<string, number>());
+      const scrollTopRef = React.useRef(0);
+      itemsRef.current = props.items;
+
+      const viewer = React.useMemo(
+        () => ({
+          getRenderedItems: () =>
+            itemsRef.current
+              .filter((item) => renderedIdsRef.current.has(item.id))
+              .map((item) => ({
+                element: document.createElement('div'),
+                id: item.id,
+                instance: {},
+                item,
+                type: item.type,
+                version: item.version,
+              })),
+          getScrollTop: () => scrollTopRef.current,
+          getTopForItem: (id: string) => {
+            const index = itemsRef.current.findIndex((item) => item.id === id);
+            return index === -1 ? undefined : index * 200 + 20;
+          },
+        }),
+        [],
+      );
+
+      React.useImperativeHandle(
+        ref,
+        () => ({
+          clearSelectedLines: () => {},
+          getInstance: () => viewer,
+          scrollTo: (target: { id: string; offset?: number }) => {
+            codeViewMock.scrollTo(target);
+            const attempts = (scrollAttemptByIdRef.current.get(target.id) ?? 0) + 1;
+            scrollAttemptByIdRef.current.set(target.id, attempts);
+            const itemTop = viewer.getTopForItem(target.id) ?? 0;
+            scrollTopRef.current = Math.max(0, itemTop - (target.offset ?? 0));
+            if (attempts >= 2) {
+              renderedIdsRef.current.add(target.id);
+            }
+            props.onScroll?.(scrollTopRef.current, viewer);
+          },
+        }),
+        [props, viewer],
+      );
+
+      return React.createElement(
+        'div',
+        { className: props.className },
+        props.items.map((item) =>
+          React.createElement(
+            'div',
+            { key: item.id },
+            props.renderCustomHeader ? props.renderCustomHeader(item) : null,
+          ),
+        ),
+      );
+    }),
+    WorkerPoolContextProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+const createChangedFile = (path: string) =>
+  ({
+    fingerprint: `${path}:1`,
+    path,
+    sections: [
+      {
+        binary: false,
+        id: `${path}:unstaged`,
+        kind: 'unstaged',
+        patch: `diff --git a/${path} b/${path}\n@@ -1 +1 @@\n-old\n+new\n`,
+      },
+    ],
+    status: 'modified',
+  }) satisfies ChangedFile;
+
+const source = { type: 'working-tree' } satisfies ReviewSource;
+
+const waitFor = async (assertion: () => void) => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+  }
+
+  throw lastError;
+};
+
+test('reload scroll target is retried until the selected item renders', async () => {
+  codeViewMock.scrollTo.mockClear();
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <ReviewCodeView
+          activeSearchMatch={null}
+          collapsed={new Set()}
+          comments={[]}
+          diffStyle="split"
+          files={[createChangedFile('src/first.ts'), createChangedFile('src/second.ts')]}
+          focusCommentId={null}
+          focusCommentRequest={0}
+          forceExpandedPaths={new Set()}
+          gitIdentity={null}
+          isPullRequest={false}
+          itemVersionByPath={{}}
+          keymap={defaultKeymap}
+          loadingSectionIds={new Set()}
+          onAskCodex={() => {}}
+          onCreateComment={() => {}}
+          onDeleteComment={() => {}}
+          onLoadSection={() => {}}
+          onOpenFile={() => {}}
+          onSelectPathFromScroll={() => {}}
+          onSubmitComment={() => {}}
+          onToggleCollapsed={() => {}}
+          onToggleViewed={() => {}}
+          onUpdateComment={() => {}}
+          scrollTarget={{ path: 'src/second.ts', request: 1 }}
+          searchQuery=""
+          selectedPath="src/second.ts"
+          showWhitespace={false}
+          source={source}
+          viewed={{}}
+          walkthroughNotes={new Map()}
+        />,
+      );
+    });
+
+    await waitFor(() => {
+      expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(2);
+    });
+    expect(codeViewMock.scrollTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: 'diff:src/second.ts:unstaged',
+        type: 'item',
+      }),
+    );
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});

--- a/src/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/src/__tests__/ReviewCodeView-scroll.test.tsx
@@ -169,6 +169,7 @@ test('reload scroll target is retried until the selected item renders', async ()
           source={source}
           viewed={{}}
           walkthroughNotes={new Map()}
+          wordWrap={false}
         />,
       );
     });

--- a/src/__tests__/git-state.test.ts
+++ b/src/__tests__/git-state.test.ts
@@ -102,6 +102,7 @@ const git = async (repo: string, args: ReadonlyArray<string>) => {
 const createRepo = async () => {
   const repo = await mkdtemp(join(tmpdir(), 'codiff-git-state-'));
   await git(repo, ['init']);
+  await git(repo, ['config', 'core.excludesfile', '/dev/null']);
   await git(repo, ['config', 'user.email', 'codiff@example.com']);
   await git(repo, ['config', 'user.name', 'Codiff Test']);
   return realpath(repo);

--- a/src/__tests__/reload-selection.test.ts
+++ b/src/__tests__/reload-selection.test.ts
@@ -2,20 +2,25 @@
  * @vitest-environment jsdom
  */
 
-import { expect, test } from 'vite-plus/test';
+import { beforeEach, expect, test } from 'vite-plus/test';
 import {
   consumeReloadSelection,
+  getReloadDeltaPaths,
   getReloadSelectionPath,
   writeReloadSelection,
 } from '../lib/reload-selection.ts';
-import type { ChangedFile, RepositoryState } from '../types.ts';
+import type { ChangedFile, GitFileStatus, RepositoryState } from '../types.ts';
 
-const file = (path: string) =>
+beforeEach(() => {
+  window.sessionStorage.clear();
+});
+
+const file = (path: string, fingerprint = `${path}:1`, status: GitFileStatus = 'modified') =>
   ({
-    fingerprint: `${path}:1`,
+    fingerprint,
     path,
     sections: [],
-    status: 'modified',
+    status,
   }) satisfies ChangedFile;
 
 const state = (files: ReadonlyArray<ChangedFile>) =>
@@ -36,9 +41,27 @@ test('reload selection is consumed once and restored only when the file still ex
   writeReloadSelection(currentState, secondFile.path);
 
   const selection = consumeReloadSelection();
+  expect(selection?.source).toEqual(currentState.source);
   expect(getReloadSelectionPath(selection, currentState)).toBe(secondFile.path);
   expect(consumeReloadSelection()).toBeNull();
   expect(getReloadSelectionPath(selection, state([firstFile]))).toBeNull();
+});
+
+test('reload delta paths include only current files changed since reload', () => {
+  const unchangedFile = file('src/unchanged.ts', 'same');
+  const changedFile = file('src/changed.ts', 'before');
+  const removedFile = file('src/removed.ts', 'old');
+  const currentState = state([unchangedFile, changedFile, removedFile]);
+
+  writeReloadSelection(currentState, changedFile.path);
+
+  const selection = consumeReloadSelection();
+  expect(
+    getReloadDeltaPaths(
+      selection,
+      state([unchangedFile, file('src/changed.ts', 'after'), file('src/new.ts', 'new', 'added')]),
+    ),
+  ).toEqual(new Set(['src/changed.ts', 'src/new.ts']));
 });
 
 test('reload selection is ignored when it belongs to another repository source', () => {

--- a/src/__tests__/reload-selection.test.ts
+++ b/src/__tests__/reload-selection.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { expect, test } from 'vite-plus/test';
+import {
+  consumeReloadSelection,
+  getReloadSelectionPath,
+  writeReloadSelection,
+} from '../lib/reload-selection.ts';
+import type { ChangedFile, RepositoryState } from '../types.ts';
+
+const file = (path: string) =>
+  ({
+    fingerprint: `${path}:1`,
+    path,
+    sections: [],
+    status: 'modified',
+  }) satisfies ChangedFile;
+
+const state = (files: ReadonlyArray<ChangedFile>) =>
+  ({
+    branch: 'main',
+    files,
+    generatedAt: 1,
+    launchPath: '/repo',
+    root: '/repo',
+    source: { type: 'working-tree' },
+  }) satisfies RepositoryState;
+
+test('reload selection is consumed once and restored only when the file still exists', () => {
+  const firstFile = file('src/first.ts');
+  const secondFile = file('src/second.ts');
+  const currentState = state([firstFile, secondFile]);
+
+  writeReloadSelection(currentState, secondFile.path);
+
+  const selection = consumeReloadSelection();
+  expect(getReloadSelectionPath(selection, currentState)).toBe(secondFile.path);
+  expect(consumeReloadSelection()).toBeNull();
+  expect(getReloadSelectionPath(selection, state([firstFile]))).toBeNull();
+});
+
+test('reload selection is ignored when it belongs to another repository source', () => {
+  const changedFile = file('src/app.ts');
+  const workingTreeState = state([changedFile]);
+  const commitState = {
+    ...workingTreeState,
+    source: { ref: 'abc1234', type: 'commit' },
+  } satisfies RepositoryState;
+
+  writeReloadSelection(workingTreeState, changedFile.path);
+
+  expect(getReloadSelectionPath(consumeReloadSelection(), commitState)).toBeNull();
+});

--- a/src/app/components/Panels.tsx
+++ b/src/app/components/Panels.tsx
@@ -32,7 +32,13 @@ export function ReviewSourceLoading() {
   );
 }
 
-export function RepositoryChangeBanner({ visible }: { visible: boolean }) {
+export function RepositoryChangeBanner({
+  onReload,
+  visible,
+}: {
+  onReload: () => void;
+  visible: boolean;
+}) {
   const [dismissed, setDismissed] = useState(false);
   const isVisible = visible && !dismissed;
 
@@ -40,11 +46,7 @@ export function RepositoryChangeBanner({ visible }: { visible: boolean }) {
     <div aria-live="polite" className={`repository-change-banner${isVisible ? ' visible' : ''}`}>
       <span className="repository-change-banner-content">
         <span>Local changes detected,</span>
-        <button
-          className="repository-change-reload"
-          onClick={() => window.location.reload()}
-          type="button"
-        >
+        <button className="repository-change-reload" onClick={onReload} type="button">
           {getReloadShortcutLabel()} to reload.
         </button>
       </span>

--- a/src/app/components/ReviewCodeView.tsx
+++ b/src/app/components/ReviewCodeView.tsx
@@ -776,6 +776,12 @@ function ReviewAnnotation({
   );
 }
 
+const scrollTargetRetryFrameLimit = 90;
+
+function isScrollTargetRendered(viewer: CodeViewInstance, itemId: string) {
+  return viewer.getRenderedItems().some((item) => item.id === itemId);
+}
+
 export function ReviewCodeView({
   activeSearchMatch,
   collapsed,
@@ -1289,7 +1295,7 @@ export function ReviewCodeView({
     [],
   );
 
-  const scrollItemHeaderIntoView = useCallback((itemId: string) => {
+  const requestScrollItemHeaderIntoView = useCallback((itemId: string) => {
     const handle = codeViewRef.current;
     const viewer = handle?.getInstance();
     if (!handle || !viewer || viewer.getTopForItem(itemId) == null) {
@@ -1306,27 +1312,37 @@ export function ReviewCodeView({
     return true;
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!scrollTarget || handledScrollRequestRef.current === scrollTarget.request) {
+      return;
+    }
+
+    const itemId = firstItemByPath.get(scrollTarget.path);
+    if (!itemId) {
       return;
     }
 
     let frame: number | null = null;
     let attempts = 0;
     let canceled = false;
+    let requested = false;
 
     const tryScroll = () => {
       if (canceled || handledScrollRequestRef.current === scrollTarget.request) {
         return;
       }
 
-      const itemId = firstItemByPath.get(scrollTarget.path);
-      if (itemId && scrollItemHeaderIntoView(itemId)) {
+      const viewer = codeViewRef.current?.getInstance();
+      if (requested && viewer && isScrollTargetRendered(viewer, itemId)) {
         handledScrollRequestRef.current = scrollTarget.request;
         return;
       }
 
-      if (attempts < 6) {
+      if (requestScrollItemHeaderIntoView(itemId)) {
+        requested = true;
+      }
+
+      if (attempts < scrollTargetRetryFrameLimit) {
         attempts += 1;
         frame = window.requestAnimationFrame(tryScroll);
       }
@@ -1340,7 +1356,7 @@ export function ReviewCodeView({
         window.cancelAnimationFrame(frame);
       }
     };
-  }, [firstItemByPath, scrollItemHeaderIntoView, scrollTarget]);
+  }, [firstItemByPath, requestScrollItemHeaderIntoView, scrollTarget]);
 
   const scheduleSearchHighlights = useCallback(() => {
     const viewer = codeViewRef.current?.getInstance();

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -42,6 +42,7 @@ export function Sidebar({
   onSelectPath,
   onSelectSource,
   pullRequestSource,
+  reloadDeltaPaths,
   searchQuery,
   selectedPath,
   showWhitespace,
@@ -67,6 +68,7 @@ export function Sidebar({
   onSelectPath: (path: string) => void;
   onSelectSource: (source: ReviewSource) => void;
   pullRequestSource: PullRequestSource | null;
+  reloadDeltaPaths: ReadonlySet<string>;
   searchQuery: string;
   selectedPath: string | null;
   showWhitespace: boolean;
@@ -94,6 +96,10 @@ export function Sidebar({
   );
   const showTotalLineCount = mode !== 'history' && totalLineCount.countable;
   const lineCountsByPathRef = useRef(lineCountsByPath);
+  const reloadDeltaGitStatusCSS = useMemo(
+    () => getReloadDeltaGitStatusCSS(reloadDeltaPaths),
+    [reloadDeltaPaths],
+  );
   const renderTreeRowDecoration = useCallback<FileTreeRowDecorationRenderer>(({ item }) => {
     const lineCount = lineCountsByPathRef.current.get(item.path);
     return lineCount?.countable
@@ -160,6 +166,18 @@ export function Sidebar({
   });
 
   useEffect(() => {
+    // Tree unsafeCSS is constructor-time; keep reload delta styling dynamic without remounting.
+    if (syncReloadDeltaGitStatusCSS(treeHostRef.current, reloadDeltaGitStatusCSS)) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      syncReloadDeltaGitStatusCSS(treeHostRef.current, reloadDeltaGitStatusCSS);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [reloadDeltaGitStatusCSS]);
+
+  useEffect(() => {
     model.resetPaths(paths);
   }, [model, paths]);
 
@@ -169,7 +187,7 @@ export function Sidebar({
 
   useEffect(() => {
     model.setGitStatus(status);
-  }, [lineCountsByPath, model, status]);
+  }, [model, status]);
 
   const scrollPathIntoView = useCallback(
     (path: string) => {
@@ -345,6 +363,50 @@ export function Sidebar({
     </>
   );
 }
+
+const escapeCSSString = (value: string) =>
+  value
+    .replaceAll('\\', String.raw`\\`)
+    .replaceAll('\n', String.raw`\a `)
+    .replaceAll('\r', String.raw`\d `)
+    .replaceAll('\f', String.raw`\c `)
+    .replaceAll('"', String.raw`\"`);
+
+const getReloadDeltaGitStatusCSS = (paths: ReadonlySet<string>) =>
+  [...paths]
+    .map(
+      (path) => `
+        [data-item-path="${escapeCSSString(path)}"][data-item-git-status] > [data-item-section='git'] {
+          color: var(--sidebar-ref);
+        }
+      `,
+    )
+    .join('\n');
+
+const reloadDeltaGitStatusStyleAttribute = 'data-codiff-reload-delta-git-status';
+
+const syncReloadDeltaGitStatusCSS = (treeHost: HTMLElement | null, css: string) => {
+  const shadowRoot = treeHost?.querySelector('file-tree-container')?.shadowRoot;
+  if (!shadowRoot) {
+    return false;
+  }
+
+  const existingStyle = shadowRoot.querySelector<HTMLStyleElement>(
+    `style[${reloadDeltaGitStatusStyleAttribute}]`,
+  );
+  if (css.length === 0) {
+    existingStyle?.remove();
+    return true;
+  }
+
+  const style = existingStyle ?? document.createElement('style');
+  style.setAttribute(reloadDeltaGitStatusStyleAttribute, '');
+  style.textContent = css;
+  if (!existingStyle) {
+    shadowRoot.append(style);
+  }
+  return true;
+};
 
 const shortDate = (timestamp: number) => {
   const seconds = Math.floor((Date.now() - timestamp) / 1000);

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -29,16 +29,3 @@ export const isDiffSearchShortcut = (
 export const getReloadShortcutLabel = () => {
   return isMacPlatform() ? '⌘R' : 'Ctrl+R';
 };
-
-export const isReloadShortcut = (
-  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
-  platform = navigator.platform,
-) => {
-  if (event.altKey || event.shiftKey || event.key.toLowerCase() !== 'r') {
-    return false;
-  }
-
-  return isMacPlatform(platform)
-    ? event.metaKey && !event.ctrlKey
-    : event.ctrlKey && !event.metaKey;
-};

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -29,3 +29,16 @@ export const isDiffSearchShortcut = (
 export const getReloadShortcutLabel = () => {
   return isMacPlatform() ? '⌘R' : 'Ctrl+R';
 };
+
+export const isReloadShortcut = (
+  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
+  platform = navigator.platform,
+) => {
+  if (event.altKey || event.shiftKey || event.key.toLowerCase() !== 'r') {
+    return false;
+  }
+
+  return isMacPlatform(platform)
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
+};

--- a/src/lib/reload-selection.ts
+++ b/src/lib/reload-selection.ts
@@ -1,0 +1,93 @@
+import type { RepositoryState } from '../types.ts';
+import { getSourceKey } from './source.ts';
+
+const reloadSelectionStorageKey = 'codiff.reloadSelection.v1';
+
+type ReloadSelection = {
+  root: string;
+  selectedPath: string;
+  sourceKey: string;
+};
+
+const getStorage = () => {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+};
+
+const isReloadSelection = (value: unknown): value is ReloadSelection =>
+  typeof value === 'object' &&
+  value != null &&
+  'root' in value &&
+  typeof value.root === 'string' &&
+  'selectedPath' in value &&
+  typeof value.selectedPath === 'string' &&
+  'sourceKey' in value &&
+  typeof value.sourceKey === 'string';
+
+export const consumeReloadSelection = (): ReloadSelection | null => {
+  const storage = getStorage();
+  if (!storage) {
+    return null;
+  }
+
+  let raw: string | null;
+  try {
+    raw = storage.getItem(reloadSelectionStorageKey);
+    storage.removeItem(reloadSelectionStorageKey);
+  } catch {
+    return null;
+  }
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isReloadSelection(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+export const getReloadSelectionPath = (
+  selection: ReloadSelection | null,
+  state: RepositoryState,
+): string | null => {
+  if (
+    !selection ||
+    selection.root !== state.root ||
+    selection.sourceKey !== getSourceKey(state.source)
+  ) {
+    return null;
+  }
+
+  return state.files.some((file) => file.path === selection.selectedPath)
+    ? selection.selectedPath
+    : null;
+};
+
+export const writeReloadSelection = (
+  state: RepositoryState | null,
+  selectedPath: string | null,
+) => {
+  const storage = getStorage();
+  if (!storage || !state || !selectedPath) {
+    return;
+  }
+
+  try {
+    storage.setItem(
+      reloadSelectionStorageKey,
+      JSON.stringify({
+        root: state.root,
+        selectedPath,
+        sourceKey: getSourceKey(state.source),
+      } satisfies ReloadSelection),
+    );
+  } catch {
+    return;
+  }
+};

--- a/src/lib/reload-selection.ts
+++ b/src/lib/reload-selection.ts
@@ -1,12 +1,19 @@
-import type { RepositoryState } from '../types.ts';
+import type { GitFileStatus, RepositoryState, ReviewSource } from '../types.ts';
 import { getSourceKey } from './source.ts';
 
-const reloadSelectionStorageKey = 'codiff.reloadSelection.v1';
+const reloadSelectionStorageKey = 'codiff.reloadSelection.v3';
+
+type ReloadSelectionFile = {
+  fingerprint: string;
+  path: string;
+  status: GitFileStatus;
+};
 
 type ReloadSelection = {
+  files: ReadonlyArray<ReloadSelectionFile>;
   root: string;
   selectedPath: string;
-  sourceKey: string;
+  source: ReviewSource;
 };
 
 const getStorage = () => {
@@ -17,15 +24,60 @@ const getStorage = () => {
   }
 };
 
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value != null;
+
+const isOptionalString = (value: unknown) => value == null || typeof value === 'string';
+
+const isReviewSource = (value: unknown): value is ReviewSource => {
+  if (!isObject(value) || typeof value.type !== 'string') {
+    return false;
+  }
+
+  if (value.type === 'working-tree') {
+    return true;
+  }
+
+  if (value.type === 'commit' || value.type === 'branch') {
+    return typeof value.ref === 'string';
+  }
+
+  return (
+    value.type === 'pull-request' &&
+    typeof value.url === 'string' &&
+    (value.number == null || typeof value.number === 'number') &&
+    isOptionalString(value.headSha) &&
+    isOptionalString(value.owner) &&
+    isOptionalString(value.repo) &&
+    isOptionalString(value.title)
+  );
+};
+
+const isGitFileStatus = (value: unknown): value is GitFileStatus =>
+  value === 'added' ||
+  value === 'deleted' ||
+  value === 'modified' ||
+  value === 'renamed' ||
+  value === 'untracked';
+
+const isReloadSelectionFile = (value: unknown): value is ReloadSelectionFile =>
+  isObject(value) &&
+  typeof value.fingerprint === 'string' &&
+  typeof value.path === 'string' &&
+  isGitFileStatus(value.status);
+
 const isReloadSelection = (value: unknown): value is ReloadSelection =>
-  typeof value === 'object' &&
-  value != null &&
-  'root' in value &&
+  isObject(value) &&
+  Array.isArray(value.files) &&
+  value.files.every(isReloadSelectionFile) &&
   typeof value.root === 'string' &&
-  'selectedPath' in value &&
   typeof value.selectedPath === 'string' &&
-  'sourceKey' in value &&
-  typeof value.sourceKey === 'string';
+  isReviewSource(value.source);
+
+const getMatchingSelection = (selection: ReloadSelection | null, state: RepositoryState) =>
+  selection?.root === state.root && getSourceKey(selection.source) === getSourceKey(state.source)
+    ? selection
+    : null;
 
 export const consumeReloadSelection = (): ReloadSelection | null => {
   const storage = getStorage();
@@ -56,17 +108,39 @@ export const getReloadSelectionPath = (
   selection: ReloadSelection | null,
   state: RepositoryState,
 ): string | null => {
-  if (
-    !selection ||
-    selection.root !== state.root ||
-    selection.sourceKey !== getSourceKey(state.source)
-  ) {
+  const matchedSelection = getMatchingSelection(selection, state);
+  if (!matchedSelection) {
     return null;
   }
 
-  return state.files.some((file) => file.path === selection.selectedPath)
-    ? selection.selectedPath
+  return state.files.some((file) => file.path === matchedSelection.selectedPath)
+    ? matchedSelection.selectedPath
     : null;
+};
+
+export const getReloadDeltaPaths = (
+  selection: ReloadSelection | null,
+  state: RepositoryState,
+): ReadonlySet<string> => {
+  const matchedSelection = getMatchingSelection(selection, state);
+  if (!matchedSelection) {
+    return new Set();
+  }
+
+  const previousFiles = new Map(matchedSelection.files.map((file) => [file.path, file]));
+  const deltaPaths = new Set<string>();
+  for (const file of state.files) {
+    const previousFile = previousFiles.get(file.path);
+    if (
+      !previousFile ||
+      previousFile.fingerprint !== file.fingerprint ||
+      previousFile.status !== file.status
+    ) {
+      deltaPaths.add(file.path);
+    }
+  }
+
+  return deltaPaths;
 };
 
 export const writeReloadSelection = (
@@ -82,9 +156,14 @@ export const writeReloadSelection = (
     storage.setItem(
       reloadSelectionStorageKey,
       JSON.stringify({
+        files: state.files.map((file) => ({
+          fingerprint: file.fingerprint,
+          path: file.path,
+          status: file.status,
+        })),
         root: state.root,
         selectedPath,
-        sourceKey: getSourceKey(state.source),
+        source: state.source,
       } satisfies ReloadSelection),
     );
   } catch {


### PR DESCRIPTION
## Summary

This keeps the selected source and file stable when Codiff reloads. Maintains the currently selected file in the sidebar and in the diffs view. It also highlights only the git status glyph for files that changed since the last refresh, so we can quickly see which files changed since the last reload without adding extra UI (see orange M in the example).

<img width="317" height="300" alt="image" src="https://github.com/user-attachments/assets/b8d751ba-f246-40f3-a72a-28d11001e270" />


## Why

This makes reloads feel like a refresh, not like relaunching codiff. The implementation stores a small one-shot reload snapshot, restores the selected file only when it still matches the same source/root, and compares file fingerprints to mark changed files after reload.

## Testing

- `pnpm exec vp check --fix`
- `env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false pnpm exec vp test`
- `pnpm exec vp build`
