### PR TITLE
Add configurable editor command and open-file shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ is running so changes apply to open windows.
 ```
 
 Set `settings.editorCommand` to customize file opening. Use `{file}` for the selected file and
-`{repo}` for the repository root, for example `"subl {repo} {file}"`.
+`{repo}` for the repository root, for example `"subl \"{repo}\" \"{file}\""`.
 
 Choose `View > Split Diff` or `View > Unified Diff`, use Toggle Diff Layout in the command bar,
 or set `settings.diffStyle` to `split` for side-by-side diffs or `unified` for unified diffs.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ is running so changes apply to open windows.
   "settings": {
     "copyCommentsOnClose": false,
     "diffStyle": "split",
+    "editorCommand": "",
     "lastRepositoryPath": "",
     "openAIModel": "gpt-5.3-codex-spark",
     "showWhitespace": false,
@@ -99,6 +100,7 @@ is running so changes apply to open windows.
     "diffSearch": "Mod+f",
     "fileFilter": "Mod+p",
     "nextSearchMatch": "Enter",
+    "openFile": "Mod+k",
     "prevSearchMatch": "Shift+Enter",
     "closeSearch": "Escape",
     "submitComment": "Mod+Enter",
@@ -107,6 +109,9 @@ is running so changes apply to open windows.
   },
 }
 ```
+
+Set `settings.editorCommand` to customize file opening. Use `{file}` for the selected file and
+`{repo}` for the repository root, for example `"subl {repo} {file}"`.
 
 Choose `View > Split Diff` or `View > Unified Diff`, use Toggle Diff Layout in the command bar,
 or set `settings.diffStyle` to `split` for side-by-side diffs or `unified` for unified diffs.

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,0 +1,25 @@
+{
+  "settings": {
+    "copyCommentsOnClose": false,
+    "diffStyle": "split",
+    "editorCommand": "",
+    "lastRepositoryPath": "",
+    "openAIModel": "gpt-5.3-codex-spark",
+    "showOutdated": false,
+    "showWhitespace": false,
+    "theme": "system",
+    "wordWrap": false
+  },
+  "keymap": {
+    "closeSearch": "Escape",
+    "commandBar": "Mod+Shift+p",
+    "diffSearch": "Mod+f",
+    "discardComment": "Escape",
+    "fileFilter": "Mod+p",
+    "nextSearchMatch": "Enter",
+    "openFile": "Mod+k",
+    "prevSearchMatch": "Shift+Enter",
+    "submitComment": "Mod+Enter",
+    "toggleSidebar": "Mod+b"
+  }
+}

--- a/electron/__tests__/editor.test.ts
+++ b/electron/__tests__/editor.test.ts
@@ -4,12 +4,18 @@ import { expect, test } from 'vite-plus/test';
 const require = createRequire(import.meta.url);
 const { createEditorOpener } = require('../main/editor.cjs') as {
   createEditorOpener: (options: {
+    getEditorCommand?: () => string;
     platform?: NodeJS.Platform;
     shell: {
       openPath: (path: string) => Promise<string>;
     };
   }) => {
-    getEditorCommands: (absolutePath: string) => Array<{
+    getEditorCommands: (
+      absolutePath: string,
+      context?: {
+        repoPath?: string;
+      },
+    ) => Array<{
       args: Array<string>;
       command: string;
     }>;
@@ -17,12 +23,19 @@ const { createEditorOpener } = require('../main/editor.cjs') as {
   };
 };
 
-test('falls back to the macOS default text editor for text files without app associations', () => {
-  const opener = createEditorOpener({
-    platform: 'darwin',
+const createOpener = (
+  options: { getEditorCommand?: () => string; platform?: NodeJS.Platform } = {},
+) =>
+  createEditorOpener({
+    ...options,
     shell: {
       openPath: async () => '',
     },
+  });
+
+test('falls back to the macOS default text editor for text files without app associations', () => {
+  const opener = createOpener({
+    platform: 'darwin',
   });
 
   expect(opener.getEditorCommands('/Users/test/.codiff/codiff.jsonc')).toContainEqual({
@@ -32,15 +45,74 @@ test('falls back to the macOS default text editor for text files without app ass
 });
 
 test('parses custom editor commands with quoted arguments', () => {
-  const opener = createEditorOpener({
-    shell: {
-      openPath: async () => '',
-    },
-  });
+  const opener = createOpener();
 
   expect(opener.parseEditorCommand('editor --goto "{file}"')).toEqual([
     'editor',
     '--goto',
     '{file}',
   ]);
+});
+
+test('uses the configured editor command before built-in commands', () => {
+  const opener = createOpener({
+    getEditorCommand: () => 'cursor --goto "{file}"',
+  });
+
+  expect(opener.getEditorCommands('/Users/test/project/file.ts')[0]).toEqual({
+    args: ['--goto', '/Users/test/project/file.ts'],
+    command: 'cursor',
+  });
+});
+
+test('expands the repo placeholder in configured editor commands', () => {
+  const opener = createOpener({
+    getEditorCommand: () => 'subl "{repo}" "{file}"',
+  });
+
+  expect(
+    opener.getEditorCommands('/Users/test/project/src/file.ts', {
+      repoPath: '/Users/test/project',
+    })[0],
+  ).toEqual({
+    args: ['/Users/test/project', '/Users/test/project/src/file.ts'],
+    command: 'subl',
+  });
+});
+
+test('appends the file path when the configured editor command only uses the repo placeholder', () => {
+  const opener = createOpener({
+    getEditorCommand: () => 'subl "{repo}"',
+  });
+
+  expect(
+    opener.getEditorCommands('/Users/test/project/src/file.ts', {
+      repoPath: '/Users/test/project',
+    })[0],
+  ).toEqual({
+    args: ['/Users/test/project', '/Users/test/project/src/file.ts'],
+    command: 'subl',
+  });
+});
+
+test('lets CODIFF_EDITOR override the configured editor command', () => {
+  const previous = process.env.CODIFF_EDITOR;
+  process.env.CODIFF_EDITOR = 'zed --wait';
+
+  try {
+    const opener = createOpener({
+      getEditorCommand: () => 'cursor --goto "{file}"',
+    });
+
+    expect(opener.getEditorCommands('/Users/test/project/file.ts')[0]).toEqual({
+      args: ['--wait', '/Users/test/project/file.ts'],
+      command: 'zed',
+    });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CODIFF_EDITOR;
+    } else {
+      process.env.CODIFF_EDITOR = previous;
+    }
+  }
 });

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -14,45 +14,21 @@ const { join } = require('node:path');
 /**
  * @typedef {import('../src/config/types.ts').CodiffConfig} CodiffConfig
  * @typedef {import('../src/config/types.ts').CodiffDiffStyle} CodiffDiffStyle
- * @typedef {import('../src/config/types.ts').CodiffKeymap} CodiffKeymap
- * @typedef {import('../src/config/types.ts').CodiffSettings} CodiffSettings
  * @typedef {import('../src/config/types.ts').CodiffTheme} CodiffTheme
  * @typedef {import('../src/types.ts').CodiffPreferences} CodiffPreferences
  */
 
+/** @type {CodiffConfig} */
+const defaultConfigTemplate = require('../config/defaults.json');
+
 const SCHEMA_URL =
   'https://raw.githubusercontent.com/nkzw-tech/codiff/main/src/config/codiff-config.schema.json';
 
-/** @type {CodiffSettings} */
-const defaultSettings = {
-  copyCommentsOnClose: false,
-  diffStyle: 'split',
-  lastRepositoryPath: '',
-  openAIModel: 'gpt-5.3-codex-spark',
-  showOutdated: false,
-  showWhitespace: false,
-  theme: 'system',
-  wordWrap: false,
-};
-
-/** @type {CodiffKeymap} */
-const defaultKeymap = {
-  closeSearch: 'Escape',
-  commandBar: 'Mod+Shift+p',
-  diffSearch: 'Mod+f',
-  discardComment: 'Escape',
-  fileFilter: 'Mod+p',
-  nextSearchMatch: 'Enter',
-  prevSearchMatch: 'Shift+Enter',
-  submitComment: 'Mod+Enter',
-  toggleSidebar: 'Mod+b',
-};
-
-/** @type {CodiffConfig} */
-const defaultConfig = {
-  keymap: defaultKeymap,
-  settings: defaultSettings,
-};
+/** @returns {CodiffConfig} */
+const createDefaultConfig = () => ({
+  keymap: { ...defaultConfigTemplate.keymap },
+  settings: { ...defaultConfigTemplate.settings },
+});
 
 const getConfigDir = () => join(homedir(), '.codiff');
 
@@ -147,8 +123,10 @@ const normalizeLastRepositoryPath = (path) =>
  * @returns {CodiffConfig}
  */
 const mergeConfig = (raw) => {
+  const defaults = createDefaultConfig();
+
   if (typeof raw !== 'object' || raw === null) {
-    return defaultConfig;
+    return defaults;
   }
 
   const obj = /** @type {Record<string, unknown>} */ (raw);
@@ -166,56 +144,70 @@ const mergeConfig = (raw) => {
       closeSearch:
         typeof rawKeymap.closeSearch === 'string'
           ? rawKeymap.closeSearch
-          : defaultKeymap.closeSearch,
+          : defaults.keymap.closeSearch,
       commandBar:
-        typeof rawKeymap.commandBar === 'string' ? rawKeymap.commandBar : defaultKeymap.commandBar,
+        typeof rawKeymap.commandBar === 'string'
+          ? rawKeymap.commandBar
+          : defaults.keymap.commandBar,
       diffSearch:
-        typeof rawKeymap.diffSearch === 'string' ? rawKeymap.diffSearch : defaultKeymap.diffSearch,
+        typeof rawKeymap.diffSearch === 'string'
+          ? rawKeymap.diffSearch
+          : defaults.keymap.diffSearch,
       discardComment:
         typeof rawKeymap.discardComment === 'string'
           ? rawKeymap.discardComment
-          : defaultKeymap.discardComment,
+          : defaults.keymap.discardComment,
       fileFilter:
-        typeof rawKeymap.fileFilter === 'string' ? rawKeymap.fileFilter : defaultKeymap.fileFilter,
+        typeof rawKeymap.fileFilter === 'string'
+          ? rawKeymap.fileFilter
+          : defaults.keymap.fileFilter,
       nextSearchMatch:
         typeof rawKeymap.nextSearchMatch === 'string'
           ? rawKeymap.nextSearchMatch
-          : defaultKeymap.nextSearchMatch,
+          : defaults.keymap.nextSearchMatch,
+      openFile:
+        typeof rawKeymap.openFile === 'string' ? rawKeymap.openFile : defaults.keymap.openFile,
       prevSearchMatch:
         typeof rawKeymap.prevSearchMatch === 'string'
           ? rawKeymap.prevSearchMatch
-          : defaultKeymap.prevSearchMatch,
+          : defaults.keymap.prevSearchMatch,
       submitComment:
         typeof rawKeymap.submitComment === 'string'
           ? rawKeymap.submitComment
-          : defaultKeymap.submitComment,
+          : defaults.keymap.submitComment,
       toggleSidebar:
         typeof rawKeymap.toggleSidebar === 'string'
           ? rawKeymap.toggleSidebar
-          : defaultKeymap.toggleSidebar,
+          : defaults.keymap.toggleSidebar,
     },
     settings: {
       copyCommentsOnClose:
         typeof rawSettings.copyCommentsOnClose === 'boolean'
           ? rawSettings.copyCommentsOnClose
-          : defaultSettings.copyCommentsOnClose,
+          : defaults.settings.copyCommentsOnClose,
       diffStyle: normalizeDiffStyle(rawSettings.diffStyle),
+      editorCommand:
+        typeof rawSettings.editorCommand === 'string'
+          ? rawSettings.editorCommand
+          : defaults.settings.editorCommand,
       lastRepositoryPath: normalizeLastRepositoryPath(rawSettings.lastRepositoryPath),
       openAIModel:
         typeof rawSettings.openAIModel === 'string'
           ? rawSettings.openAIModel
-          : defaultSettings.openAIModel,
+          : defaults.settings.openAIModel,
       showOutdated:
         typeof rawSettings.showOutdated === 'boolean'
           ? rawSettings.showOutdated
-          : defaultSettings.showOutdated,
+          : defaults.settings.showOutdated,
       showWhitespace:
         typeof rawSettings.showWhitespace === 'boolean'
           ? rawSettings.showWhitespace
-          : defaultSettings.showWhitespace,
+          : defaults.settings.showWhitespace,
       theme: normalizeTheme(rawSettings.theme),
       wordWrap:
-        typeof rawSettings.wordWrap === 'boolean' ? rawSettings.wordWrap : defaultSettings.wordWrap,
+        typeof rawSettings.wordWrap === 'boolean'
+          ? rawSettings.wordWrap
+          : defaults.settings.wordWrap,
     },
   };
 };
@@ -228,7 +220,7 @@ const readConfig = () => {
   const configPath = getConfigPath();
 
   if (!existsSync(configPath)) {
-    return defaultConfig;
+    return createDefaultConfig();
   }
 
   try {
@@ -236,7 +228,7 @@ const readConfig = () => {
     const raw = parseJsonc(text);
     return mergeConfig(raw);
   } catch {
-    return defaultConfig;
+    return createDefaultConfig();
   }
 };
 
@@ -268,7 +260,7 @@ const initConfig = () => {
     return false;
   }
 
-  writeConfig(defaultConfig);
+  writeConfig(createDefaultConfig());
   return true;
 };
 
@@ -297,11 +289,12 @@ const migrateFromPreferences = (userDataPath, normalizeOpenAIModel) => {
 
   try {
     const oldPrefs = JSON.parse(readFileSync(oldPath, 'utf8'));
+    const defaults = createDefaultConfig();
     const config = mergeConfig({
       settings: {
         ...oldPrefs,
         lastRepositoryPath: normalizeLastRepositoryPath(oldPrefs?.lastRepositoryPath),
-        openAIModel: normalizeOpenAIModel(oldPrefs?.openAIModel ?? defaultSettings.openAIModel),
+        openAIModel: normalizeOpenAIModel(oldPrefs?.openAIModel ?? defaults.settings.openAIModel),
         theme: normalizeTheme(oldPrefs?.theme),
       },
     });
@@ -364,7 +357,7 @@ const configToPreferences = (config) => ({
 
 module.exports = {
   configToPreferences,
-  defaultConfig,
+  createDefaultConfig,
   getConfigPath,
   initConfig,
   mergeConfig,

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -29,7 +29,7 @@ const {
 const { FALLBACK_OPENAI_MODEL, normalizeOpenAIModel, OPENAI_MODELS } = require('./codex.cjs');
 const {
   configToPreferences,
-  defaultConfig,
+  createDefaultConfig,
   getConfigPath,
   initConfig,
   migrateFromPreferences,
@@ -88,7 +88,7 @@ const windowLaunchOptions = new Map();
 const windowInitialRepositoryStates = new Map();
 const pendingCommentsClipboardController = createPendingCommentsClipboardController({ clipboard });
 /** @type {CodiffConfig} */
-let config = defaultConfig;
+let config = createDefaultConfig();
 
 const { getCodexSkillStatus, installCodexSkill } = createCodexSkillInstaller({
   app,
@@ -100,7 +100,10 @@ const { getTerminalHelperStatus, installTerminalHelper } = createTerminalHelper(
   dialog,
   root,
 });
-const { openFileInEditor } = createEditorOpener({ shell });
+const { openFileInEditor } = createEditorOpener({
+  getEditorCommand: () => config.settings.editorCommand,
+  shell,
+});
 
 const openConfigFile = async () => {
   initConfig();
@@ -874,7 +877,7 @@ ipcMain.handle('codiff:openFile', async (event, filePath) => {
   const absolutePath = resolve(state.root, repositoryFilePath);
 
   if (existsSync(absolutePath)) {
-    await openFileInEditor(absolutePath);
+    await openFileInEditor(absolutePath, { repoPath: state.root });
   } else {
     await shell.openPath(state.root);
   }

--- a/electron/main/editor.cjs
+++ b/electron/main/editor.cjs
@@ -1,14 +1,22 @@
 // @ts-check
 
 const { execFile } = require('node:child_process');
+const { dirname } = require('node:path');
 
 /**
  * @typedef {{args: Array<string>; command: string}} EditorCommand
+ * @typedef {{repoPath?: string}} EditorCommandContext
  */
 
-/** @param {{platform?: NodeJS.Platform; shell: import('electron').Shell}} options */
-const createEditorOpener = ({ platform = process.platform, shell }) => {
+/** @param {{getEditorCommand?: () => string; platform?: NodeJS.Platform; shell: import('electron').Shell}} options */
+const createEditorOpener = ({
+  getEditorCommand = () => '',
+  platform = process.platform,
+  shell,
+}) => {
   /** @param {string} command */
+  // Handles simple editor commands with quoted arguments. Keep this small unless
+  // we need full shell-style escaping semantics.
   const parseEditorCommand = (command) =>
     command.match(/"[^"]+"|'[^']+'|\S+/g)?.map((part) => part.replace(/^['"]|['"]$/g, '')) ?? [];
 
@@ -18,23 +26,42 @@ const createEditorOpener = ({ platform = process.platform, shell }) => {
       execFile(command, args, { windowsHide: true }, (error) => resolveCommand(!error));
     });
 
-  /** @param {string} absolutePath @returns {Array<EditorCommand>} */
-  const getEditorCommands = (absolutePath) => {
+  /**
+   * @param {string} arg
+   * @param {string} absolutePath
+   * @param {EditorCommandContext} context
+   */
+  const replaceEditorPlaceholders = (arg, absolutePath, context) =>
+    arg
+      .replaceAll('{file}', absolutePath)
+      .replaceAll('{repo}', context.repoPath || dirname(absolutePath));
+
+  /**
+   * @param {ReadonlyArray<string>} args
+   * @param {string} absolutePath
+   * @param {EditorCommandContext} context
+   */
+  const getCustomEditorArgs = (args, absolutePath, context) => {
+    if (args.length === 0) {
+      return [absolutePath];
+    }
+
+    const expandedArgs = args.map((arg) => replaceEditorPlaceholders(arg, absolutePath, context));
+    return args.some((arg) => arg.includes('{file}'))
+      ? expandedArgs
+      : [...expandedArgs, absolutePath];
+  };
+
+  /** @param {string} absolutePath @param {EditorCommandContext} [context] @returns {Array<EditorCommand>} */
+  const getEditorCommands = (absolutePath, context = {}) => {
     /** @type {Array<EditorCommand>} */
     const commands = [];
-    const customEditor = process.env.CODIFF_EDITOR;
+    const customEditor = process.env.CODIFF_EDITOR || getEditorCommand();
     if (customEditor) {
       const [command, ...args] = parseEditorCommand(customEditor);
       if (command) {
-        const hasFilePlaceholder = args.some((arg) => arg.includes('{file}'));
         commands.push({
-          args:
-            args.length > 0
-              ? [
-                  ...args.map((arg) => arg.replaceAll('{file}', absolutePath)),
-                  ...(hasFilePlaceholder ? [] : [absolutePath]),
-                ]
-              : [absolutePath],
+          args: getCustomEditorArgs(args, absolutePath, context),
           command,
         });
       }
@@ -61,9 +88,9 @@ const createEditorOpener = ({ platform = process.platform, shell }) => {
     return commands;
   };
 
-  /** @param {string} absolutePath */
-  const openFileInEditor = async (absolutePath) => {
-    for (const { args, command } of getEditorCommands(absolutePath)) {
+  /** @param {string} absolutePath @param {EditorCommandContext} [context] */
+  const openFileInEditor = async (absolutePath, context = {}) => {
+    for (const { args, command } of getEditorCommands(absolutePath, context)) {
       if (await runEditorCommand(command, args)) {
         return;
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "bin",
+    "config",
     "codex",
     "dist",
     "electron"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,13 +19,12 @@ import {
 } from './app/components/Panels.tsx';
 import { ReviewCodeView } from './app/components/ReviewCodeView.tsx';
 import { Sidebar } from './app/components/Sidebar.tsx';
-import { defaultConfig } from './config/defaults.ts';
+import { createDefaultConfig } from './config/defaults.ts';
 import { getShortcutLabel, matchesShortcut } from './config/keymap.ts';
 import type { CodiffConfig } from './config/types.ts';
 import {
   defaultCodexSkillStatus,
   defaultLaunchOptions,
-  defaultPreferences,
   defaultTerminalHelperStatus,
   HISTORY_PAGE_SIZE,
 } from './lib/app-constants.ts';
@@ -49,6 +48,7 @@ import {
   shouldLoadDiffSectionContents,
 } from './lib/diff.ts';
 import { compactPath, fuzzyMatches, sortFiles } from './lib/files.ts';
+import { isNativeInputTarget } from './lib/keyboard.ts';
 import {
   consumeReloadSelection,
   getReloadDeltaPaths,
@@ -115,6 +115,8 @@ const getPreferencesFromConfig = ({ settings }: CodiffConfig): CodiffPreferences
   ...settings,
 });
 
+const defaultPreferences = getPreferencesFromConfig(createDefaultConfig());
+
 export default function App() {
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
   const [activeDiffSearchMatchIndex, setActiveDiffSearchMatchIndex] = useState(0);
@@ -133,7 +135,7 @@ export default function App() {
   const [itemVersionByPath, setItemVersionByPath] = useState<Record<string, number>>({});
   const [localChangesDetected, setLocalChangesDetected] = useState(false);
   const [launchOptions, setLaunchOptions] = useState<CodiffLaunchOptions>(defaultLaunchOptions);
-  const [codiffConfig, setCodiffConfig] = useState<CodiffConfig>(defaultConfig);
+  const [codiffConfig, setCodiffConfig] = useState<CodiffConfig>(createDefaultConfig);
   const [codexSkillInstalling, setCodexSkillInstalling] = useState(false);
   const [codexSkillStatus, setCodexSkillStatus] =
     useState<CodexSkillStatus>(defaultCodexSkillStatus);
@@ -798,6 +800,25 @@ export default function App() {
     writeSidebarCollapsed(false);
   }, []);
 
+  const openFile = useCallback((file: ChangedFile) => {
+    // Deleted files are still shown in diffs, but there is no current file to open.
+    if (file.status === 'deleted') {
+      return;
+    }
+
+    void window.codiff.openFile(file.path).catch(() => {});
+  }, []);
+
+  const openSelectedFile = useCallback(() => {
+    const currentState = stateRef.current;
+    const path = selectedPathRef.current;
+    const file = currentState?.files.find((candidate) => candidate.path === path);
+
+    if (file) {
+      openFile(file);
+    }
+  }, [openFile]);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (matchesShortcut(event, codiffConfig.keymap, 'commandBar')) {
@@ -813,6 +834,14 @@ export default function App() {
       if (matchesShortcut(event, codiffConfig.keymap, 'diffSearch')) {
         event.preventDefault();
         openDiffSearch();
+        return;
+      }
+      if (
+        !isNativeInputTarget(event.target) &&
+        matchesShortcut(event, codiffConfig.keymap, 'openFile')
+      ) {
+        event.preventDefault();
+        openSelectedFile();
         return;
       }
       if (matchesShortcut(event, codiffConfig.keymap, 'fileFilter')) {
@@ -831,7 +860,14 @@ export default function App() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [codiffConfig.keymap, expandSidebar, openDiffSearch, sidebarCollapsed, toggleSidebar]);
+  }, [
+    codiffConfig.keymap,
+    expandSidebar,
+    openDiffSearch,
+    openSelectedFile,
+    sidebarCollapsed,
+    toggleSidebar,
+  ]);
 
   useEffect(() => window.codiff.onFindInDiffs(openDiffSearch), [openDiffSearch]);
 
@@ -1243,13 +1279,9 @@ export default function App() {
       }),
       registry.register({
         description: () => selectedPathRef.current,
-        execute: () => {
-          const path = selectedPathRef.current;
-          if (path) {
-            void window.codiff.openFile(path).catch(() => {});
-          }
-        },
+        execute: openSelectedFile,
         id: 'open-file',
+        keymapAction: 'openFile',
         title: 'Open File in Editor',
       }),
       registry.register({
@@ -1302,6 +1334,7 @@ export default function App() {
     changeSidebarMode,
     expandSidebar,
     openDiffSearch,
+    openSelectedFile,
     reloadWindow,
     toggleSidebar,
   ]);
@@ -1321,10 +1354,6 @@ export default function App() {
     },
     [bumpItemVersion],
   );
-
-  const openFile = useCallback((file: ChangedFile) => {
-    void window.codiff.openFile(file.path).catch(() => {});
-  }, []);
 
   const updateSelectedPathFromScroll = useCallback(
     (viewer: CodeViewInstance) => {

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -6,7 +6,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { beforeEach, expect, test, vi } from 'vite-plus/test';
 import App from '../App.tsx';
-import { defaultConfig } from '../config/defaults.ts';
+import { createDefaultConfig, defaultSettings } from '../config/defaults.ts';
 import {
   consumeReloadSelection,
   getReloadSelectionPath,
@@ -115,7 +115,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
     installed: true,
     path: '/Users/reviewer/.codex/skills/codiff',
   })),
-  getConfig: vi.fn(async () => defaultConfig),
+  getConfig: vi.fn(async () => createDefaultConfig()),
   getDiffImageContent: vi.fn(async () => ({
     reason: 'Unavailable in tests.',
     status: 'unavailable' as const,
@@ -134,8 +134,9 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
   getPreferences: vi.fn(async () => ({
     copyCommentsOnClose: true,
     diffStyle: 'split' as const,
+    editorCommand: '',
     lastRepositoryPath: '/repo',
-    openAIModel: defaultConfig.settings.openAIModel,
+    openAIModel: defaultSettings.openAIModel,
     showOutdated: false,
     showWhitespace: false,
     theme: 'system' as const,
@@ -180,6 +181,44 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
   submitPullRequestReview: vi.fn(async () => {}),
   ...overrides,
 });
+
+const dispatchModK = () => {
+  const isMac = navigator.platform.toLowerCase().includes('mac');
+  window.dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: !isMac, key: 'k', metaKey: isMac }));
+};
+
+const renderAppForOpenFileShortcut = async (file: ChangedFile) => {
+  const openFile = vi.fn(async () => {});
+
+  window.codiff = createCodiffMock({
+    getRepositoryState: vi.fn(async () => ({
+      ...repositoryState,
+      files: [file],
+    })),
+    openFile,
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<App />);
+  });
+
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(container.querySelector('.codiff-file-header.selected')).not.toBeNull();
+  });
+
+  return {
+    cleanup: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+    openFile,
+  };
+};
 
 test('repository reload restores the selected file when it still exists', async () => {
   const firstFile = createChangedFile('src/first.ts');
@@ -356,6 +395,41 @@ test('before unload saves the current source and selected file for any reload tr
       await act(async () => root?.unmount());
     }
     container.remove();
+  }
+});
+
+test('Mod+K opens the selected file in the editor', async () => {
+  const changedFile = createChangedFile('src/app.ts');
+  const app = await renderAppForOpenFileShortcut(changedFile);
+
+  try {
+    await act(async () => {
+      dispatchModK();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(app.openFile).toHaveBeenCalledWith(changedFile.path);
+  } finally {
+    await app.cleanup();
+  }
+});
+
+test('Mod+K does not open deleted files', async () => {
+  const deletedFile = {
+    ...createChangedFile('src/removed.ts'),
+    status: 'deleted',
+  } satisfies ChangedFile;
+  const app = await renderAppForOpenFileShortcut(deletedFile);
+
+  try {
+    await act(async () => {
+      dispatchModK();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(app.openFile).not.toHaveBeenCalled();
+  } finally {
+    await app.cleanup();
   }
 });
 

--- a/src/__tests__/config-defaults.test.ts
+++ b/src/__tests__/config-defaults.test.ts
@@ -1,0 +1,48 @@
+import { copyFileSync, mkdirSync, mkdtempSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, test } from 'vite-plus/test';
+import packageJson from '../../package.json' with { type: 'json' };
+import schema from '../config/codiff-config.schema.json' with { type: 'json' };
+import { createDefaultConfig } from '../config/defaults.ts';
+
+const require = createRequire(import.meta.url);
+const { createDefaultConfig: createElectronDefaultConfig } =
+  require('../../electron/config.cjs') as {
+    createDefaultConfig: typeof createDefaultConfig;
+  };
+
+const getSchemaDefaults = (section: 'keymap' | 'settings') =>
+  Object.fromEntries(
+    Object.entries(schema.properties[section].properties).map(([key, property]) => [
+      key,
+      property.default,
+    ]),
+  );
+
+test('schema defaults match config defaults', () => {
+  const defaults = createDefaultConfig();
+
+  expect(getSchemaDefaults('settings')).toEqual(defaults.settings);
+  expect(getSchemaDefaults('keymap')).toEqual(defaults.keymap);
+});
+
+test('electron and renderer defaults match', () => {
+  expect(createElectronDefaultConfig()).toEqual(createDefaultConfig());
+});
+
+test('electron defaults load from packaged app shape', () => {
+  const packageRoot = mkdtempSync(join(tmpdir(), 'codiff-package-shape.'));
+  mkdirSync(join(packageRoot, 'config'));
+  mkdirSync(join(packageRoot, 'electron'));
+  copyFileSync('config/defaults.json', join(packageRoot, 'config/defaults.json'));
+  copyFileSync('electron/config.cjs', join(packageRoot, 'electron/config.cjs'));
+
+  const packageRequire = createRequire(join(packageRoot, 'electron/config.cjs'));
+  expect(packageRequire('./config.cjs').createDefaultConfig()).toEqual(createDefaultConfig());
+});
+
+test('npm package includes shared config defaults', () => {
+  expect(packageJson.files).toContain('config');
+});

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -28,7 +28,7 @@
         "editorCommand": {
           "type": "string",
           "default": "",
-          "description": "Command used to open files from Codiff. Use {file} as the file path placeholder and {repo} as the repository root placeholder, or leave empty to use Codiff's default editor lookup."
+          "description": "Command used to open files from Codiff. Use {file} as the file path placeholder and {repo} as the repository root placeholder, for example \"subl \\\"{repo}\\\" \\\"{file}\\\"\", or leave empty to use Codiff's default editor lookup."
         },
         "lastRepositoryPath": {
           "type": "string",

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -25,6 +25,11 @@
           "default": "split",
           "description": "Diff layout style. 'split' shows deleted and added lines side by side; 'unified' shows them in one column."
         },
+        "editorCommand": {
+          "type": "string",
+          "default": "",
+          "description": "Command used to open files from Codiff. Use {file} as the file path placeholder and {repo} as the repository root placeholder, or leave empty to use Codiff's default editor lookup."
+        },
         "lastRepositoryPath": {
           "type": "string",
           "default": "",
@@ -82,6 +87,11 @@
           "type": "string",
           "default": "Enter",
           "description": "Navigate to the next search match."
+        },
+        "openFile": {
+          "type": "string",
+          "default": "Mod+k",
+          "description": "Open the currently selected file in the configured editor."
         },
         "prevSearchMatch": {
           "type": "string",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,5 +1,5 @@
 import defaults from '../../config/defaults.json' with { type: 'json' };
-import type { CodiffConfig } from './types.ts';
+import type { CodiffConfig, CodiffKeymap, CodiffSettings } from './types.ts';
 
 // TypeScript widens values imported from JSON, so it cannot know that
 // "split" is a valid CodiffDiffStyle or "system" is a valid CodiffTheme.
@@ -13,5 +13,9 @@ export const createDefaultConfig = (): CodiffConfig => ({
   settings: { ...defaultConfigTemplate.settings },
 });
 
-export const defaultKeymap = defaultConfigTemplate.keymap;
-export const defaultSettings = defaultConfigTemplate.settings;
+export const defaultKeymap: Readonly<CodiffKeymap> = Object.freeze({
+  ...defaultConfigTemplate.keymap,
+});
+export const defaultSettings: Readonly<CodiffSettings> = Object.freeze({
+  ...defaultConfigTemplate.settings,
+});

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,29 +1,17 @@
-import type { CodiffConfig, CodiffKeymap, CodiffSettings } from './types.ts';
+import defaults from '../../config/defaults.json' with { type: 'json' };
+import type { CodiffConfig } from './types.ts';
 
-export const defaultSettings: CodiffSettings = {
-  copyCommentsOnClose: false,
-  diffStyle: 'split',
-  lastRepositoryPath: '',
-  openAIModel: 'gpt-5.3-codex-spark',
-  showOutdated: false,
-  showWhitespace: false,
-  theme: 'system',
-  wordWrap: false,
-};
+// TypeScript widens values imported from JSON, so it cannot know that
+// "split" is a valid CodiffDiffStyle or "system" is a valid CodiffTheme.
+// We keep defaults in JSON so Electron and the renderer share one source.
+// If config gets deeper or more complex, replace this cast with runtime
+// validation or a typed source that generates the CJS shape.
+const defaultConfigTemplate = defaults as CodiffConfig;
 
-export const defaultKeymap: CodiffKeymap = {
-  closeSearch: 'Escape',
-  commandBar: 'Mod+Shift+p',
-  diffSearch: 'Mod+f',
-  discardComment: 'Escape',
-  fileFilter: 'Mod+p',
-  nextSearchMatch: 'Enter',
-  prevSearchMatch: 'Shift+Enter',
-  submitComment: 'Mod+Enter',
-  toggleSidebar: 'Mod+b',
-};
+export const createDefaultConfig = (): CodiffConfig => ({
+  keymap: { ...defaultConfigTemplate.keymap },
+  settings: { ...defaultConfigTemplate.settings },
+});
 
-export const defaultConfig: CodiffConfig = {
-  keymap: defaultKeymap,
-  settings: defaultSettings,
-};
+export const defaultKeymap = defaultConfigTemplate.keymap;
+export const defaultSettings = defaultConfigTemplate.settings;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -4,6 +4,7 @@ export type CodiffTheme = 'system' | 'light' | 'dark';
 export type CodiffSettings = {
   copyCommentsOnClose: boolean;
   diffStyle: CodiffDiffStyle;
+  editorCommand: string;
   lastRepositoryPath: string;
   openAIModel: string;
   showOutdated: boolean;
@@ -21,6 +22,7 @@ export type CodiffKeymap = {
   discardComment: KeyCombo;
   fileFilter: KeyCombo;
   nextSearchMatch: KeyCombo;
+  openFile: KeyCombo;
   prevSearchMatch: KeyCombo;
   submitComment: KeyCombo;
   toggleSidebar: KeyCombo;

--- a/src/lib/app-constants.ts
+++ b/src/lib/app-constants.ts
@@ -1,9 +1,4 @@
-import type {
-  CodexSkillStatus,
-  CodiffLaunchOptions,
-  CodiffPreferences,
-  TerminalHelperStatus,
-} from '../types.ts';
+import type { CodexSkillStatus, CodiffLaunchOptions, TerminalHelperStatus } from '../types.ts';
 
 export const HISTORY_PAGE_SIZE = 30;
 
@@ -21,15 +16,4 @@ export const defaultTerminalHelperStatus: TerminalHelperStatus = {
   command: 'codiff',
   installed: false,
   path: '',
-};
-
-export const defaultPreferences: CodiffPreferences = {
-  copyCommentsOnClose: false,
-  diffStyle: 'split',
-  lastRepositoryPath: '',
-  openAIModel: 'gpt-5.3-codex-spark',
-  showOutdated: false,
-  showWhitespace: false,
-  theme: 'system',
-  wordWrap: false,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,7 @@ export type CodiffTheme = 'system' | 'light' | 'dark';
 export type CodiffPreferences = {
   copyCommentsOnClose: boolean;
   diffStyle: CodiffDiffStyle;
+  editorCommand: string;
   lastRepositoryPath: string;
   openAIModel: string;
   showOutdated: boolean;


### PR DESCRIPTION
## Summary

Adds config support for choosing which editor opens files from Codiff. For example, to open the repo in Sublime Text and edit the currently selected file: `"editorCommand": "subl {repo} {file}"`.

This also adds a default `Mod+k` shortcut to open the currently selected file in the configured editor. The shortcut uses the existing keymap config, so users can customize it like the other shortcuts.

Config defaults are now centralized in `config/defaults.json`, a packaged-safe shared source used by Electron and the renderer. This keeps the editor setting, shortcut defaults, schema defaults, package contents, and runtime defaults from drifting.

## Changes

- Add `settings.editorCommand` to config.
- Add `keymap.openFile` with default `Mod+k`.
- Use the configured editor command when opening files.
- Keep `CODIFF_EDITOR` as the environment override.
- Pass repository context into editor command expansion so `{repo}` resolves to the repository root.
- Skip editor opens for deleted files from the renderer.
- Move config defaults into packaged-safe `config/defaults.json`.
- Include `config` in package files.
- Add tests for editor command behavior, config defaults, package-shape loading, package inclusion, and the open-file shortcut.

## Validation

- `vp check --fix`
- `vp test src/__tests__/config-defaults.test.ts src/__tests__/App-render.test.tsx electron/__tests__/editor.test.ts`
- `vp build`
- `pnpm pack --pack-destination /tmp/codiff-npm-pack-check`
- Verified the npm package includes `config/defaults.json`.
- Packaged an unsigned macOS app with Electron Packager using the production package shape and `/src` excluded.
- Verified the packaged app includes `config/defaults.json` and `electron/config.cjs`.
- Verified packaged `electron/config.cjs` loads and returns the expected defaults.
- Launched the packaged app with an isolated `--user-data-dir`; it stayed running until timeout with no stderr.
