### PR TITLE
Fix extra blank lines in copied review comment diffs

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -586,6 +586,8 @@ test('review comment markdown includes multi-line ranges', () => {
   expect(markdown).toContain('1. **src/range.ts** (New lines 1-2)');
   expect(markdown).toContain('+   1 | const first = true;');
   expect(markdown).toContain('+   2 | const second = true;');
+  expect(markdown).toContain('+   1 | const first = true;\n   +   2 | const second = true;');
+  expect(markdown).not.toContain('const first = true;\n\n   +');
 });
 
 test('escape discards empty review comments without confirmation', () => {

--- a/src/lib/review-comments.ts
+++ b/src/lib/review-comments.ts
@@ -140,6 +140,10 @@ const indentMarkdown = (value: string) =>
     .join('\n');
 
 const formatReviewLineNumber = (lineNumber: number | string) => String(lineNumber).padStart(4);
+// @pierre/diffs keeps source line terminators; copied Markdown rows add their own separators.
+const normalizeReviewPatchText = (line: string) => line.replace(/\r?\n$/, '');
+const getReviewPatchText = (lines: ReadonlyArray<string>, index: number) =>
+  normalizeReviewPatchText(lines[index] ?? '');
 
 export const getReviewCommentPatchContext = (
   file: ChangedFile,
@@ -161,7 +165,7 @@ export const getReviewCommentPatchContext = (
             additionLineNumber: additionLineNumber + index,
             deletionLineNumber: deletionLineNumber + index,
             prefix: ' ',
-            text: fileDiff.additionLines[content.additionLineIndex + index] ?? '',
+            text: getReviewPatchText(fileDiff.additionLines, content.additionLineIndex + index),
           });
         }
         deletionLineNumber += content.lines;
@@ -174,7 +178,7 @@ export const getReviewCommentPatchContext = (
           deletionLineNumber: deletionLineNumber + index,
           prefix: '-',
           side: 'deletions',
-          text: fileDiff.deletionLines[content.deletionLineIndex + index] ?? '',
+          text: getReviewPatchText(fileDiff.deletionLines, content.deletionLineIndex + index),
         });
       }
 
@@ -183,7 +187,7 @@ export const getReviewCommentPatchContext = (
           additionLineNumber: additionLineNumber + index,
           prefix: '+',
           side: 'additions',
-          text: fileDiff.additionLines[content.additionLineIndex + index] ?? '',
+          text: getReviewPatchText(fileDiff.additionLines, content.additionLineIndex + index),
         });
       }
 

--- a/src/lib/review-comments.ts
+++ b/src/lib/review-comments.ts
@@ -27,9 +27,10 @@ export const getReviewCommentLineSelection = (comment: ReviewComment): CodeViewL
 type ReviewPatchRow = {
   additionLineNumber?: number;
   deletionLineNumber?: number;
+  patchLineIndex: number;
+  patchLines: ReadonlyArray<string>;
   prefix: '+' | '-' | ' ';
   side?: ReviewComment['side'];
-  text: string;
 };
 
 const matchesReviewPatchLine = (
@@ -141,9 +142,11 @@ const indentMarkdown = (value: string) =>
 
 const formatReviewLineNumber = (lineNumber: number | string) => String(lineNumber).padStart(4);
 // @pierre/diffs keeps source line terminators; copied Markdown rows add their own separators.
-const normalizeReviewPatchText = (line: string) => line.replace(/\r?\n$/, '');
+const trimReviewPatchLineTerminator = (line: string) =>
+  line.endsWith('\r\n') ? line.slice(0, -2) : line.endsWith('\n') ? line.slice(0, -1) : line;
+
 const getReviewPatchText = (lines: ReadonlyArray<string>, index: number) =>
-  normalizeReviewPatchText(lines[index] ?? '');
+  trimReviewPatchLineTerminator(lines[index] ?? '');
 
 export const getReviewCommentPatchContext = (
   file: ChangedFile,
@@ -164,8 +167,9 @@ export const getReviewCommentPatchContext = (
           rows.push({
             additionLineNumber: additionLineNumber + index,
             deletionLineNumber: deletionLineNumber + index,
+            patchLineIndex: content.additionLineIndex + index,
+            patchLines: fileDiff.additionLines,
             prefix: ' ',
-            text: getReviewPatchText(fileDiff.additionLines, content.additionLineIndex + index),
           });
         }
         deletionLineNumber += content.lines;
@@ -176,18 +180,20 @@ export const getReviewCommentPatchContext = (
       for (let index = 0; index < content.deletions; index += 1) {
         rows.push({
           deletionLineNumber: deletionLineNumber + index,
+          patchLineIndex: content.deletionLineIndex + index,
+          patchLines: fileDiff.deletionLines,
           prefix: '-',
           side: 'deletions',
-          text: getReviewPatchText(fileDiff.deletionLines, content.deletionLineIndex + index),
         });
       }
 
       for (let index = 0; index < content.additions; index += 1) {
         rows.push({
           additionLineNumber: additionLineNumber + index,
+          patchLineIndex: content.additionLineIndex + index,
+          patchLines: fileDiff.additionLines,
           prefix: '+',
           side: 'additions',
-          text: getReviewPatchText(fileDiff.additionLines, content.additionLineIndex + index),
         });
       }
 
@@ -217,7 +223,10 @@ export const getReviewCommentPatchContext = (
           : row.prefix === '-'
             ? row.deletionLineNumber
             : `${row.deletionLineNumber ?? ''}/${row.additionLineNumber ?? ''}`;
-      return `${row.prefix}${formatReviewLineNumber(lineNumber ?? '')} | ${row.text}`;
+      return `${row.prefix}${formatReviewLineNumber(lineNumber ?? '')} | ${getReviewPatchText(
+        row.patchLines,
+        row.patchLineIndex,
+      )}`;
     });
 
     return [hunk.hunkSpecs?.trim(), ...context].filter(Boolean).join('\n');


### PR DESCRIPTION
## Summary

Copied review comments could add an empty line between each line in the
included diff block.

Codiff now normalizes diff line text before building the copied Markdown, so
the copied diff block uses one newline between rows.

## Example

Before:

```diff
+ 589 | const first = true;

+ 590 | const second = true;

+ 591 | const third = true;
```

After:

```diff
+ 589 | const first = true;
+ 590 | const second = true;
+ 591 | const third = true;
```

For a copied review comment, this keeps the Markdown compact and readable:

```diff
@@ -585,8 +585,10 @@
 587/587 |   expect(markdown).toContain('+   1 | const first = true;');
 588/588 |   expect(markdown).toContain('+   2 | const second = true;');
+ 589 |   expect(markdown).toContain('+   1 | const first = true;\n   +   2 | const second = true;');
+ 590 |   expect(markdown).not.toContain('const first = true;\n\n   +');
```

## Validation

- `pnpm exec vp test src/__tests__/App.test.tsx -t 'review comment markdown'`
- `pnpm exec vp check --fix`
- `pnpm exec vp build`
