### PR TITLE
Review full branch diffs with codiff main

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Review a specific commit:
 codiff a1b2c3d
 ```
 
+Review the current branch against a target branch:
+
+```bash
+codiff main
+```
+
 Start with an LLM-generated narrative walkthrough:
 
 ```bash

--- a/bin/arguments.js
+++ b/bin/arguments.js
@@ -10,7 +10,12 @@ export const flagDefinitions = [
     name: 'agent',
     type: 'string',
   },
-  { argument: '<ref>', description: 'Open branch history.', name: 'branch', type: 'string' },
+  {
+    argument: '<ref>',
+    description: 'Review the current branch against a target branch.',
+    name: 'branch',
+    type: 'string',
+  },
   {
     argument: '<id>',
     description: 'Attach Claude Code session metadata to a walkthrough.',
@@ -59,7 +64,7 @@ export const flagDefinitions = [
 export const usageExamples = [
   { command: 'codiff', description: 'Review staged and unstaged changes.' },
   { command: 'codiff /path/to/repo', description: 'Review changes in a specific repository.' },
-  { command: 'codiff branch-name', description: 'Review a branch history.' },
+  { command: 'codiff main', description: 'Review the current branch against main.' },
   { command: 'codiff a1b2c3d', description: 'Review a specific commit.' },
   { command: "codiff '#75'", description: 'Review pull request #75.' },
   { command: 'codiff pr 75', description: 'Review pull request #75 (alternate syntax).' },

--- a/bin/codiff-app
+++ b/bin/codiff-app
@@ -32,7 +32,7 @@ show_help() {
   printf '\n'
   printf '%s\n' "${blue_bold}Options:${reset}"
   printf '  %-22s%s%s%s\n' "--agent <codex|claude>" "$gray" "Override the agent backend for this session." "$reset"
-  printf '  %-22s%s%s%s\n' "--branch <ref>" "$gray" "Open branch history." "$reset"
+  printf '  %-22s%s%s%s\n' "--branch <ref>" "$gray" "Review the current branch against a target branch." "$reset"
   printf '  %-22s%s%s%s\n' "--commit <ref>" "$gray" "Review a specific commit." "$reset"
   printf '  %-22s%s%s%s\n' "--codex-session <id>" "$gray" "Attach Codex session metadata to a walkthrough." "$reset"
   printf '  %-22s%s%s%s\n' "--claude-session <id>" "$gray" "Attach Claude Code session metadata to a walkthrough." "$reset"
@@ -45,7 +45,7 @@ show_help() {
   printf '%s\n' "${blue_bold}Examples:${reset}"
   printf '  %-22s%s%s%s\n' "codiff" "$gray" "Review staged and unstaged changes." "$reset"
   printf '  %-22s%s%s%s\n' "codiff /path/to/repo" "$gray" "Review changes in a specific repository." "$reset"
-  printf '  %-22s%s%s%s\n' "codiff branch-name" "$gray" "Review a branch history." "$reset"
+  printf '  %-22s%s%s%s\n' "codiff main" "$gray" "Review the current branch against main." "$reset"
   printf '  %-22s%s%s%s\n' "codiff a1b2c3d" "$gray" "Review a specific commit." "$reset"
   printf '  %-22s%s%s%s\n' "codiff '#75'" "$gray" "Review pull request #75." "$reset"
   printf '  %-22s%s%s%s\n' "codiff pr 75" "$gray" "Review pull request #75 (alternate syntax)." "$reset"

--- a/electron/__tests__/window-identity.test.ts
+++ b/electron/__tests__/window-identity.test.ts
@@ -19,6 +19,7 @@ const { findMatchingWindowIdentity, getWindowIdentity, parseGitHubPullRequestUrl
         source?:
           | { type: 'working-tree' }
           | { ref: string; type: 'branch' }
+          | { baseRef: string; headRef: string; ref: string; type: 'branch-diff' }
           | { ref: string; type: 'commit' }
           | {
               number?: number;
@@ -95,12 +96,22 @@ test('window identities distinguish branch history launches', async () => {
 
   try {
     await git(repositoryPath, ['checkout', '-b', 'feature']);
+    const head = (await git(repositoryPath, ['rev-parse', 'HEAD'])).trim().toLowerCase();
 
     expect(
       getWindowIdentity(repositoryPath, {
         source: { ref: 'feature', type: 'branch' },
       })?.sourceKey,
-    ).toBe('branch:feature');
+    ).toBe(`branch-diff:feature:${head}:${head}`);
+
+    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'feature update']);
+    const nextHead = (await git(repositoryPath, ['rev-parse', 'HEAD'])).trim().toLowerCase();
+
+    expect(
+      getWindowIdentity(repositoryPath, {
+        source: { baseRef: head, headRef: nextHead, ref: 'feature', type: 'branch-diff' },
+      })?.sourceKey,
+    ).toBe(`branch-diff:feature:${head}:${nextHead}`);
   } finally {
     await rm(repositoryPath, { force: true, recursive: true });
   }

--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -3,10 +3,13 @@
 const { gitOrEmpty, parseStatus, validateRepositoryPath } = require('./git-state/common.cjs');
 const {
   listRepositoryHistory,
+  readBranchImageContent,
+  readBranchSectionContent,
   readBranchState,
   readCommitImageContent,
   readCommitSectionContent,
   readCommitState,
+  readRangeImageContent,
   readRangeSectionContent,
   readRangeState,
 } = require('./git-state/commit.cjs');
@@ -53,18 +56,28 @@ const readRepositoryState = async (launchPath, source = { type: 'working-tree' }
         ? await readCommitState(launchPath, source.ref)
         : source.type === 'range'
           ? await readRangeState(launchPath, source.base, source.head, source.symmetric)
-          : source.type === 'branch'
-            ? await readBranchState(launchPath, source.ref)
+          : source.type === 'branch' || source.type === 'branch-diff'
+            ? await readBranchState(launchPath, source)
             : await readWorkingTreeState(launchPath, { eagerContents: false });
   const branch = (await gitOrEmpty(state.root, ['symbolic-ref', '--short', 'HEAD'])).trim() || null;
   return { ...state, branch };
 };
 
+/** @param {Extract<ReviewSource, {type: 'branch' | 'branch-diff'}>} source */
+const getBranchHistoryRef = (source) =>
+  source.type === 'branch-diff' ? `${source.baseRef}..${source.headRef}` : `${source.ref}..HEAD`;
+
 /** @param {string} launchPath @param {number} [limit] @param {ReviewSource} [source] @returns {Promise<RepositoryHistory>} */
 const readRepositoryHistory = (launchPath, limit, source) =>
   source?.type === 'pull-request'
     ? listPullRequestHistory(launchPath, source, limit)
-    : listRepositoryHistory(launchPath, limit, source?.type === 'branch' ? source.ref : undefined);
+    : listRepositoryHistory(
+        launchPath,
+        limit,
+        source?.type === 'branch' || source?.type === 'branch-diff'
+          ? getBranchHistoryRef(source)
+          : undefined,
+      );
 
 /** @param {string} launchPath @param {DiffSectionContentRequest} request */
 const readDiffSectionContent = async (launchPath, request) =>
@@ -77,19 +90,33 @@ const readDiffSectionContent = async (launchPath, request) =>
         request.path,
         { force: request.force },
       )
-    : request.kind === 'commit' || request.source?.type === 'commit'
-      ? readCommitSectionContent(launchPath, request.source?.ref || 'HEAD', request.path, {
+    : request.source?.type === 'branch' || request.source?.type === 'branch-diff'
+      ? readBranchSectionContent(launchPath, request.source, request.path, {
           force: request.force,
         })
-      : readWorkingTreeDiffSectionContent(launchPath, request);
+      : request.kind === 'commit' || request.source?.type === 'commit'
+        ? readCommitSectionContent(launchPath, request.source?.ref || 'HEAD', request.path, {
+            force: request.force,
+          })
+        : readWorkingTreeDiffSectionContent(launchPath, request);
 
 /** @param {string} launchPath @param {DiffImageContentRequest} request @returns {Promise<DiffImageContentResult>} */
 const readDiffImageContent = (launchPath, request) =>
   request.source?.type === 'pull-request'
     ? readPullRequestImageContent(launchPath, request.source, request.path)
-    : request.kind === 'commit' || request.source?.type === 'commit'
-      ? readCommitImageContent(launchPath, request.source?.ref || 'HEAD', request.path)
-      : readWorkingTreeDiffImageContent(launchPath, request);
+    : request.source?.type === 'range'
+      ? readRangeImageContent(
+          launchPath,
+          request.source.base,
+          request.source.head,
+          request.source.symmetric,
+          request.path,
+        )
+      : request.source?.type === 'branch' || request.source?.type === 'branch-diff'
+        ? readBranchImageContent(launchPath, request.source, request.path)
+        : request.kind === 'commit' || request.source?.type === 'commit'
+          ? readCommitImageContent(launchPath, request.source?.ref || 'HEAD', request.path)
+          : readWorkingTreeDiffImageContent(launchPath, request);
 
 module.exports = {
   collectResolvedReviewCommentIds,

--- a/electron/git-state/commit.cjs
+++ b/electron/git-state/commit.cjs
@@ -1,28 +1,32 @@
 // @ts-check
 
+const { fileSort, getGravatarHash, git, normalizeStatus } = require('./common.cjs');
 const {
-  EAGER_TEXT_FILE_LIMIT,
-  MANUAL_TEXT_FILE_LIMIT,
-  bufferToTextFile,
-  createSummary,
-  fileSort,
-  formatBytes,
-  getFingerprint,
-  getGravatarHash,
-  git,
-  gitBufferWithInput,
-  normalizeStatus,
-  readGitImageFile,
-  summarizeContent,
-  validateRepositoryPath,
-} = require('./common.cjs');
+  readComparisonImageContent,
+  readComparisonSectionContent,
+  readComparisonState,
+} = require('./comparison.cjs');
 const { readCommitMetadataForCommit } = require('./commit-metadata.cjs');
 
 /**
- * @typedef {import('../../src/types.ts').ChangedFile} ChangedFile
  * @typedef {import('../../src/types.ts').DiffImageContentResult} DiffImageContentResult
  * @typedef {import('../../src/types.ts').RepositoryState} RepositoryState
+ * @typedef {import('../../src/types.ts').ReviewSource} ReviewSource
  * @typedef {import('./common.cjs').StatusItem} StatusItem
+ * @typedef {Extract<ReviewSource, {type: 'branch'}>} BranchSource
+ * @typedef {Extract<ReviewSource, {type: 'branch-diff'}>} BranchDiffSource
+ * @typedef {Extract<ReviewSource, {type: 'commit'}>} CommitSource
+ * @typedef {Extract<ReviewSource, {type: 'range'}>} RangeSource
+ * @typedef {BranchSource | BranchDiffSource | CommitSource | RangeSource} ComparisonSource
+ * @typedef {CommitSource | BranchDiffSource | RangeSource} ResolvedComparisonSource
+ * @typedef {{
+ *   newRef: string;
+ *   oldRef?: string;
+ *   repoRoot: string;
+ *   source: ResolvedComparisonSource;
+ *   sourceLabel: string;
+ *   status: Array<Pick<StatusItem, 'oldPath' | 'path' | 'status'>>;
+ * }} ResolvedComparison
  */
 
 /**
@@ -59,16 +63,6 @@ const parseCommitNameStatus = (raw, options = {}) => {
   return options.sort === false ? files : files.sort(fileSort);
 };
 
-/** @param {string} path */
-const createEmptyFileContent = (path) => ({
-  binary: false,
-  file: {
-    cacheKey: `empty:${path}`,
-    contents: '',
-    name: path,
-  },
-});
-
 /** @param {string} repoRoot @param {string} commit @returns {Promise<Array<string>>} */
 const readCommitParents = async (repoRoot, commit) => {
   const raw = (await git(repoRoot, ['rev-list', '--parents', '-n', '1', commit])).trim();
@@ -91,510 +85,6 @@ const readCommitNameStatus = async (repoRoot, commit, firstParent, options = {})
     ),
     options,
   );
-
-/** @param {string} repoRoot @param {string} commit @param {string | undefined} firstParent @param {string} path */
-const readCommitPatch = (repoRoot, commit, firstParent, path) =>
-  git(
-    repoRoot,
-    firstParent
-      ? ['diff', '--patch', '--no-ext-diff', '--find-renames', firstParent, commit, '--', path]
-      : ['show', '--format=', '--patch', '--no-ext-diff', '--find-renames', commit, '--', path],
-  );
-
-/** @param {ReadonlyArray<string>} values @param {number} size */
-const chunk = (values, size) => {
-  /** @type {Array<Array<string>>} */
-  const chunks = [];
-  for (let index = 0; index < values.length; index += size) {
-    chunks.push(values.slice(index, index + size));
-  }
-  return chunks;
-};
-
-/** @param {string} patch */
-const splitCommitPatch = (patch) =>
-  patch
-    .split(/(?=^diff --git )/m)
-    .map((part) => part.trimEnd())
-    .filter((part) => part.startsWith('diff --git '))
-    .map((part) => `${part}\n`);
-
-/**
- * @param {string} repoRoot
- * @param {string} ref
- * @param {ReadonlyArray<string>} paths
- */
-const readTreeEntries = async (repoRoot, ref, paths) => {
-  /** @type {Map<string, {object: string; type: string}>} */
-  const entries = new Map();
-  const uniquePaths = [...new Set(paths)];
-
-  for (const pathChunk of chunk(uniquePaths, 200)) {
-    if (pathChunk.length === 0) {
-      continue;
-    }
-
-    const raw = await git(repoRoot, ['ls-tree', '-rz', ref, '--', ...pathChunk]);
-    for (const record of raw.split('\0')) {
-      if (!record) {
-        continue;
-      }
-
-      const tabIndex = record.indexOf('\t');
-      if (tabIndex === -1) {
-        continue;
-      }
-
-      const [mode, type, object] = record.slice(0, tabIndex).split(' ');
-      const path = record.slice(tabIndex + 1);
-      if (mode && type && object) {
-        entries.set(path, { object, type });
-      }
-    }
-  }
-
-  return entries;
-};
-
-/**
- * @param {string} repoRoot
- * @param {ReadonlyArray<string>} objects
- */
-const readObjectSizes = async (repoRoot, objects) => {
-  /** @type {Map<string, {size: number; type: string}>} */
-  const sizes = new Map();
-  const uniqueObjects = [...new Set(objects)];
-  if (uniqueObjects.length === 0) {
-    return sizes;
-  }
-
-  const output = (
-    await gitBufferWithInput(
-      repoRoot,
-      ['cat-file', '--batch-check=%(objectname) %(objecttype) %(objectsize)'],
-      `${uniqueObjects.join('\n')}\n`,
-    )
-  ).toString('utf8');
-
-  for (const line of output.split('\n')) {
-    if (!line) {
-      continue;
-    }
-
-    const [object, type, size] = line.split(' ');
-    if (object && type && size && type !== 'missing') {
-      sizes.set(object, {
-        size: Number(size),
-        type,
-      });
-    }
-  }
-
-  return sizes;
-};
-
-/**
- * @param {string} repoRoot
- * @param {ReadonlyArray<{object: string; size: number}>} objects
- */
-const readObjectContents = async (repoRoot, objects) => {
-  /** @type {Map<string, Buffer>} */
-  const contents = new Map();
-  /** @type {Array<{object: string; size: number}>} */
-  let batch = [];
-  let batchSize = 0;
-
-  const flush = async () => {
-    if (batch.length === 0) {
-      return;
-    }
-
-    const output = await gitBufferWithInput(
-      repoRoot,
-      ['cat-file', '--batch'],
-      `${batch.map((item) => item.object).join('\n')}\n`,
-    );
-    let offset = 0;
-
-    for (const item of batch) {
-      const headerEnd = output.indexOf(10, offset);
-      if (headerEnd === -1) {
-        break;
-      }
-
-      const header = output.subarray(offset, headerEnd).toString('utf8');
-      const [, type, sizeText] = header.split(' ');
-      const size = Number(sizeText);
-      const contentStart = headerEnd + 1;
-      const contentEnd = contentStart + size;
-
-      if (type === 'blob' && Number.isFinite(size)) {
-        contents.set(item.object, output.subarray(contentStart, contentEnd));
-      }
-
-      offset = contentEnd + 1;
-    }
-
-    batch = [];
-    batchSize = 0;
-  };
-
-  for (const item of objects) {
-    if (batchSize > 0 && batchSize + item.size > 32 * 1024 * 1024) {
-      await flush();
-    }
-
-    batch.push(item);
-    batchSize += item.size;
-  }
-
-  await flush();
-  return contents;
-};
-
-/**
- * @param {number} size
- * @param {number} limit
- */
-const createLargeBlobResult = (size, limit) => ({
-  binary: false,
-  loadState: size > MANUAL_TEXT_FILE_LIMIT ? 'too-large' : 'deferred',
-  summary: createSummary(
-    size > MANUAL_TEXT_FILE_LIMIT
-      ? `File is ${formatBytes(size)}, so Codiff skipped rendering it.`
-      : `File is ${formatBytes(size)} and will be loaded on demand.`,
-    {
-      canLoad: size <= MANUAL_TEXT_FILE_LIMIT,
-      limit,
-      size,
-    },
-  ),
-});
-
-/**
- * @param {string} repoRoot
- * @param {string} ref
- * @param {ReadonlyArray<string>} paths
- * @param {{force?: boolean}} [options]
- */
-const readGitFiles = async (repoRoot, ref, paths, options = {}) => {
-  const limit = options.force ? MANUAL_TEXT_FILE_LIMIT : EAGER_TEXT_FILE_LIMIT;
-  const entries = await readTreeEntries(repoRoot, ref, paths);
-  const sizes = await readObjectSizes(
-    repoRoot,
-    [...entries.values()].filter((entry) => entry.type === 'blob').map((entry) => entry.object),
-  );
-  const readableObjects = [...entries.values()]
-    .map((entry) => {
-      const object = sizes.get(entry.object);
-      return object && object.type === 'blob' && object.size <= limit
-        ? {
-            object: entry.object,
-            size: object.size,
-          }
-        : null;
-    })
-    .filter(Boolean);
-  const contents = await readObjectContents(repoRoot, readableObjects);
-  /** @type {Map<string, ReturnType<typeof createEmptyFileContent> | import('./common.cjs').FileContentResult>} */
-  const files = new Map();
-
-  for (const path of paths) {
-    const entry = entries.get(path);
-    if (!entry) {
-      files.set(path, createEmptyFileContent(path));
-      continue;
-    }
-
-    const object = sizes.get(entry.object);
-    if (!object || object.type !== 'blob') {
-      files.set(path, createEmptyFileContent(path));
-      continue;
-    }
-
-    if (object.size > limit) {
-      files.set(path, createLargeBlobResult(object.size, limit));
-      continue;
-    }
-
-    const buffer = contents.get(entry.object);
-    files.set(
-      path,
-      buffer
-        ? bufferToTextFile(path, buffer, `${ref}:${path}`)
-        : {
-            binary: false,
-            file: {
-              cacheKey: `${ref}:${path}:empty`,
-              contents: '',
-              name: path,
-            },
-          },
-    );
-  }
-
-  return files;
-};
-
-/**
- * @param {string} repoRoot
- * @param {string} commit
- * @param {string | undefined} firstParent
- * @param {ReadonlyArray<Pick<StatusItem, 'path'>>} items
- */
-const readCommitPatches = async (repoRoot, commit, firstParent, items) => {
-  /** @type {Map<string, string>} */
-  const patches = new Map();
-
-  for (const itemChunk of chunk(
-    items.map((item) => item.path),
-    200,
-  )) {
-    if (itemChunk.length === 0) {
-      continue;
-    }
-
-    const patch = await git(
-      repoRoot,
-      firstParent
-        ? [
-            'diff',
-            '--patch',
-            '--no-ext-diff',
-            '--find-renames',
-            firstParent,
-            commit,
-            '--',
-            ...itemChunk,
-          ]
-        : [
-            'show',
-            '--format=',
-            '--patch',
-            '--no-ext-diff',
-            '--find-renames',
-            commit,
-            '--',
-            ...itemChunk,
-          ],
-    );
-    const patchChunks = splitCommitPatch(patch);
-
-    if (patchChunks.length === itemChunk.length) {
-      for (let index = 0; index < itemChunk.length; index += 1) {
-        patches.set(itemChunk[index], patchChunks[index]);
-      }
-    } else {
-      await Promise.all(
-        itemChunk.map(async (path) => {
-          patches.set(path, await readCommitPatch(repoRoot, commit, firstParent, path));
-        }),
-      );
-    }
-  }
-
-  return patches;
-};
-
-/**
- * @param {string} commit
- * @param {Pick<StatusItem, 'oldPath' | 'path' | 'status'>} item
- * @param {ReturnType<typeof createEmptyFileContent>} oldFile
- * @param {ReturnType<typeof createEmptyFileContent>} newFile
- * @param {string} patch
- */
-const createCommitFile = (commit, item, oldFile, newFile, patch) => {
-  const summary = summarizeContent(oldFile, newFile);
-
-  return {
-    fingerprint: getFingerprint(
-      `${commit}\n${item.status}\n${item.oldPath || ''}\n${summary.loadState || 'ready'}\n${
-        summary.summary?.reason || ''
-      }\n${summary.summary?.fingerprint || ''}\n${patch}\n${oldFile.file?.contents || ''}\n${
-        newFile.file?.contents || ''
-      }`,
-    ),
-    oldPath: item.oldPath,
-    path: item.path,
-    sections: [
-      {
-        binary: summary.binary || /Binary files .* differ/.test(patch),
-        id: `${item.path}:${commit}`,
-        kind: 'commit',
-        loadState: summary.loadState,
-        newFile: newFile.file,
-        oldFile: oldFile.file,
-        patch,
-        summary: summary.summary,
-      },
-    ],
-    status: item.status,
-  };
-};
-
-/**
- * @param {string} commit
- * @param {Pick<StatusItem, 'oldPath' | 'path' | 'status'>} item
- * @param {ReturnType<typeof createEmptyFileContent>} oldFile
- * @param {ReturnType<typeof createEmptyFileContent>} newFile
- * @param {string} patch
- */
-const createCommitSection = (commit, item, oldFile, newFile, patch) =>
-  createCommitFile(commit, item, oldFile, newFile, patch).sections[0];
-
-/** @param {string} launchPath @param {string} ref @returns {Promise<RepositoryState>} */
-const readCommitState = async (launchPath, ref) => {
-  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
-  const commit = (await git(repoRoot, ['rev-parse', '--verify', `${ref}^{commit}`])).trim();
-  const [firstParent] = await readCommitParents(repoRoot, commit);
-  const status = await readCommitNameStatus(repoRoot, commit, firstParent, { sort: false });
-  const [commitMetadata, oldFiles, newFiles] = await Promise.all([
-    readCommitMetadataForCommit(repoRoot, commit, firstParent, status),
-    firstParent
-      ? readGitFiles(
-          repoRoot,
-          firstParent,
-          status.map((item) => item.oldPath || item.path),
-        )
-      : Promise.resolve(new Map()),
-    readGitFiles(
-      repoRoot,
-      commit,
-      status.map((item) => item.path),
-    ),
-  ]);
-  const readyItems = status.filter((item) => {
-    const oldFile = firstParent
-      ? oldFiles.get(item.oldPath || item.path) || createEmptyFileContent(item.oldPath || item.path)
-      : createEmptyFileContent(item.oldPath || item.path);
-    const newFile = newFiles.get(item.path) || createEmptyFileContent(item.path);
-    return summarizeContent(oldFile, newFile).loadState === 'ready';
-  });
-  const patches = await readCommitPatches(repoRoot, commit, firstParent, readyItems);
-  /** @type {Array<ChangedFile>} */
-  const files = status
-    .map((item) =>
-      createCommitFile(
-        commit,
-        item,
-        firstParent
-          ? oldFiles.get(item.oldPath || item.path) ||
-              createEmptyFileContent(item.oldPath || item.path)
-          : createEmptyFileContent(item.oldPath || item.path),
-        newFiles.get(item.path) || createEmptyFileContent(item.path),
-        patches.get(item.path) || '',
-      ),
-    )
-    .sort(fileSort);
-
-  return {
-    commitMetadata,
-    files,
-    generatedAt: Date.now(),
-    launchPath,
-    root: repoRoot,
-    source: {
-      ref: commit,
-      type: 'commit',
-    },
-  };
-};
-
-/**
- * @param {string} launchPath
- * @param {string} ref
- * @param {string} requestedPath
- * @param {{force?: boolean}} [options]
- */
-const readCommitSectionContent = async (launchPath, ref, requestedPath, options = {}) => {
-  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
-  const path = validateRepositoryPath(requestedPath);
-  const commit = (await git(repoRoot, ['rev-parse', '--verify', `${ref}^{commit}`])).trim();
-  const [firstParent] = await readCommitParents(repoRoot, commit);
-  const status = await readCommitNameStatus(repoRoot, commit, firstParent, { sort: false });
-  const item = status.find((candidate) => candidate.path === path);
-  if (!item) {
-    throw new Error('File is not part of this commit.');
-  }
-
-  const [oldFiles, newFiles] = await Promise.all([
-    firstParent
-      ? readGitFiles(repoRoot, firstParent, [item.oldPath || item.path], options)
-      : Promise.resolve(new Map()),
-    readGitFiles(repoRoot, commit, [item.path], options),
-  ]);
-  const oldFile = firstParent
-    ? oldFiles.get(item.oldPath || item.path) || createEmptyFileContent(item.oldPath || item.path)
-    : createEmptyFileContent(item.oldPath || item.path);
-  const newFile = newFiles.get(item.path) || createEmptyFileContent(item.path);
-  const summary = summarizeContent(oldFile, newFile);
-  const patch =
-    summary.loadState === 'ready'
-      ? await readCommitPatch(repoRoot, commit, firstParent, item.path)
-      : '';
-
-  return createCommitSection(commit, item, oldFile, newFile, patch);
-};
-
-/**
- * @param {string} launchPath
- * @param {string} ref
- * @param {string} requestedPath
- * @returns {Promise<DiffImageContentResult>}
- */
-const readCommitImageContent = async (launchPath, ref, requestedPath) => {
-  try {
-    const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
-    const path = validateRepositoryPath(requestedPath);
-    const commit = (await git(repoRoot, ['rev-parse', '--verify', `${ref}^{commit}`])).trim();
-    const [firstParent] = await readCommitParents(repoRoot, commit);
-    const status = await readCommitNameStatus(repoRoot, commit, firstParent, { sort: false });
-    const item = status.find((candidate) => candidate.path === path);
-    if (!item) {
-      throw new Error('File is not part of this commit.');
-    }
-
-    const [oldImage, newImage] = await Promise.all([
-      firstParent ? readGitImageFile(repoRoot, firstParent, item.oldPath || item.path) : undefined,
-      readGitImageFile(repoRoot, commit, item.path),
-    ]);
-
-    if (!oldImage && !newImage) {
-      return {
-        reason: 'Codiff could not load either side of this image.',
-        status: 'unavailable',
-      };
-    }
-
-    return {
-      ...(newImage ? { newImage } : {}),
-      ...(oldImage ? { oldImage } : {}),
-      status: 'ready',
-    };
-  } catch (error) {
-    return {
-      reason: error instanceof Error ? error.message : 'Codiff could not load this image.',
-      status: 'unavailable',
-    };
-  }
-};
-
-/** @param {string} launchPath @param {string} ref @returns {Promise<RepositoryState>} */
-const readBranchState = async (launchPath, ref) => {
-  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
-  await git(repoRoot, ['rev-parse', '--verify', `${ref}^{commit}`]);
-
-  return {
-    files: [],
-    generatedAt: Date.now(),
-    launchPath,
-    root: repoRoot,
-    source: {
-      ref,
-      type: 'branch',
-    },
-  };
-};
 
 /**
  * @param {string} repoRoot
@@ -628,113 +118,279 @@ const resolveRangeRefs = async (repoRoot, base, head, symmetric) => {
   return { newRef, oldRef };
 };
 
+/** @param {string | BranchSource | BranchDiffSource} input @returns {BranchSource | BranchDiffSource} */
+const normalizeBranchSourceInput = (input) =>
+  typeof input === 'string' ? { ref: input, type: 'branch' } : input;
+
 /**
- * Build the diff for a ref range. Mirrors {@link readCommitState} with the range's
- * base as the "parent" side and head as the "commit" side.
+ * @param {string} repoRoot
+ * @param {BranchSource | BranchDiffSource} source
+ * @returns {Promise<{newRef: string; oldRef: string; source: BranchDiffSource; sourceLabel: string}>}
+ */
+const resolveBranchComparison = async (repoRoot, source) => {
+  if (source.type === 'branch-diff') {
+    return {
+      newRef: source.headRef,
+      oldRef: source.baseRef,
+      source,
+      sourceLabel: 'branch',
+    };
+  }
+
+  const { newRef, oldRef } = await resolveRangeRefs(repoRoot, source.ref, 'HEAD', true);
+  return {
+    newRef,
+    oldRef,
+    source: {
+      baseRef: oldRef,
+      headRef: newRef,
+      ref: source.ref,
+      type: 'branch-diff',
+    },
+    sourceLabel: 'branch',
+  };
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {ComparisonSource} source
+ * @returns {Promise<Omit<ResolvedComparison, 'repoRoot' | 'status'>>}
+ */
+const resolveComparisonSource = async (repoRoot, source) => {
+  if (source.type === 'commit') {
+    const commit = (
+      await git(repoRoot, ['rev-parse', '--verify', `${source.ref}^{commit}`])
+    ).trim();
+    const [firstParent] = await readCommitParents(repoRoot, commit);
+    return {
+      newRef: commit,
+      oldRef: firstParent,
+      source: {
+        ref: commit,
+        type: 'commit',
+      },
+      sourceLabel: 'commit',
+    };
+  }
+
+  if (source.type === 'range') {
+    const { newRef, oldRef } = await resolveRangeRefs(
+      repoRoot,
+      source.base,
+      source.head,
+      source.symmetric,
+    );
+    return {
+      newRef,
+      oldRef,
+      source,
+      sourceLabel: 'range',
+    };
+  }
+
+  if (source.type === 'branch' || source.type === 'branch-diff') {
+    return resolveBranchComparison(repoRoot, source);
+  }
+
+  throw new Error('Unsupported comparison source.');
+};
+
+/** @param {string} launchPath @param {ComparisonSource} source @returns {Promise<ResolvedComparison>} */
+const readResolvedComparison = async (launchPath, source) => {
+  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
+  const comparison = await resolveComparisonSource(repoRoot, source);
+  const status = await readCommitNameStatus(repoRoot, comparison.newRef, comparison.oldRef, {
+    sort: false,
+  });
+
+  return {
+    ...comparison,
+    repoRoot,
+    status,
+  };
+};
+
+/** @param {string} launchPath @param {ResolvedComparison} comparison */
+const readResolvedComparisonState = (launchPath, comparison) =>
+  readComparisonState({
+    launchPath,
+    newRef: comparison.newRef,
+    oldRef: comparison.oldRef,
+    repoRoot: comparison.repoRoot,
+    source: comparison.source,
+    status: comparison.status,
+  });
+
+/** @param {string} launchPath @param {ComparisonSource} source @returns {Promise<RepositoryState>} */
+const readComparisonSourceState = async (launchPath, source) =>
+  readResolvedComparisonState(launchPath, await readResolvedComparison(launchPath, source));
+
+/**
+ * @param {string} launchPath
+ * @param {ComparisonSource} source
+ * @param {string} requestedPath
+ * @param {{force?: boolean}} [options]
+ */
+const readComparisonSourceSectionContent = async (
+  launchPath,
+  source,
+  requestedPath,
+  options = {},
+) => {
+  const comparison = await readResolvedComparison(launchPath, source);
+  return readComparisonSectionContent(
+    comparison.repoRoot,
+    comparison.newRef,
+    comparison.oldRef,
+    comparison.status,
+    requestedPath,
+    comparison.sourceLabel,
+    options,
+  );
+};
+
+/**
+ * @param {string} launchPath
+ * @param {ComparisonSource} source
+ * @param {string} requestedPath
+ * @returns {Promise<DiffImageContentResult>}
+ */
+const readComparisonSourceImageContent = async (launchPath, source, requestedPath) => {
+  try {
+    const comparison = await readResolvedComparison(launchPath, source);
+    return await readComparisonImageContent(
+      comparison.repoRoot,
+      comparison.newRef,
+      comparison.oldRef,
+      comparison.status,
+      requestedPath,
+      comparison.sourceLabel,
+    );
+  } catch (error) {
+    return {
+      reason: error instanceof Error ? error.message : 'Codiff could not load this image.',
+      status: 'unavailable',
+    };
+  }
+};
+
+/** @param {string} launchPath @param {string} ref @returns {Promise<RepositoryState>} */
+const readCommitState = async (launchPath, ref) => {
+  const comparison = await readResolvedComparison(launchPath, { ref, type: 'commit' });
+  const [commitMetadata, state] = await Promise.all([
+    readCommitMetadataForCommit(
+      comparison.repoRoot,
+      comparison.newRef,
+      comparison.oldRef,
+      comparison.status,
+    ),
+    readResolvedComparisonState(launchPath, comparison),
+  ]);
+
+  return {
+    ...state,
+    commitMetadata,
+  };
+};
+
+/**
+ * @param {string} launchPath
+ * @param {string} ref
+ * @param {string} requestedPath
+ * @param {{force?: boolean}} [options]
+ */
+const readCommitSectionContent = (launchPath, ref, requestedPath, options = {}) =>
+  readComparisonSourceSectionContent(launchPath, { ref, type: 'commit' }, requestedPath, options);
+
+/**
+ * @param {string} launchPath
+ * @param {string} ref
+ * @param {string} requestedPath
+ * @returns {Promise<DiffImageContentResult>}
+ */
+const readCommitImageContent = (launchPath, ref, requestedPath) =>
+  readComparisonSourceImageContent(launchPath, { ref, type: 'commit' }, requestedPath);
+
+/**
  * @param {string} launchPath @param {string} base @param {string} head @param {boolean} symmetric
  * @returns {Promise<RepositoryState>}
  */
-const readRangeState = async (launchPath, base, head, symmetric) => {
-  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
-  const { newRef, oldRef } = await resolveRangeRefs(repoRoot, base, head, symmetric);
-  const status = await readCommitNameStatus(repoRoot, newRef, oldRef, { sort: false });
-  const [oldFiles, newFiles] = await Promise.all([
-    readGitFiles(
-      repoRoot,
-      oldRef,
-      status.map((item) => item.oldPath || item.path),
-    ),
-    readGitFiles(
-      repoRoot,
-      newRef,
-      status.map((item) => item.path),
-    ),
-  ]);
-  const readyItems = status.filter((item) => {
-    const oldFile =
-      oldFiles.get(item.oldPath || item.path) || createEmptyFileContent(item.oldPath || item.path);
-    const newFile = newFiles.get(item.path) || createEmptyFileContent(item.path);
-    return summarizeContent(oldFile, newFile).loadState === 'ready';
+const readRangeState = (launchPath, base, head, symmetric) =>
+  readComparisonSourceState(launchPath, {
+    base,
+    head,
+    symmetric,
+    type: 'range',
   });
-  const patches = await readCommitPatches(repoRoot, newRef, oldRef, readyItems);
-  /** @type {Array<ChangedFile>} */
-  const files = status
-    .map((item) =>
-      createCommitFile(
-        newRef,
-        item,
-        oldFiles.get(item.oldPath || item.path) ||
-          createEmptyFileContent(item.oldPath || item.path),
-        newFiles.get(item.path) || createEmptyFileContent(item.path),
-        patches.get(item.path) || '',
-      ),
-    )
-    .sort(fileSort);
 
-  return {
-    files,
-    generatedAt: Date.now(),
+/**
+ * @param {string} launchPath @param {string} base @param {string} head @param {boolean} symmetric @param {string} requestedPath @param {{encoding?: BufferEncoding, force?: boolean}} [options]
+ */
+const readRangeSectionContent = (launchPath, base, head, symmetric, requestedPath, options = {}) =>
+  readComparisonSourceSectionContent(
     launchPath,
-    root: repoRoot,
-    source: {
+    {
       base,
       head,
       symmetric,
       type: 'range',
     },
-  };
-};
+    requestedPath,
+    options,
+  );
 
 /**
- * Lazy section content for a ref range. Mirrors {@link readCommitSectionContent}.
- * @param {string} launchPath @param {string} base @param {string} head @param {boolean} symmetric @param {string} requestedPath @param {{encoding?: BufferEncoding, force?: boolean}} [options]
+ * @param {string} launchPath @param {string} base @param {string} head @param {boolean} symmetric @param {string} requestedPath
+ * @returns {Promise<DiffImageContentResult>}
  */
-const readRangeSectionContent = async (
-  launchPath,
-  base,
-  head,
-  symmetric,
-  requestedPath,
-  options = {},
-) => {
-  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
-  const path = validateRepositoryPath(requestedPath);
-  const { newRef, oldRef } = await resolveRangeRefs(repoRoot, base, head, symmetric);
-  const status = await readCommitNameStatus(repoRoot, newRef, oldRef, { sort: false });
-  const item = status.find((candidate) => candidate.path === path);
-  if (!item) {
-    throw new Error('File is not part of this range.');
-  }
+const readRangeImageContent = (launchPath, base, head, symmetric, requestedPath) =>
+  readComparisonSourceImageContent(
+    launchPath,
+    {
+      base,
+      head,
+      symmetric,
+      type: 'range',
+    },
+    requestedPath,
+  );
 
-  const [oldFiles, newFiles] = await Promise.all([
-    readGitFiles(repoRoot, oldRef, [item.oldPath || item.path], options),
-    readGitFiles(repoRoot, newRef, [item.path], options),
-  ]);
-  const oldFile =
-    oldFiles.get(item.oldPath || item.path) || createEmptyFileContent(item.oldPath || item.path);
-  const newFile = newFiles.get(item.path) || createEmptyFileContent(item.path);
-  const summary = summarizeContent(oldFile, newFile);
-  const patch =
-    summary.loadState === 'ready' ? await readCommitPatch(repoRoot, newRef, oldRef, item.path) : '';
+/** @param {string} launchPath @param {string | BranchSource | BranchDiffSource} input @returns {Promise<RepositoryState>} */
+const readBranchState = (launchPath, input) =>
+  readComparisonSourceState(launchPath, normalizeBranchSourceInput(input));
 
-  return createCommitSection(newRef, item, oldFile, newFile, patch);
-};
+/**
+ * @param {string} launchPath
+ * @param {string | BranchSource | BranchDiffSource} input
+ * @param {string} requestedPath
+ * @param {{force?: boolean}} [options]
+ */
+const readBranchSectionContent = (launchPath, input, requestedPath, options = {}) =>
+  readComparisonSourceSectionContent(
+    launchPath,
+    normalizeBranchSourceInput(input),
+    requestedPath,
+    options,
+  );
 
-/** @param {string} launchPath @param {ReviewSource} [source] @returns {Promise<RepositoryState>} */
-const readRepositoryState = async (launchPath, source = { type: 'working-tree' }) =>
-  source.type === 'pull-request'
-    ? readPullRequestState(launchPath, source)
-    : source.type === 'commit'
-      ? readCommitState(launchPath, source.ref)
-      : source.type === 'branch'
-        ? readBranchState(launchPath, source.ref)
-        : readWorkingTreeState(launchPath);
+/**
+ * @param {string} launchPath
+ * @param {string | BranchSource | BranchDiffSource} input
+ * @param {string} requestedPath
+ * @returns {Promise<DiffImageContentResult>}
+ */
+const readBranchImageContent = (launchPath, input, requestedPath) =>
+  readComparisonSourceImageContent(launchPath, normalizeBranchSourceInput(input), requestedPath);
 
 /** @param {string} launchPath @param {number} [limit] @param {string} [ref] */
 const listRepositoryHistory = async (launchPath, limit = 200, ref = 'HEAD') => {
   const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
   try {
-    await git(repoRoot, ['rev-parse', '--verify', `${ref}^{commit}`]);
+    if (ref.includes('..')) {
+      await git(repoRoot, ['rev-list', '--max-count=1', ref]);
+    } else {
+      await git(repoRoot, ['rev-parse', '--verify', `${ref}^{commit}`]);
+    }
   } catch {
     return {
       entries: [],
@@ -779,10 +435,13 @@ const listRepositoryHistory = async (launchPath, limit = 200, ref = 'HEAD') => {
 module.exports = {
   listRepositoryHistory,
   parseCommitNameStatus,
+  readBranchImageContent,
+  readBranchSectionContent,
   readBranchState,
   readCommitImageContent,
   readCommitSectionContent,
   readCommitState,
+  readRangeImageContent,
   readRangeSectionContent,
   readRangeState,
 };

--- a/electron/git-state/comparison.cjs
+++ b/electron/git-state/comparison.cjs
@@ -1,0 +1,540 @@
+// @ts-check
+
+const {
+  EAGER_TEXT_FILE_LIMIT,
+  MANUAL_TEXT_FILE_LIMIT,
+  bufferToTextFile,
+  createSummary,
+  fileSort,
+  formatBytes,
+  getFingerprint,
+  git,
+  gitBufferWithInput,
+  readGitImageFile,
+  summarizeContent,
+  validateRepositoryPath,
+} = require('./common.cjs');
+
+/**
+ * @typedef {import('../../src/types.ts').ChangedFile} ChangedFile
+ * @typedef {import('../../src/types.ts').DiffImageContentResult} DiffImageContentResult
+ * @typedef {import('../../src/types.ts').RepositoryState} RepositoryState
+ * @typedef {import('../../src/types.ts').ReviewSource} ReviewSource
+ * @typedef {import('./common.cjs').StatusItem} StatusItem
+ */
+
+/** @param {string} newRef @param {string | undefined} oldRef @param {ReadonlyArray<string>} paths */
+const createComparisonPatchArgs = (newRef, oldRef, paths) =>
+  oldRef
+    ? ['diff', '--patch', '--no-ext-diff', '--find-renames', oldRef, newRef, '--', ...paths]
+    : ['show', '--format=', '--patch', '--no-ext-diff', '--find-renames', newRef, '--', ...paths];
+
+/** @param {string} repoRoot @param {string} newRef @param {string | undefined} oldRef @param {string} path */
+const readComparisonPatch = (repoRoot, newRef, oldRef, path) =>
+  git(repoRoot, createComparisonPatchArgs(newRef, oldRef, [path]));
+
+/** @param {ReadonlyArray<string>} values @param {number} size */
+const chunk = (values, size) => {
+  /** @type {Array<Array<string>>} */
+  const chunks = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+  return chunks;
+};
+
+/** @param {string} patch */
+const splitCommitPatch = (patch) =>
+  patch
+    .split(/(?=^diff --git )/m)
+    .map((part) => part.trimEnd())
+    .filter((part) => part.startsWith('diff --git '))
+    .map((part) => `${part}\n`);
+
+/**
+ * @param {string} repoRoot
+ * @param {string} ref
+ * @param {ReadonlyArray<string>} paths
+ */
+const readTreeEntries = async (repoRoot, ref, paths) => {
+  /** @type {Map<string, {object: string; type: string}>} */
+  const entries = new Map();
+  const uniquePaths = [...new Set(paths)];
+
+  for (const pathChunk of chunk(uniquePaths, 200)) {
+    if (pathChunk.length === 0) {
+      continue;
+    }
+
+    const raw = await git(repoRoot, ['ls-tree', '-rz', ref, '--', ...pathChunk]);
+    for (const record of raw.split('\0')) {
+      if (!record) {
+        continue;
+      }
+
+      const tabIndex = record.indexOf('\t');
+      if (tabIndex === -1) {
+        continue;
+      }
+
+      const [mode, type, object] = record.slice(0, tabIndex).split(' ');
+      const path = record.slice(tabIndex + 1);
+      if (mode && type && object) {
+        entries.set(path, { object, type });
+      }
+    }
+  }
+
+  return entries;
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {ReadonlyArray<string>} objects
+ */
+const readObjectSizes = async (repoRoot, objects) => {
+  /** @type {Map<string, {size: number; type: string}>} */
+  const sizes = new Map();
+  const uniqueObjects = [...new Set(objects)];
+  if (uniqueObjects.length === 0) {
+    return sizes;
+  }
+
+  const output = (
+    await gitBufferWithInput(
+      repoRoot,
+      ['cat-file', '--batch-check=%(objectname) %(objecttype) %(objectsize)'],
+      `${uniqueObjects.join('\n')}\n`,
+    )
+  ).toString('utf8');
+
+  for (const line of output.split('\n')) {
+    if (!line) {
+      continue;
+    }
+
+    const [object, type, size] = line.split(' ');
+    if (object && type && size && type !== 'missing') {
+      sizes.set(object, {
+        size: Number(size),
+        type,
+      });
+    }
+  }
+
+  return sizes;
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {ReadonlyArray<{object: string; size: number}>} objects
+ */
+const readObjectContents = async (repoRoot, objects) => {
+  /** @type {Map<string, Buffer>} */
+  const contents = new Map();
+  /** @type {Array<{object: string; size: number}>} */
+  let batch = [];
+  let batchSize = 0;
+
+  const flush = async () => {
+    if (batch.length === 0) {
+      return;
+    }
+
+    const output = await gitBufferWithInput(
+      repoRoot,
+      ['cat-file', '--batch'],
+      `${batch.map((item) => item.object).join('\n')}\n`,
+    );
+    let offset = 0;
+
+    for (const item of batch) {
+      const headerEnd = output.indexOf(10, offset);
+      if (headerEnd === -1) {
+        break;
+      }
+
+      const header = output.subarray(offset, headerEnd).toString('utf8');
+      const [, type, sizeText] = header.split(' ');
+      const size = Number(sizeText);
+      const contentStart = headerEnd + 1;
+      const contentEnd = contentStart + size;
+
+      if (type === 'blob' && Number.isFinite(size)) {
+        contents.set(item.object, output.subarray(contentStart, contentEnd));
+      }
+
+      offset = contentEnd + 1;
+    }
+
+    batch = [];
+    batchSize = 0;
+  };
+
+  for (const item of objects) {
+    if (batchSize > 0 && batchSize + item.size > 32 * 1024 * 1024) {
+      await flush();
+    }
+
+    batch.push(item);
+    batchSize += item.size;
+  }
+
+  await flush();
+  return contents;
+};
+
+/**
+ * @param {number} size
+ * @param {number} limit
+ */
+const createLargeBlobResult = (size, limit) => ({
+  binary: false,
+  loadState: size > MANUAL_TEXT_FILE_LIMIT ? 'too-large' : 'deferred',
+  summary: createSummary(
+    size > MANUAL_TEXT_FILE_LIMIT
+      ? `File is ${formatBytes(size)}, so Codiff skipped rendering it.`
+      : `File is ${formatBytes(size)} and will be loaded on demand.`,
+    {
+      canLoad: size <= MANUAL_TEXT_FILE_LIMIT,
+      limit,
+      size,
+    },
+  ),
+});
+
+/**
+ * @param {string} path
+ */
+const createEmptyFileContent = (path) => ({
+  binary: false,
+  file: {
+    cacheKey: `empty:${path}`,
+    contents: '',
+    name: path,
+  },
+});
+
+/**
+ * @param {string} repoRoot
+ * @param {string} ref
+ * @param {ReadonlyArray<string>} paths
+ * @param {{force?: boolean}} [options]
+ */
+const readGitFiles = async (repoRoot, ref, paths, options = {}) => {
+  const limit = options.force ? MANUAL_TEXT_FILE_LIMIT : EAGER_TEXT_FILE_LIMIT;
+  const entries = await readTreeEntries(repoRoot, ref, paths);
+  const sizes = await readObjectSizes(
+    repoRoot,
+    [...entries.values()].filter((entry) => entry.type === 'blob').map((entry) => entry.object),
+  );
+  const readableObjects = [...entries.values()]
+    .map((entry) => {
+      const object = sizes.get(entry.object);
+      return object && object.type === 'blob' && object.size <= limit
+        ? {
+            object: entry.object,
+            size: object.size,
+          }
+        : null;
+    })
+    .filter(Boolean);
+  const contents = await readObjectContents(repoRoot, readableObjects);
+  /** @type {Map<string, ReturnType<typeof createEmptyFileContent> | import('./common.cjs').FileContentResult>} */
+  const files = new Map();
+
+  for (const path of paths) {
+    const entry = entries.get(path);
+    if (!entry) {
+      files.set(path, createEmptyFileContent(path));
+      continue;
+    }
+
+    const object = sizes.get(entry.object);
+    if (!object || object.type !== 'blob') {
+      files.set(path, createEmptyFileContent(path));
+      continue;
+    }
+
+    if (object.size > limit) {
+      files.set(path, createLargeBlobResult(object.size, limit));
+      continue;
+    }
+
+    const buffer = contents.get(entry.object);
+    files.set(
+      path,
+      buffer
+        ? bufferToTextFile(path, buffer, `${ref}:${path}`)
+        : {
+            binary: false,
+            file: {
+              cacheKey: `${ref}:${path}:empty`,
+              contents: '',
+              name: path,
+            },
+          },
+    );
+  }
+
+  return files;
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {string} newRef
+ * @param {string | undefined} oldRef
+ * @param {ReadonlyArray<Pick<StatusItem, 'path'>>} items
+ */
+const readComparisonPatches = async (repoRoot, newRef, oldRef, items) => {
+  /** @type {Map<string, string>} */
+  const patches = new Map();
+
+  for (const itemChunk of chunk(
+    items.map((item) => item.path),
+    200,
+  )) {
+    if (itemChunk.length === 0) {
+      continue;
+    }
+
+    const patch = await git(repoRoot, createComparisonPatchArgs(newRef, oldRef, itemChunk));
+    const patchChunks = splitCommitPatch(patch);
+
+    if (patchChunks.length === itemChunk.length) {
+      for (let index = 0; index < itemChunk.length; index += 1) {
+        patches.set(itemChunk[index], patchChunks[index]);
+      }
+    } else {
+      await Promise.all(
+        itemChunk.map(async (path) => {
+          patches.set(path, await readComparisonPatch(repoRoot, newRef, oldRef, path));
+        }),
+      );
+    }
+  }
+
+  return patches;
+};
+
+/**
+ * @param {string} ref
+ * @param {Pick<StatusItem, 'oldPath' | 'path' | 'status'>} item
+ * @param {ReturnType<typeof createEmptyFileContent>} oldFile
+ * @param {ReturnType<typeof createEmptyFileContent>} newFile
+ * @param {string} patch
+ */
+const createComparisonFile = (ref, item, oldFile, newFile, patch) => {
+  const summary = summarizeContent(oldFile, newFile);
+
+  return {
+    fingerprint: getFingerprint(
+      `${ref}\n${item.status}\n${item.oldPath || ''}\n${summary.loadState || 'ready'}\n${
+        summary.summary?.reason || ''
+      }\n${summary.summary?.fingerprint || ''}\n${patch}\n${oldFile.file?.contents || ''}\n${
+        newFile.file?.contents || ''
+      }`,
+    ),
+    oldPath: item.oldPath,
+    path: item.path,
+    sections: [
+      {
+        binary: summary.binary || /Binary files .* differ/.test(patch),
+        id: `${item.path}:${ref}`,
+        kind: 'commit',
+        loadState: summary.loadState,
+        newFile: newFile.file,
+        oldFile: oldFile.file,
+        patch,
+        summary: summary.summary,
+      },
+    ],
+    status: item.status,
+  };
+};
+
+/**
+ * @param {string} ref
+ * @param {Pick<StatusItem, 'oldPath' | 'path' | 'status'>} item
+ * @param {ReturnType<typeof createEmptyFileContent>} oldFile
+ * @param {ReturnType<typeof createEmptyFileContent>} newFile
+ * @param {string} patch
+ */
+const createComparisonSection = (ref, item, oldFile, newFile, patch) =>
+  createComparisonFile(ref, item, oldFile, newFile, patch).sections[0];
+
+/**
+ * @param {Map<string, ReturnType<typeof createEmptyFileContent> | import('./common.cjs').FileContentResult>} oldFiles
+ * @param {string | undefined} oldRef
+ * @param {Pick<StatusItem, 'oldPath' | 'path'>} item
+ */
+const getOldComparisonFile = (oldFiles, oldRef, item) =>
+  oldRef
+    ? oldFiles.get(item.oldPath || item.path) || createEmptyFileContent(item.oldPath || item.path)
+    : createEmptyFileContent(item.oldPath || item.path);
+
+/**
+ * @param {string} repoRoot
+ * @param {string} newRef
+ * @param {string | undefined} oldRef
+ * @param {ReadonlyArray<Pick<StatusItem, 'oldPath' | 'path' | 'status'>>} status
+ * @param {{force?: boolean}} [options]
+ */
+const readComparisonFiles = async (repoRoot, newRef, oldRef, status, options = {}) => {
+  const [oldFiles, newFiles] = await Promise.all([
+    oldRef
+      ? readGitFiles(
+          repoRoot,
+          oldRef,
+          status.map((item) => item.oldPath || item.path),
+          options,
+        )
+      : Promise.resolve(new Map()),
+    readGitFiles(
+      repoRoot,
+      newRef,
+      status.map((item) => item.path),
+      options,
+    ),
+  ]);
+
+  return { newFiles, oldFiles };
+};
+
+/**
+ * @param {{
+ *   launchPath: string;
+ *   newRef: string;
+ *   oldRef?: string;
+ *   repoRoot: string;
+ *   source: ReviewSource;
+ *   status: ReadonlyArray<Pick<StatusItem, 'oldPath' | 'path' | 'status'>>;
+ * }} input
+ * @returns {Promise<RepositoryState>}
+ */
+const readComparisonState = async ({ launchPath, newRef, oldRef, repoRoot, source, status }) => {
+  const { oldFiles, newFiles } = await readComparisonFiles(repoRoot, newRef, oldRef, status);
+  const readyItems = status.filter((item) => {
+    const oldFile = getOldComparisonFile(oldFiles, oldRef, item);
+    const newFile = newFiles.get(item.path) || createEmptyFileContent(item.path);
+    return summarizeContent(oldFile, newFile).loadState === 'ready';
+  });
+  const patches = await readComparisonPatches(repoRoot, newRef, oldRef, readyItems);
+  /** @type {Array<ChangedFile>} */
+  const files = status
+    .map((item) =>
+      createComparisonFile(
+        newRef,
+        item,
+        getOldComparisonFile(oldFiles, oldRef, item),
+        newFiles.get(item.path) || createEmptyFileContent(item.path),
+        patches.get(item.path) || '',
+      ),
+    )
+    .sort(fileSort);
+
+  return {
+    files,
+    generatedAt: Date.now(),
+    launchPath,
+    root: repoRoot,
+    source,
+  };
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {string} newRef
+ * @param {string | undefined} oldRef
+ * @param {ReadonlyArray<Pick<StatusItem, 'oldPath' | 'path' | 'status'>>} status
+ * @param {string} requestedPath
+ * @param {string} sourceLabel
+ * @param {{force?: boolean}} [options]
+ */
+const readComparisonSectionContent = async (
+  repoRoot,
+  newRef,
+  oldRef,
+  status,
+  requestedPath,
+  sourceLabel,
+  options = {},
+) => {
+  const path = validateRepositoryPath(requestedPath);
+  const item = status.find((candidate) => candidate.path === path);
+  if (!item) {
+    throw new Error(`File is not part of this ${sourceLabel}.`);
+  }
+
+  const { oldFiles, newFiles } = await readComparisonFiles(
+    repoRoot,
+    newRef,
+    oldRef,
+    [item],
+    options,
+  );
+  const oldFile = getOldComparisonFile(oldFiles, oldRef, item);
+  const newFile = newFiles.get(item.path) || createEmptyFileContent(item.path);
+  const summary = summarizeContent(oldFile, newFile);
+  const patch =
+    summary.loadState === 'ready'
+      ? await readComparisonPatch(repoRoot, newRef, oldRef, item.path)
+      : '';
+
+  return createComparisonSection(newRef, item, oldFile, newFile, patch);
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {string} newRef
+ * @param {string | undefined} oldRef
+ * @param {ReadonlyArray<Pick<StatusItem, 'oldPath' | 'path' | 'status'>>} status
+ * @param {string} requestedPath
+ * @param {string} sourceLabel
+ * @returns {Promise<DiffImageContentResult>}
+ */
+const readComparisonImageContent = async (
+  repoRoot,
+  newRef,
+  oldRef,
+  status,
+  requestedPath,
+  sourceLabel,
+) => {
+  try {
+    const path = validateRepositoryPath(requestedPath);
+    const item = status.find((candidate) => candidate.path === path);
+    if (!item) {
+      throw new Error(`File is not part of this ${sourceLabel}.`);
+    }
+
+    const [oldImage, newImage] = await Promise.all([
+      oldRef ? readGitImageFile(repoRoot, oldRef, item.oldPath || item.path) : undefined,
+      readGitImageFile(repoRoot, newRef, item.path),
+    ]);
+
+    if (!oldImage && !newImage) {
+      return {
+        reason: 'Codiff could not load either side of this image.',
+        status: 'unavailable',
+      };
+    }
+
+    return {
+      ...(newImage ? { newImage } : {}),
+      ...(oldImage ? { oldImage } : {}),
+      status: 'ready',
+    };
+  } catch (error) {
+    return {
+      reason: error instanceof Error ? error.message : 'Codiff could not load this image.',
+      status: 'unavailable',
+    };
+  }
+};
+
+module.exports = {
+  readComparisonImageContent,
+  readComparisonSectionContent,
+  readComparisonState,
+};

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -862,6 +862,12 @@ ipcMain.handle('codiff:getRepositoryState', async (event, source) => {
   const state = initialState
     ? await initialState
     : await readRepositoryState(repositoryPath, source || launchOptions?.source);
+  if (launchOptions) {
+    windowLaunchOptions.set(event.sender.id, {
+      ...launchOptions,
+      source: state.source,
+    });
+  }
   rememberLastRepositoryPath(state.root);
   const identity = getWindowIdentityForSource(state.root, state.source);
   if (identity) {

--- a/electron/window-identity.cjs
+++ b/electron/window-identity.cjs
@@ -48,6 +48,19 @@ const resolveCommitRef = (repositoryRoot, ref) => {
   }
 };
 
+/** @param {string} repositoryRoot @param {string} baseRef @param {string} headRef */
+const resolveMergeBase = (repositoryRoot, baseRef, headRef) => {
+  try {
+    return execFileSync('git', ['-C', repositoryRoot, 'merge-base', baseRef, headRef], {
+      encoding: 'utf8',
+    })
+      .trim()
+      .toLowerCase();
+  } catch {
+    return null;
+  }
+};
+
 /** @param {string} value @returns {ParsedPullRequest | null} */
 const parseGitHubPullRequestUrl = (value) => {
   try {
@@ -99,7 +112,16 @@ const getSourceKey = (repositoryRoot, source = { type: 'working-tree' }) => {
   }
 
   if (source.type === 'branch') {
-    return resolveCommitRef(repositoryRoot, source.ref) ? `branch:${source.ref}` : null;
+    const head = resolveCommitRef(repositoryRoot, 'HEAD');
+    const target = resolveCommitRef(repositoryRoot, source.ref);
+    const nextBase = target && head ? resolveMergeBase(repositoryRoot, target, head) : null;
+    return nextBase && head ? `branch-diff:${source.ref}:${nextBase}:${head}` : null;
+  }
+
+  if (source.type === 'branch-diff') {
+    const base = resolveCommitRef(repositoryRoot, source.baseRef);
+    const head = resolveCommitRef(repositoryRoot, source.headRef);
+    return base && head ? `branch-diff:${source.ref}:${base}:${head}` : null;
   }
 
   if (source.type === 'pull-request') {

--- a/src/App.css
+++ b/src/App.css
@@ -603,10 +603,10 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  gap: 6px;
+  gap: 2px;
   min-height: 0;
   overflow: auto;
-  padding: 8px;
+  padding: 8px 6px;
 }
 
 .history-entry {
@@ -618,9 +618,10 @@
   corner-shape: squircle;
   cursor: pointer;
   display: grid;
-  gap: 6px;
-  grid-template-columns: 74px minmax(0, 1fr);
-  padding: 4px;
+  column-gap: 8px;
+  grid-template-columns: 72px minmax(0, 1fr);
+  padding: 3px 5px;
+  row-gap: 2px;
   text-align: left;
   width: 100%;
 }
@@ -639,14 +640,19 @@
   color: var(--text);
   display: flex;
   font: 700 11px/1.25 var(--font-sans);
-  min-height: 24px;
+  margin-top: 8px;
+  min-height: 20px;
   overflow: hidden;
-  padding: 6px 10px 2px;
+  padding: 4px 10px 1px;
   position: relative;
   text-overflow: ellipsis;
   text-transform: uppercase;
   white-space: nowrap;
   z-index: 1;
+}
+
+.history-list > .history-section:first-child {
+  margin-top: 0;
 }
 
 .history-entry-subject {
@@ -659,7 +665,7 @@
   align-self: center;
   color: var(--sidebar-ref);
   font: 12px/1.35 var(--font-mono);
-  justify-self: center;
+  justify-self: start;
   min-width: 0;
   white-space: nowrap;
 }
@@ -673,7 +679,6 @@
   color: var(--text);
   font: 12px/1.35 var(--font-sans);
   min-width: 0;
-  padding-inline: 4px;
 }
 
 .history-entry-meta {
@@ -683,7 +688,6 @@
   font: 10px/1.2 var(--font-sans);
   gap: 8px;
   justify-content: space-between;
-  padding-inline: 4px;
   white-space: nowrap;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,7 @@ import { isNativeInputTarget } from './lib/keyboard.ts';
 import {
   consumeReloadSelection,
   getReloadDeltaPaths,
+  getReloadHistorySource,
   getReloadSelectionPath,
   writeReloadSelection,
 } from './lib/reload-selection.ts';
@@ -77,7 +78,18 @@ import {
   writeSidebarCollapsed,
   writeSidebarWidth,
 } from './lib/sidebar-width.ts';
-import { getRepositoryLoadError, getShortRef, getSourceKey, getSourceLabel } from './lib/source.ts';
+import {
+  getEmptySourceDetail,
+  getEmptySourceTitle,
+  getHistorySource,
+  getRepositoryLoadError,
+  getSourceKey,
+  getSourceLabel,
+  shouldStartInHistoryWhenEmpty,
+  supportsDiffSearchContentPreload,
+  supportsLazyDiffContent,
+  usesViewedFileState,
+} from './lib/source.ts';
 import { readViewed, writeViewed } from './lib/viewed.ts';
 import type {
   ChangedFile,
@@ -133,6 +145,23 @@ const createInlineWalkthroughNote = (reason: string): WalkthroughNote => ({
 
 const defaultPreferences = getPreferencesFromConfig(createDefaultConfig());
 
+const getReloadSourceForLaunch = (
+  reloadSelection: ReturnType<typeof consumeReloadSelection>,
+  launchOptions: CodiffLaunchOptions,
+) => {
+  if (!reloadSelection) {
+    return undefined;
+  }
+
+  if (!launchOptions.source) {
+    return reloadSelection.source;
+  }
+
+  return getSourceKey(reloadSelection.source) === getSourceKey(launchOptions.source)
+    ? reloadSelection.source
+    : undefined;
+};
+
 export default function App() {
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
   const [activeDiffSearchMatchIndex, setActiveDiffSearchMatchIndex] = useState(0);
@@ -182,6 +211,7 @@ export default function App() {
   const [walkthroughLoading, setWalkthroughLoading] = useState(false);
   const [walkthroughUnread, setWalkthroughUnread] = useState(false);
   const historyRequestRef = useRef(0);
+  const historySourceRef = useRef<ReviewSource | null>(null);
   const loadingSectionKeysRef = useRef<Set<string>>(new Set());
   const programmaticScrollPathRef = useRef<string | null>(null);
   const programmaticScrollTimerRef = useRef<number | null>(null);
@@ -228,9 +258,7 @@ export default function App() {
       const currentState = repositoryState;
       if (
         !currentState ||
-        (currentState.source.type !== 'working-tree' &&
-          currentState.source.type !== 'commit' &&
-          currentState.source.type !== 'range') ||
+        !supportsLazyDiffContent(currentState.source) ||
         !shouldLoadDiffSectionContents(section)
       ) {
         return;
@@ -378,7 +406,9 @@ export default function App() {
       }
       setTerminalHelperStatus(nextTerminalHelperStatus);
 
-      const nextState = await window.codiff.getRepositoryState(reloadSelection?.source);
+      const nextState = await window.codiff.getRepositoryState(
+        getReloadSourceForLaunch(reloadSelection, nextLaunchOptions),
+      );
 
       if (canceled) {
         return;
@@ -388,11 +418,12 @@ export default function App() {
         ...nextState,
         files: sortFiles(nextState.files),
       };
+      const nextHistorySource =
+        getReloadHistorySource(reloadSelection, orderedState) ??
+        getHistorySource(orderedState.source);
       const history = await window.codiff.getRepositoryHistory(
         HISTORY_PAGE_SIZE,
-        orderedState.source.type === 'pull-request' || orderedState.source.type === 'branch'
-          ? orderedState.source
-          : undefined,
+        nextHistorySource,
       );
 
       if (canceled) {
@@ -402,8 +433,7 @@ export default function App() {
       const filesPresent = orderedState.files.length > 0;
       const shouldLoadNarrative = nextLaunchOptions.walkthrough && filesPresent;
       const shouldStartInHistory =
-        (orderedState.source.type === 'working-tree' || orderedState.source.type === 'branch') &&
-        orderedState.files.length === 0;
+        shouldStartInHistoryWhenEmpty(orderedState.source) && orderedState.files.length === 0;
 
       setLaunchOptions(nextLaunchOptions);
       setSidebarMode(
@@ -429,19 +459,16 @@ export default function App() {
 
       setWalkthroughLoading(false);
 
-      const nextViewed =
-        orderedState.source.type === 'working-tree' ? readViewed(orderedState.root) : {};
+      const nextViewed = usesViewedFileState(orderedState.source)
+        ? readViewed(orderedState.root)
+        : {};
       const reloadSelectedPath = getReloadSelectionPath(reloadSelection, orderedState);
       const nextReloadDeltaPaths = getReloadDeltaPaths(reloadSelection, orderedState);
 
       setHistoryEntries(history.entries);
       setHistoryHasMore(history.entries.length >= HISTORY_PAGE_SIZE);
       setHistoryLimit(HISTORY_PAGE_SIZE);
-      setHistorySource(
-        orderedState.source.type === 'pull-request' || orderedState.source.type === 'branch'
-          ? orderedState.source
-          : null,
-      );
+      setHistorySource(nextHistorySource ?? null);
       setState(orderedState);
       setLoadError(null);
       setCollapsed(
@@ -508,13 +535,7 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    if (
-      !state ||
-      (state.source.type !== 'working-tree' &&
-        state.source.type !== 'commit' &&
-        state.source.type !== 'range') ||
-      !selectedPath
-    ) {
+    if (!state || !supportsLazyDiffContent(state.source) || !selectedPath) {
       return;
     }
 
@@ -535,7 +556,7 @@ export default function App() {
   }, [loadDiffSection, selectedPath, state]);
 
   useEffect(() => {
-    if (!state || state.source.type !== 'working-tree' || !diffSearchQuery.trim()) {
+    if (!state || !supportsDiffSearchContentPreload(state.source) || !diffSearchQuery.trim()) {
       return;
     }
 
@@ -696,6 +717,10 @@ export default function App() {
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
+
+  useEffect(() => {
+    historySourceRef.current = historySource;
+  }, [historySource]);
 
   useEffect(() => {
     sidebarModeRef.current = sidebarMode;
@@ -1044,7 +1069,7 @@ export default function App() {
 
   useEffect(() => {
     const writeCurrentReloadSelection = () => {
-      writeReloadSelection(stateRef.current, selectedPathRef.current);
+      writeReloadSelection(stateRef.current, selectedPathRef.current, historySourceRef.current);
     };
 
     window.addEventListener('beforeunload', writeCurrentReloadSelection);
@@ -1086,7 +1111,7 @@ export default function App() {
           const session = sourceSessionsRef.current.get(getSourceKey(orderedState.source));
           const nextViewed =
             session?.viewed ??
-            (orderedState.source.type === 'working-tree' ? readViewed(orderedState.root) : {});
+            (usesViewedFileState(orderedState.source) ? readViewed(orderedState.root) : {});
           const nextSelectedPath =
             session?.selectedPath &&
             orderedState.files.some((file) => file.path === session.selectedPath)
@@ -1101,12 +1126,7 @@ export default function App() {
             );
 
           setState(orderedState);
-          if (
-            orderedState.source.type === 'pull-request' ||
-            orderedState.source.type === 'branch'
-          ) {
-            setHistorySource(orderedState.source);
-          }
+          setHistorySource(getHistorySource(orderedState.source) ?? historySource);
           setCollapsed(new Set(nextCollapsed));
           setItemVersionByPath({});
           setReviewComments(session?.reviewComments ?? getReviewCommentsFromState(orderedState));
@@ -1128,7 +1148,7 @@ export default function App() {
           }
         });
     },
-    [pendingSource, saveCurrentSourceSession],
+    [historySource, pendingSource, saveCurrentSourceSession],
   );
 
   const resizeSidebar = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
@@ -1872,6 +1892,7 @@ export default function App() {
   const sidebarLabel = `${compactPath(state.root)}${state.branch ? ` (${state.branch})` : ''}`;
   const sidebarSourceLabel =
     state.source.type !== 'working-tree' ? ` · ${getSourceLabel(state.source)}` : '';
+  const emptySourceDetail = getEmptySourceDetail(state.source, state.root);
 
   const showNarrativeWalkthrough = narrativeWalkthrough != null && sidebarMode === 'walkthrough';
   // Props shared by the full review and the per-stop scoped diffs, so the two
@@ -2035,7 +2056,7 @@ export default function App() {
           </div>
         </div>
         <Sidebar
-          branchSource={historySource?.type === 'branch' ? historySource : null}
+          branchSource={historySource?.type === 'branch-diff' ? historySource : null}
           currentSource={pendingSource ?? state.source}
           files={visibleFiles}
           historyEntries={historyEntries}
@@ -2090,21 +2111,13 @@ export default function App() {
         ) : state.files.length === 0 ? (
           <div className="empty-state">
             <div className="empty-panel squircle">
-              <strong>
-                {state.source.type === 'commit'
-                  ? 'No changes in commit'
-                  : state.source.type === 'branch'
-                    ? 'Branch history'
-                    : 'No local changes'}
-              </strong>
-              {state.source.type === 'commit' ? (
-                <span>{getShortRef(state.source.ref)}</span>
-              ) : state.source.type === 'branch' ? (
-                <span>{state.source.ref}</span>
-              ) : (
-                <code className="walkthrough-inline-code" title={state.root}>
-                  {compactPath(state.root)}
+              <strong>{getEmptySourceTitle(state.source)}</strong>
+              {emptySourceDetail.kind === 'code' ? (
+                <code className="walkthrough-inline-code" title={emptySourceDetail.title}>
+                  {emptySourceDetail.text}
                 </code>
+              ) : (
+                <span>{emptySourceDetail.text}</span>
               )}
             </div>
           </div>

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -323,6 +323,241 @@ test('repository reload restores the selected file from the previous source', as
   }
 });
 
+test('repository reload preserves a branch diff source even without a selected file', async () => {
+  const source = {
+    baseRef: 'base123',
+    headRef: 'head123',
+    ref: 'main',
+    type: 'branch-diff',
+  } satisfies ReviewSource;
+  const nextState = {
+    ...repositoryState,
+    files: [],
+    source,
+  } satisfies RepositoryState;
+  const getRepositoryState = vi.fn(async (requestedSource?: ReviewSource) =>
+    requestedSource?.type === 'branch-diff' ? nextState : repositoryState,
+  );
+
+  writeReloadSelection(nextState, null);
+
+  window.codiff = createCodiffMock({
+    getRepositoryState,
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+    });
+    expect(getRepositoryState).toHaveBeenCalledWith(source);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('branch history keeps branch diff available after selecting uncommitted changes', async () => {
+  const branchSource = {
+    baseRef: 'base123',
+    headRef: 'head123',
+    ref: 'main',
+    type: 'branch-diff',
+  } satisfies ReviewSource;
+  const branchState = {
+    ...repositoryState,
+    branch: 'fork',
+    source: branchSource,
+  } satisfies RepositoryState;
+  const workingTreeState = {
+    ...repositoryState,
+    branch: 'fork',
+    source: { type: 'working-tree' },
+  } satisfies RepositoryState;
+  const getRepositoryState = vi.fn(async (requestedSource?: ReviewSource) =>
+    requestedSource?.type === 'working-tree' ? workingTreeState : branchState,
+  );
+
+  window.codiff = createCodiffMock({
+    getRepositoryHistory: vi.fn(async () => ({
+      entries: [
+        {
+          author: 'Reviewer',
+          committedAt: Date.now(),
+          parents: [],
+          ref: '99e7b27',
+          subject: 'Add branch diff review mode',
+        },
+      ],
+      root: '/repo',
+    })),
+    getRepositoryState,
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  const findButton = (label: string) =>
+    Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes(label),
+    );
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+      expect(findButton('Branch diff')).toBeTruthy();
+    });
+
+    await act(async () => {
+      findButton('Uncommitted')?.click();
+    });
+
+    await waitFor(() => {
+      expect(getRepositoryState).toHaveBeenCalledWith({ type: 'working-tree' });
+      expect(findButton('Branch diff')).toBeTruthy();
+    });
+
+    await act(async () => {
+      findButton('Branch diff')?.click();
+    });
+
+    await waitFor(() => {
+      expect(getRepositoryState).toHaveBeenCalledWith(branchSource);
+    });
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('repository reload restores branch diff scope after selecting uncommitted changes', async () => {
+  const branchSource = {
+    baseRef: 'base123',
+    headRef: 'head123',
+    ref: 'main',
+    type: 'branch-diff',
+  } satisfies ReviewSource;
+  const workingTreeState = {
+    ...repositoryState,
+    branch: 'fork',
+    source: { type: 'working-tree' },
+  } satisfies RepositoryState;
+  const getRepositoryHistory = vi.fn(async () => ({
+    entries: [
+      {
+        author: 'Reviewer',
+        committedAt: Date.now(),
+        parents: [],
+        ref: '99e7b27',
+        subject: 'Add branch diff review mode',
+      },
+    ],
+    root: '/repo',
+  }));
+  const getRepositoryState = vi.fn(async () => workingTreeState);
+
+  writeReloadSelection(workingTreeState, null, branchSource);
+
+  window.codiff = createCodiffMock({
+    getRepositoryHistory,
+    getRepositoryState,
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  const findButton = (label: string) =>
+    Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes(label),
+    );
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+      expect(findButton('Branch diff')).toBeTruthy();
+    });
+    expect(getRepositoryState).toHaveBeenCalledWith({ type: 'working-tree' });
+    expect(getRepositoryHistory).toHaveBeenCalledWith(expect.any(Number), branchSource);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('repository reload does not let stale selection override launch source', async () => {
+  const launchSource = { ref: 'main', type: 'branch' } satisfies ReviewSource;
+  const staleState = {
+    ...repositoryState,
+    source: { type: 'working-tree' },
+  } satisfies RepositoryState;
+  const branchState = {
+    ...repositoryState,
+    source: launchSource,
+  } satisfies RepositoryState;
+  const getRepositoryState = vi.fn(async (requestedSource?: ReviewSource) =>
+    requestedSource?.type === 'working-tree' ? staleState : branchState,
+  );
+
+  writeReloadSelection(staleState, null);
+
+  window.codiff = createCodiffMock({
+    getLaunchOptions: vi.fn(async () => ({
+      repositoryPathProvided: true,
+      source: launchSource,
+      walkthrough: false,
+    })),
+    getRepositoryState,
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+    });
+    expect(getRepositoryState).toHaveBeenCalledWith(undefined);
+    expect(getRepositoryState).not.toHaveBeenCalledWith(staleState.source);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
 test('repository reload colors only git status glyphs for files changed after reload', async () => {
   const unchangedFile = createChangedFile('src/unchanged.ts', 'same');
   const changedFileBeforeReload = createChangedFile('src/changed.ts', 'before');

--- a/src/__tests__/git-state.test.ts
+++ b/src/__tests__/git-state.test.ts
@@ -787,7 +787,7 @@ test('readRepositoryState preserves numstat for committed paths with tabs', asyn
   });
 });
 
-test('readRepositoryState opens branch refs as history-focused sources', async () => {
+test('readRepositoryState opens branch refs as current branch diffs against the target branch', async () => {
   await withRepo(async (repo) => {
     await writeRepoFile(repo, 'file.txt', 'base\n');
     await commitAll(repo, 'initial commit');
@@ -802,18 +802,42 @@ test('readRepositoryState opens branch refs as history-focused sources', async (
     await git(repo, ['checkout', baseBranch]);
     await writeRepoFile(repo, 'file.txt', 'main change\n');
     await commitAll(repo, 'main change');
+    await git(repo, ['checkout', 'feature']);
 
-    const [state, history] = await Promise.all([
-      readRepositoryState(repo, { ref: 'feature', type: 'branch' }),
-      listRepositoryHistory(repo, 10, { ref: 'feature', type: 'branch' }),
-    ]);
+    const state = await readRepositoryState(repo, { ref: baseBranch, type: 'branch' });
+    const source = state.source as Extract<ReviewSource, { type: 'branch-diff' }>;
+    const history = await listRepositoryHistory(repo, 10, source);
 
-    expect(state.files).toEqual([]);
-    expect(state.source).toEqual({ ref: 'feature', type: 'branch' });
+    expect(source.ref).toBe(baseBranch);
+    expect(source.type).toBe('branch-diff');
+    expect(source.baseRef).toBeTruthy();
+    expect(source.headRef).toBeTruthy();
+    expect(state.files.map((file) => file.path)).toEqual(['file.txt']);
+    expect(state.files[0].sections[0].oldFile?.contents).toBe('base\n');
+    expect(state.files[0].sections[0].newFile?.contents).toBe('feature two\n');
     expect(history.entries.map((entry) => (entry as { subject: string }).subject)).toEqual([
       'feature two',
       'feature one',
-      'initial commit',
+    ]);
+
+    await writeRepoFile(repo, 'file.txt', 'feature three\n');
+    await commitAll(repo, 'feature three');
+
+    const [section, staleHistory] = await Promise.all([
+      readDiffSectionContent(repo, {
+        force: true,
+        kind: state.files[0].sections[0].kind,
+        path: 'file.txt',
+        source,
+      }),
+      listRepositoryHistory(repo, 10, source),
+    ]);
+
+    expect(section.oldFile?.contents).toBe('base\n');
+    expect(section.newFile?.contents).toBe('feature two\n');
+    expect(staleHistory.entries.map((entry) => (entry as { subject: string }).subject)).toEqual([
+      'feature two',
+      'feature one',
     ]);
   });
 });

--- a/src/__tests__/reload-selection.test.ts
+++ b/src/__tests__/reload-selection.test.ts
@@ -6,10 +6,11 @@ import { beforeEach, expect, test } from 'vite-plus/test';
 import {
   consumeReloadSelection,
   getReloadDeltaPaths,
+  getReloadHistorySource,
   getReloadSelectionPath,
   writeReloadSelection,
 } from '../lib/reload-selection.ts';
-import type { ChangedFile, GitFileStatus, RepositoryState } from '../types.ts';
+import type { ChangedFile, GitFileStatus, RepositoryState, ReviewSource } from '../types.ts';
 
 beforeEach(() => {
   window.sessionStorage.clear();
@@ -45,6 +46,46 @@ test('reload selection is consumed once and restored only when the file still ex
   expect(getReloadSelectionPath(selection, currentState)).toBe(secondFile.path);
   expect(consumeReloadSelection()).toBeNull();
   expect(getReloadSelectionPath(selection, state([firstFile]))).toBeNull();
+});
+
+test('reload selection preserves the branch diff source without a selected file', () => {
+  const currentState = {
+    ...state([]),
+    source: {
+      baseRef: 'base123',
+      headRef: 'head123',
+      ref: 'main',
+      type: 'branch-diff',
+    },
+  } satisfies RepositoryState;
+
+  writeReloadSelection(currentState, null);
+
+  const selection = consumeReloadSelection();
+  expect(selection?.source).toEqual(currentState.source);
+  expect(getReloadSelectionPath(selection, currentState)).toBeNull();
+});
+
+test('reload selection preserves history source for the current source', () => {
+  const branchSource = {
+    baseRef: 'base123',
+    headRef: 'head123',
+    ref: 'main',
+    type: 'branch-diff',
+  } satisfies ReviewSource;
+  const currentState = state([]);
+
+  writeReloadSelection(currentState, null, branchSource);
+
+  const selection = consumeReloadSelection();
+  expect(selection?.historySource).toEqual(branchSource);
+  expect(getReloadHistorySource(selection, currentState)).toEqual(branchSource);
+  expect(
+    getReloadHistorySource(selection, {
+      ...currentState,
+      source: { ref: 'abc1234', type: 'commit' },
+    }),
+  ).toBeNull();
 });
 
 test('reload delta paths include only current files changed since reload', () => {

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -50,7 +50,7 @@ export function Sidebar({
   walkthroughLoading,
   walkthroughUnread,
 }: {
-  branchSource: Extract<ReviewSource, { type: 'branch' }> | null;
+  branchSource: Extract<ReviewSource, { type: 'branch-diff' }> | null;
   currentSource: ReviewSource;
   files: ReadonlyArray<ChangedFile>;
   historyEntries: ReadonlyArray<HistoryEntry>;
@@ -432,7 +432,7 @@ function HistorySidebar({
   pullRequestSource,
   searchQuery,
 }: {
-  branchSource: Extract<ReviewSource, { type: 'branch' }> | null;
+  branchSource: Extract<ReviewSource, { type: 'branch-diff' }> | null;
   currentSource: ReviewSource;
   entries: ReadonlyArray<HistoryEntry>;
   hasMore: boolean;
@@ -499,14 +499,40 @@ function HistorySidebar({
       return [
         !normalizedQuery
           ? {
+              key: 'history-section:review-scope',
+              kind: 'section' as const,
+              label: 'Review scope',
+            }
+          : null,
+        !normalizedQuery
+          ? {
+              author: null,
+              committedAt: null,
+              gravatarUrl: undefined,
+              key: 'working-tree',
+              kind: 'entry' as const,
+              ref: '',
+              source: { type: 'working-tree' } satisfies ReviewSource,
+              subject: 'Uncommitted changes',
+            }
+          : null,
+        !normalizedQuery
+          ? {
               author: null,
               committedAt: null,
               gravatarUrl: undefined,
               key: getSourceKey(branchSource),
               kind: 'entry' as const,
-              ref: branchSource.ref,
+              ref: 'branch',
               source: branchSource satisfies ReviewSource,
-              subject: 'Branch history',
+              subject: `Branch diff vs ${branchSource.ref}`,
+            }
+          : null,
+        localRows.length > 0
+          ? {
+              key: 'history-section:branch',
+              kind: 'section' as const,
+              label: 'Branch history',
             }
           : null,
         ...localRows,
@@ -524,7 +550,7 @@ function HistorySidebar({
             kind: 'entry' as const,
             ref: '',
             source: { type: 'working-tree' } satisfies ReviewSource,
-            subject: 'Uncommitted',
+            subject: 'Uncommitted changes',
           }
         : null,
       ...localRows,
@@ -565,7 +591,7 @@ function HistorySidebar({
             <span className="history-entry-ref">
               {row.source.type === 'commit'
                 ? getShortRef(row.source.ref)
-                : row.source.type === 'pull-request' || row.source.type === 'branch'
+                : row.source.type === 'pull-request' || row.source.type === 'branch-diff'
                   ? row.ref
                   : 'local'}
             </span>

--- a/src/lib/reload-selection.ts
+++ b/src/lib/reload-selection.ts
@@ -11,8 +11,9 @@ type ReloadSelectionFile = {
 
 type ReloadSelection = {
   files: ReadonlyArray<ReloadSelectionFile>;
+  historySource?: ReviewSource | null;
   root: string;
-  selectedPath: string;
+  selectedPath: string | null;
   source: ReviewSource;
 };
 
@@ -38,7 +39,7 @@ const isReviewSource = (value: unknown): value is ReviewSource => {
     return true;
   }
 
-  if (value.type === 'commit' || value.type === 'branch') {
+  if (value.type === 'commit') {
     return typeof value.ref === 'string';
   }
 
@@ -47,6 +48,18 @@ const isReviewSource = (value: unknown): value is ReviewSource => {
       typeof value.base === 'string' &&
       typeof value.head === 'string' &&
       typeof value.symmetric === 'boolean'
+    );
+  }
+
+  if (value.type === 'branch') {
+    return typeof value.ref === 'string';
+  }
+
+  if (value.type === 'branch-diff') {
+    return (
+      typeof value.ref === 'string' &&
+      typeof value.baseRef === 'string' &&
+      typeof value.headRef === 'string'
     );
   }
 
@@ -78,8 +91,9 @@ const isReloadSelection = (value: unknown): value is ReloadSelection =>
   isObject(value) &&
   Array.isArray(value.files) &&
   value.files.every(isReloadSelectionFile) &&
+  (value.historySource == null || isReviewSource(value.historySource)) &&
   typeof value.root === 'string' &&
-  typeof value.selectedPath === 'string' &&
+  (value.selectedPath == null || typeof value.selectedPath === 'string') &&
   isReviewSource(value.source);
 
 const getMatchingSelection = (selection: ReloadSelection | null, state: RepositoryState) =>
@@ -117,7 +131,7 @@ export const getReloadSelectionPath = (
   state: RepositoryState,
 ): string | null => {
   const matchedSelection = getMatchingSelection(selection, state);
-  if (!matchedSelection) {
+  if (!matchedSelection || !matchedSelection.selectedPath) {
     return null;
   }
 
@@ -151,12 +165,18 @@ export const getReloadDeltaPaths = (
   return deltaPaths;
 };
 
+export const getReloadHistorySource = (
+  selection: ReloadSelection | null,
+  state: RepositoryState,
+): ReviewSource | null => getMatchingSelection(selection, state)?.historySource ?? null;
+
 export const writeReloadSelection = (
   state: RepositoryState | null,
   selectedPath: string | null,
+  historySource: ReviewSource | null = null,
 ) => {
   const storage = getStorage();
-  if (!storage || !state || !selectedPath) {
+  if (!storage || !state) {
     return;
   }
 
@@ -169,6 +189,7 @@ export const writeReloadSelection = (
           path: file.path,
           status: file.status,
         })),
+        historySource,
         root: state.root,
         selectedPath,
         source: state.source,

--- a/src/lib/source.ts
+++ b/src/lib/source.ts
@@ -1,19 +1,85 @@
 import type { ReviewSource } from '../types.ts';
 import type { RepositoryLoadError } from './app-types.ts';
+import { compactPath } from './files.ts';
 
 const rangeLabel = (source: Extract<ReviewSource, { type: 'range' }>) =>
   `${source.base}${source.symmetric ? '...' : '..'}${source.head}`;
 
+type SourceCapabilities = {
+  emptyTitle: string;
+  historySource: boolean;
+  lazyDiffContent: boolean;
+  preloadDiffSearchContent: boolean;
+  startInHistoryWhenEmpty: boolean;
+  viewedFileState: boolean;
+};
+
+const sourceCapabilitiesByType = {
+  branch: {
+    emptyTitle: 'No branch changes',
+    historySource: true,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: true,
+    startInHistoryWhenEmpty: true,
+    viewedFileState: false,
+  },
+  'branch-diff': {
+    emptyTitle: 'No branch changes',
+    historySource: true,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: true,
+    startInHistoryWhenEmpty: true,
+    viewedFileState: false,
+  },
+  commit: {
+    emptyTitle: 'No changes in commit',
+    historySource: false,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: false,
+    startInHistoryWhenEmpty: false,
+    viewedFileState: false,
+  },
+  'pull-request': {
+    emptyTitle: 'No pull request changes',
+    historySource: true,
+    lazyDiffContent: false,
+    preloadDiffSearchContent: false,
+    startInHistoryWhenEmpty: false,
+    viewedFileState: false,
+  },
+  range: {
+    emptyTitle: 'No changes in range',
+    historySource: false,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: false,
+    startInHistoryWhenEmpty: false,
+    viewedFileState: false,
+  },
+  'working-tree': {
+    emptyTitle: 'No local changes',
+    historySource: false,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: true,
+    startInHistoryWhenEmpty: true,
+    viewedFileState: true,
+  },
+} satisfies Record<ReviewSource['type'], SourceCapabilities>;
+
+export const getSourceCapabilities = (source: ReviewSource) =>
+  sourceCapabilitiesByType[source.type];
+
 export const getSourceKey = (source: ReviewSource) =>
   source.type === 'commit'
     ? `commit:${source.ref}`
-    : source.type === 'branch'
-      ? `branch:${source.ref}`
-      : source.type === 'range'
-        ? `range:${rangeLabel(source)}`
-        : source.type === 'pull-request'
-          ? `pull-request:${source.owner ?? ''}/${source.repo ?? ''}#${source.number ?? source.url}`
-          : 'working-tree';
+    : source.type === 'branch-diff'
+      ? `branch-diff:${source.ref}:${source.baseRef}:${source.headRef}`
+      : source.type === 'branch'
+        ? `branch:${source.ref}`
+        : source.type === 'range'
+          ? `range:${rangeLabel(source)}`
+          : source.type === 'pull-request'
+            ? `pull-request:${source.owner ?? ''}/${source.repo ?? ''}#${source.number ?? source.url}`
+            : 'working-tree';
 
 const getErrorMessage = (error: unknown) =>
   error instanceof Error ? error.message : String(error);
@@ -37,8 +103,8 @@ export const getShortRef = (ref: string) => ref.slice(0, 7);
 export const getSourceLabel = (source: ReviewSource) =>
   source.type === 'commit'
     ? getShortRef(source.ref)
-    : source.type === 'branch'
-      ? source.ref
+    : source.type === 'branch' || source.type === 'branch-diff'
+      ? `Branch vs ${source.ref}`
       : source.type === 'range'
         ? rangeLabel(source)
         : source.type === 'pull-request'
@@ -46,3 +112,31 @@ export const getSourceLabel = (source: ReviewSource) =>
             ? `PR #${source.number}`
             : 'Pull request'
           : 'Uncommitted';
+
+export const getHistorySource = (source: ReviewSource): ReviewSource | undefined =>
+  getSourceCapabilities(source).historySource ? source : undefined;
+
+export const supportsLazyDiffContent = (source: ReviewSource) =>
+  getSourceCapabilities(source).lazyDiffContent;
+
+export const supportsDiffSearchContentPreload = (source: ReviewSource) =>
+  getSourceCapabilities(source).preloadDiffSearchContent;
+
+export const shouldStartInHistoryWhenEmpty = (source: ReviewSource) =>
+  getSourceCapabilities(source).startInHistoryWhenEmpty;
+
+export const usesViewedFileState = (source: ReviewSource) =>
+  getSourceCapabilities(source).viewedFileState;
+
+export const getEmptySourceTitle = (source: ReviewSource) =>
+  getSourceCapabilities(source).emptyTitle;
+
+export const getEmptySourceDetail = (
+  source: ReviewSource,
+  root: string,
+): { kind: 'code' | 'text'; text: string; title?: string } =>
+  source.type === 'commit'
+    ? { kind: 'text', text: getShortRef(source.ref) }
+    : source.type === 'branch' || source.type === 'branch-diff'
+      ? { kind: 'text', text: source.ref }
+      : { kind: 'code', text: compactPath(root), title: root };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,15 @@ export type ReviewSource =
       type: 'branch';
     }
   | {
+      /** Resolved base commit for a branch diff snapshot. */
+      baseRef: string;
+      /** Resolved head commit for a branch diff snapshot. */
+      headRef: string;
+      /** Target branch the current branch was compared against. */
+      ref: string;
+      type: 'branch-diff';
+    }
+  | {
       /** Base ref (left side). For symmetric ranges the diff starts at its merge-base with head. */
       base: string;
       /** Head ref (right side). */


### PR DESCRIPTION
### Summary

This changes Codiff’s branch launch mode from showing only branch history to showing the full reviewable diff of the current branch against a target branch.

### Why
When working on feature branches, the most useful review target is often “everything this branch changes compared with main”, not just the staged/unstaged diff and not only a raw commit list. This makes Codiff usable as a local branch review tool before opening or updating a PR.

### What changed

* codiff continues to review current staged/unstaged changes.
* codiff main reviews the current branch diff against main.
* Branch diffs are computed from merge-base(main, HEAD)..HEAD, so changes on main after divergence are not included.
* Branch diff mode keeps the History tab useful as a review hub:
* Uncommitted opens the current staged/unstaged diff.
* Branch diff opens the full branch-vs-main diff.
* Branch history lists the commits unique to the current branch.
* Individual branch commits remain clickable for focused commit review.
* --branch <ref> remains as an explicit escape hatch for ambiguous refs, but the normal UX is just codiff main.
