### PR TITLE
Add custom walkthrough prompt setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ is running so changes apply to open windows.
     "openAIModel": "gpt-5.3-codex-spark",
     "showWhitespace": false,
     "theme": "system",
+    "walkthroughPrompt": "",
     "wordWrap": false,
   },
   "keymap": {
@@ -147,6 +148,10 @@ explicit path:
 CODIFF_CODEX_PATH=/absolute/path/to/codex codiff -w
 CODIFF_CLAUDE_PATH=/absolute/path/to/claude codiff --agent claude -w
 ```
+
+Set `settings.walkthroughPrompt` to add custom instructions to generated walkthrough prompts. For
+example, use it to request a specific language, tone, or level of detail while Codiff keeps its
+review-order rules and JSON schema in place.
 
 Claude Code rides your existing `claude` login (subscription or `ANTHROPIC_API_KEY`); run `claude`
 once and complete `/login` if you have not already.

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -10,6 +10,7 @@
     "showOutdated": false,
     "showWhitespace": false,
     "theme": "system",
+    "walkthroughPrompt": "",
     "wordWrap": false
   },
   "keymap": {

--- a/electron/__tests__/walkthrough.test.ts
+++ b/electron/__tests__/walkthrough.test.ts
@@ -11,6 +11,8 @@ const { buildPrompt, normalizeWalkthrough } = require('../walkthrough.cjs') as {
       source: { generatedAt: string; threadId?: string; type: string };
       version: 1;
     },
+    agentLabel?: string,
+    customPrompt?: string,
   ) => string;
   normalizeWalkthrough: (
     input: unknown,
@@ -71,6 +73,32 @@ test('includes Codex conversation context in walkthrough prompts', () => {
   expect(prompt).toContain('Make Codiff walkthroughs reuse the creating Codex session.');
   expect(prompt).toContain('The skill should only pass the session id to Codiff.');
   expect(prompt).toContain('Treat the repository change digest as the source of truth');
+});
+
+test('includes custom walkthrough prompt guidance without replacing core constraints', () => {
+  const prompt = buildPrompt(
+    {
+      files: [
+        {
+          fingerprint: 'abc',
+          path: 'README.md',
+          sections: [],
+          status: 'modified',
+        },
+      ],
+      generatedAt: 1,
+      root: '/repo',
+      source: { type: 'working-tree' },
+    },
+    null,
+    'Claude Code',
+    'Answer in Japanese and use concise reviewer-facing explanations.',
+  );
+
+  expect(prompt).toContain('Custom walkthrough instructions:');
+  expect(prompt).toContain('Answer in Japanese and use concise reviewer-facing explanations.');
+  expect(prompt).toContain('Return JSON only.');
+  expect(prompt).toContain('Repository change digest:');
 });
 
 test('normalizes review leverage walkthrough fields', () => {

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -243,6 +243,10 @@ const mergeConfig = (raw) => {
           ? rawSettings.showWhitespace
           : defaults.settings.showWhitespace,
       theme: normalizeTheme(rawSettings.theme),
+      walkthroughPrompt:
+        typeof rawSettings.walkthroughPrompt === 'string'
+          ? rawSettings.walkthroughPrompt
+          : defaults.settings.walkthroughPrompt,
       wordWrap:
         typeof rawSettings.wordWrap === 'boolean'
           ? rawSettings.wordWrap

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -874,7 +874,13 @@ ipcMain.handle('codiff:getWalkthrough', async (event, source) => {
     launchOptions?.walkthroughContext,
     agent.readSessionContext(launchOptions?.[agent.sessionLaunchOptionKey]),
   );
-  return readWalkthrough(state, agent, getAgentOptions(agent), walkthroughContext);
+  return readWalkthrough(
+    state,
+    agent,
+    getAgentOptions(agent),
+    walkthroughContext,
+    config.settings.walkthroughPrompt,
+  );
 });
 
 // Load a pre-authored narrative walkthrough (--walkthrough-file) and repair it against the

--- a/electron/walkthrough.cjs
+++ b/electron/walkthrough.cjs
@@ -121,11 +121,25 @@ If the context and digest conflict, trust the digest.
 `
     : '';
 
-/** @param {RepositoryState} state @param {WalkthroughContext | null | undefined} [context] @param {string} [agentLabel] */
+/** @param {unknown} customPrompt */
+const buildCustomPromptInput = (customPrompt) => {
+  const prompt = typeof customPrompt === 'string' ? customPrompt.trim() : '';
+
+  return prompt
+    ? `Custom walkthrough instructions:
+${prompt}
+
+Use these instructions to customize language, tone, and review detail. If they conflict with the JSON schema, changed file list, or review-order constraints above, keep the schema and digest as the source of truth.
+`
+    : '';
+};
+
+/** @param {RepositoryState} state @param {WalkthroughContext | null | undefined} [context] @param {string} [agentLabel] @param {string} [customPrompt] */
 const buildPrompt = (
   state,
   context,
   agentLabel = 'Codex',
+  customPrompt,
 ) => `You are helping Codiff order a code review.
 
 Return a high-leverage review walkthrough order, not review findings.
@@ -158,6 +172,7 @@ Do not mention files that were not provided.
 Return JSON only.
 
 ${buildWalkthroughContextInput(context, agentLabel)}
+${buildCustomPromptInput(customPrompt)}
 Repository change digest:
 ${JSON.stringify(buildPromptInput(state), null, 2)}
 `;
@@ -233,8 +248,8 @@ const normalizeWalkthrough = (input, files, agentLabel = 'Codex') => {
   };
 };
 
-/** @param {RepositoryState} state @param {Agent} agent @param {AgentOptions} agentOptions @param {WalkthroughContext | null | undefined} [context] */
-const readWalkthrough = async (state, agent, agentOptions, context) => {
+/** @param {RepositoryState} state @param {Agent} agent @param {AgentOptions} agentOptions @param {WalkthroughContext | null | undefined} [context] @param {string} [customPrompt] */
+const readWalkthrough = async (state, agent, agentOptions, context, customPrompt) => {
   if (state.files.length === 0) {
     return {
       status: 'ready',
@@ -252,7 +267,7 @@ const readWalkthrough = async (state, agent, agentOptions, context) => {
   try {
     const response = await agent.run(
       state.root,
-      buildPrompt(state, context, agent.label),
+      buildPrompt(state, context, agent.label, customPrompt),
       walkthroughSchema,
       'walkthrough.json',
       `${agent.label} walkthrough timed out.`,

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -147,6 +147,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
     showOutdated: false,
     showWhitespace: false,
     theme: 'system' as const,
+    walkthroughPrompt: defaultSettings.walkthroughPrompt,
     wordWrap: false,
   })),
   getRepositoryHistory: vi.fn(async () => ({

--- a/src/__tests__/config-defaults.test.ts
+++ b/src/__tests__/config-defaults.test.ts
@@ -8,9 +8,10 @@ import schema from '../config/codiff-config.schema.json' with { type: 'json' };
 import { createDefaultConfig } from '../config/defaults.ts';
 
 const require = createRequire(import.meta.url);
-const { createDefaultConfig: createElectronDefaultConfig } =
+const { createDefaultConfig: createElectronDefaultConfig, mergeConfig } =
   require('../../electron/config.cjs') as {
     createDefaultConfig: typeof createDefaultConfig;
+    mergeConfig: (raw: unknown) => ReturnType<typeof createDefaultConfig>;
   };
 
 const getSchemaDefaults = (section: 'keymap' | 'settings') =>
@@ -41,6 +42,24 @@ test('electron defaults load from packaged app shape', () => {
 
   const packageRequire = createRequire(join(packageRoot, 'electron/config.cjs'));
   expect(packageRequire('./config.cjs').createDefaultConfig()).toEqual(createDefaultConfig());
+});
+
+test('config keeps custom walkthrough prompt text only when it is a string', () => {
+  expect(
+    mergeConfig({
+      settings: {
+        walkthroughPrompt: 'Respond in German with product-review terminology.',
+      },
+    }).settings.walkthroughPrompt,
+  ).toBe('Respond in German with product-review terminology.');
+
+  expect(
+    mergeConfig({
+      settings: {
+        walkthroughPrompt: ['Respond in German'],
+      },
+    }).settings.walkthroughPrompt,
+  ).toBe('');
 });
 
 test('npm package includes shared config defaults', () => {

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -67,6 +67,11 @@
           "default": "system",
           "description": "Application color theme. 'system' follows OS preference."
         },
+        "walkthroughPrompt": {
+          "type": "string",
+          "default": "",
+          "description": "Additional instructions appended to LLM walkthrough prompts. Use this to request a language, tone, or level of detail while Codiff keeps its review-order constraints and schema."
+        },
         "wordWrap": {
           "type": "boolean",
           "default": false,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -13,6 +13,7 @@ export type CodiffSettings = {
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
+  walkthroughPrompt: string;
   wordWrap: boolean;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -521,6 +521,7 @@ export type CodiffPreferences = {
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
+  walkthroughPrompt: string;
   wordWrap: boolean;
 };
 


### PR DESCRIPTION
## Summary

- Add `settings.walkthroughPrompt` so users can customize generated walkthrough language, tone, and detail.
- Append custom prompt text to walkthrough prompts without replacing Codiff’s review-order rules, file digest, or JSON schema constraints.
- Document the new setting and cover config normalization plus prompt inclusion with tests.

Addresses #56.

## Validation

- `pnpm exec vp check --fix`
- `pnpm test`
- `pnpm exec vp build`
