### PR TITLE
Recommend adding code blocks into the sections for describing upcoming parts of the walkthrough

### DIFF
--- a/bin/walkthrough-guide.md
+++ b/bin/walkthrough-guide.md
@@ -48,7 +48,8 @@ to the working tree (`git diff`) and say so. Anchor every `chapters[].stops[].an
 - Do not make one stop per file for broad changes. Group files that implement the same idea in
   one stop.
 - Keep `summary` to one concrete sentence. Keep `body` short and specific. Do not use markdown
-  headings.
+  headings, lists, or other block structure. Inline code is supported, though: wrap symbol names,
+  file paths, flags, and other literals in backticks, e.g. `--walkthrough-file` or `renderInlineMarkdown`.
 - Avoid generic filler, broad assurance language, and meta-explanatory labels.
 - Do not invent bugs, risks, tests, or validation. Describe what the diff and conversation
   actually support.


### PR DESCRIPTION
Passages like this are just begging for code references to be a different font

<img width="1345" height="613" alt="image" src="https://github.com/user-attachments/assets/bb7dbb79-ad53-42ef-97b9-797adbe717e5" />
