### PR TITLE
Use hunk-based walkthroughs for focused review + single renderer

### DIFF
--- a/bin/walkthrough-guide.md
+++ b/bin/walkthrough-guide.md
@@ -20,11 +20,13 @@ choose.
   `"Tests"`, `"Docs"`, `"Runtime"`, `"Cleanup"`.
 - **`chapters[].stops[]`** — the main review path. Use 3-6 stops for small changes, 5-9 for
   medium changes, and 7-12 for large changes. Never exceed 14. A stop should represent one
-  review idea and can include up to 3 ordered `hunkIds`.
+  review idea and can include up to 14 ordered `hunkIds`.
 - **`hunkIds[]`** — deterministic hunk ids copied from the repository digest, in the exact order
   Codiff should render them. Default to one hunk id per stop or support item. Use multiple ids
   only when those hunks must be read together; cross-file and out-of-line order is allowed when it
-  improves the review path.
+  improves the review path. Some ids are synthetic hunks for binary, deferred, metadata-only, or
+  otherwise non-textual changes; treat them like normal hunk ids and explain why that review unit
+  matters.
 - **`notes[]`** — optional short header notes for individual focused hunks: `{ hunkId, body }`.
   Use these when a specific hunk needs a label under its file header.
 - **`support[]`** — changed hunks that should stay off the main path. Use it for generated files,

--- a/bin/walkthrough-guide.md
+++ b/bin/walkthrough-guide.md
@@ -1,59 +1,55 @@
 # Narrative walkthrough — authoring guide
 
 This is Codiff's guidance for authoring a **narrative walkthrough**: a compact review path
-through a change, with ordered chapters, stops, and direct anchors into the live diff.
-The diff content itself is not embedded. Codiff computes the diff from the repository,
-repairs anchors on load, and renders the real current diff.
+through a change, with ordered chapters, stops, and deterministic hunk ids from the live
+diff. The diff content itself is not embedded. Codiff computes the diff from the repository,
+resolves hunk ids on load, and renders the real current diff.
 
 Write the JSON document to a **temporary file outside the repository** and pass it to
-Codiff with `--walkthrough-file`. Set `"$schema"` to
-`https://raw.githubusercontent.com/nkzw-tech/codiff/main/src/walkthrough/narrative-walkthrough.schema.json`
-for editor validation.
+Codiff with `--walkthrough-file`.
 
 Default to the **staged** diff (`git diff --staged`). If the user named a target, use that:
 a commit, branch, pull request, ref range, or repository path. If nothing is staged, fall back
-to the working tree (`git diff`) and say so. Anchor every `chapters[].stops[].anchors[]` and
-`support[].files[]` item against whichever diff you choose.
+to the working tree (`git diff`) and say so. Anchor every `hunkId` against whichever diff you
+choose.
 
 ## Shape
 
-- **`chapters[]`** — 2-6 compact sections in the review path. A chapter is a conceptual group,
+- **`chapters[]`** — 2-6 compact sections in display order. A chapter is a conceptual group,
   not a file. Keep `title` to 1-2 short words and at most 16 characters, e.g. `"UI"`, `"CLI"`,
   `"Tests"`, `"Docs"`, `"Runtime"`, `"Cleanup"`.
 - **`chapters[].stops[]`** — the main review path. Use 3-6 stops for small changes, 5-9 for
   medium changes, and 7-12 for large changes. Never exceed 14. A stop should represent one
-  review idea and can cover up to 8 files via direct anchors.
-- **`anchors[]` / `support[].files[]`** — direct slices of the live diff:
-  - `id` — stable within the document, e.g. `"a1"`.
-  - `path`, `oldPath?`, `status` (`added` | `deleted` | `modified` | `renamed` | `untracked`).
-  - `granularity` — `line` | `hunk` | `file`.
-  - `added`, `deleted` — line counts for this slice.
-  - `anchor` — `display`, optional `sectionId`, `sectionKind`, `side`, `startLine`, `endLine`.
-    Codiff repairs missing or stale section ids against the live diff.
-  - `title?`, `summary?` — short labels for the file or slice.
-  - `comments?` — optional seeded review comments anchored by side and line.
-  - `changeType?`, `commitNote?` — optional commit composer metadata.
-- **`support[]`** — changed files that should stay off the main path. Use it for generated
-  files, lockfiles, snapshots, broad CSS churn, deleted legacy files, and repeated mechanical
-  edits unless they are essential to review.
+  review idea and can include up to 3 ordered `hunkIds`.
+- **`hunkIds[]`** — deterministic hunk ids copied from the repository digest, in the exact order
+  Codiff should render them. Default to one hunk id per stop or support item. Use multiple ids
+  only when those hunks must be read together; cross-file and out-of-line order is allowed when it
+  improves the review path.
+- **`notes[]`** — optional short header notes for individual focused hunks: `{ hunkId, body }`.
+  Use these when a specific hunk needs a label under its file header.
+- **`support[]`** — changed hunks that should stay off the main path. Use it for generated files,
+  lockfiles, snapshots, docs-only changes, and repeated mechanical edits unless they are essential
+  to review. Codiff adds any omitted live-diff hunks to support.
+- **`changeType?` / `commitNote?`** — optional commit composer metadata for committable
+  walkthroughs.
 - **`commit?`** — for working-tree walkthroughs, include `title` and `body` when there is enough
   signal for a useful commit message. Omit it for commits, branches, and pull requests.
-- **`context?`** — compact originating conversation context, if available, for follow-up Q&A.
 
 ## Rules
 
-- Every changed file should appear exactly once in either a stop anchor or support. Codiff adds
-  any omitted live-diff file to `support`, but a clean document reads better.
+- Do not provide `added`, `deleted`, `path`, `oldPath`, `status`, `anchor`, `repo`, `source`,
+  `generatedAt`, `agent`, or `meta`. Codiff computes those from the live diff.
+- Every changed hunk should appear at most once in either a stop or support. Codiff adds omitted
+  live-diff hunks to support, but a clean document reads better.
 - Order stops by review leverage, not by file path.
-- Do not make one stop per file for broad changes. Group files that implement the same idea in
+- Do not make one stop per file for broad changes. Group hunks that implement the same idea in
   one stop.
-- Keep `summary` to one concrete sentence. Keep `body` short and specific. Do not use markdown
+- Keep `summary` to one concrete sentence. Keep `prose` short and specific. Do not use markdown
   headings, lists, or other block structure. Inline code is supported, though: wrap symbol names,
   file paths, flags, and other literals in backticks, e.g. `--walkthrough-file` or `renderInlineMarkdown`.
 - Avoid generic filler, broad assurance language, and meta-explanatory labels.
 - Do not invent bugs, risks, tests, or validation. Describe what the diff and conversation
   actually support.
-- Put review findings in `comments[]`, not in the stop body.
 
 ## Schema
 

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -12,7 +12,6 @@
     "showOutdated": false,
     "showWhitespace": false,
     "theme": "system",
-    "walkthroughOrder": "keys",
     "wordWrap": false
   },
   "keymap": {

--- a/electron/__tests__/narrative-walkthrough.test.ts
+++ b/electron/__tests__/narrative-walkthrough.test.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import { expect, test } from 'vite-plus/test';
+import narrativeSchemaJson from '../../src/walkthrough/narrative-walkthrough.schema.json' with { type: 'json' };
 
 const require = createRequire(import.meta.url);
 const {
@@ -14,22 +15,40 @@ const {
     required: ReadonlyArray<string>;
     type: string;
   };
-  narrativeWalkthroughSchema: { type: string; required: ReadonlyArray<string> };
+  narrativeWalkthroughSchema: {
+    properties: Record<string, any>;
+    required: ReadonlyArray<string>;
+    type: string;
+  };
   normalizeNarrativeWalkthrough: (
     input: unknown,
     files: ReadonlyArray<{
       oldPath?: string;
       path: string;
-      sections: ReadonlyArray<{ id: string; kind: string; patch?: string }>;
+      sections: ReadonlyArray<{ id: string; kind: string; patch: string }>;
       status: string;
     }>,
+    facts?: Record<string, unknown>,
   ) => any;
 };
+
+const addedPatch = (count: number) =>
+  `@@ -0,0 +1,${count} @@\n${Array.from({ length: count }, (_, index) => `+line ${index + 1}`).join('\n')}\n`;
+const fourHunkPatch = Array.from(
+  { length: 4 },
+  (_, index) => `@@ -${index + 1} +${index + 1} @@\n-old ${index + 1}\n+new ${index + 1}\n`,
+).join('');
 
 const files = [
   {
     path: 'src/App.tsx',
-    sections: [{ id: 'src/App.tsx:staged', kind: 'staged', patch: '@@ -1 +1 @@\n-a\n+b\n' }],
+    sections: [
+      {
+        id: 'src/App.tsx:staged',
+        kind: 'staged',
+        patch: '@@ -310,3 +310,3 @@\n context\n-old order\n+new order\n context\n',
+      },
+    ],
     status: 'modified',
   },
   {
@@ -38,31 +57,24 @@ const files = [
       {
         id: 'src/__tests__/hunkNavigation.test.ts:staged',
         kind: 'staged',
-        patch: '@@ -0,0 +1,2 @@\n+one\n+two\n',
+        patch: addedPatch(14),
       },
     ],
     status: 'added',
   },
   {
     path: 'pnpm-lock.yaml',
-    sections: [{ id: 'pnpm-lock.yaml:staged', kind: 'staged', patch: '@@ -1 +1 @@\n-a\n+b\n' }],
+    sections: [{ id: 'pnpm-lock.yaml:staged', kind: 'staged', patch: addedPatch(3) }],
+    status: 'modified',
+  },
+  {
+    path: 'wide.py',
+    sections: [{ id: 'wide.py:staged', kind: 'staged', patch: fourHunkPatch }],
     status: 'modified',
   },
 ];
 
-const anchor = (id: string, path: string, extra: Record<string, unknown> = {}) => ({
-  added: 1,
-  anchor: { display: path, sectionId: `${path}:staged`, side: 'both' },
-  deleted: 1,
-  granularity: 'file',
-  id,
-  path,
-  status: path.endsWith('.test.ts') ? 'added' : 'modified',
-  ...extra,
-});
-
 const baseInput = () => ({
-  agent: 'claude',
   chapters: [
     {
       blurb: 'Where it breaks.',
@@ -70,95 +82,76 @@ const baseInput = () => ({
       id: 'bug',
       stops: [
         {
-          anchors: [
-            anchor('a1', 'src/App.tsx', {
-              anchor: {
-                display: 'src/App.tsx:311',
-                sectionId: 'src/App.tsx:staged',
-                side: 'both',
-                startLine: 311,
-              },
-              granularity: 'line',
-            }),
-          ],
-          body: 'The root cause line.',
-          id: 'stop-1',
+          hunkIds: ['src/App.tsx:staged:h1'],
+          id: 's1',
           importance: 'critical',
-          summary: 'Navigation now follows the hunk order.',
-          title: 'Hunk order',
+          prose: 'The root cause line.',
         },
         {
-          anchors: [
-            anchor('a2', 'src/__tests__/hunkNavigation.test.ts', {
-              added: 14,
-              anchor: { display: 'hunkNavigation.test.ts (new)' },
-              deleted: 0,
-            }),
-          ],
-          body: 'The regression test covers the skip.',
-          id: 'stop-2',
+          hunkIds: ['src/__tests__/hunkNavigation.test.ts:staged:h1'],
+          id: 's6',
           importance: 'normal',
-          summary: 'The regression test covers collapsed-file movement.',
-          title: 'Regression',
+          prose: 'The regression test.',
         },
       ],
-      title: 'Bug',
+      title: 'The bug',
     },
   ],
   focus: 'A one-line ordering bug let j/k skip collapsed files.',
-  generatedAt: '2026-06-05T00:00:00.000Z',
   kind: 'narrative',
-  repo: { branch: 'fix/hunk-nav', root: '/repo' },
-  source: { type: 'working-tree' },
-  support: [
-    {
-      files: [
-        anchor('lock', 'pnpm-lock.yaml', {
-          added: 312,
-          anchor: { display: 'pnpm-lock.yaml' },
-          deleted: 180,
-        }),
-      ],
-      id: 'lockfiles',
-      note: 'Regenerated.',
-      title: 'Lockfile',
-    },
-  ],
+  support: [{ hunkIds: ['pnpm-lock.yaml:staged:h1'], id: 'lock', reason: 'Lockfile' }],
   title: 'Hunk navigation skips collapsed files',
-  version: 3,
+  version: 4,
 });
 
-test('exposes a schema requiring the core narrative fields', () => {
+test('exposes a schema requiring the hunk-based narrative fields', () => {
   expect(narrativeWalkthroughSchema.type).toBe('object');
   expect(narrativeWalkthroughSchema.required).toContain('chapters');
-  expect(narrativeWalkthroughSchema.required).toContain('support');
+  expect(narrativeWalkthroughSchema.required).not.toContain('segments');
   expect(narrativeWalkthroughSchema.required).not.toContain('orders');
+  expect(narrativeWalkthroughSchema.required).not.toContain('defaultOrder');
+  expect(narrativeWalkthroughSchema.properties.agent).toBeUndefined();
+  expect(narrativeWalkthroughSchema.properties.repo).toBeUndefined();
+  const stopProperties =
+    narrativeWalkthroughSchema.properties.chapters.items.properties.stops.items.properties;
+  expect(stopProperties.added).toBeUndefined();
+  expect(stopProperties.anchor).toBeUndefined();
+});
+
+test('keeps the renderer JSON schema in sync with the live narrative schema', () => {
+  expect(narrativeSchemaJson).toEqual(narrativeWalkthroughSchema);
 });
 
 test('derives an OpenAI strict-compatible response schema', () => {
   expect(narrativeWalkthroughResponseSchema.required).toEqual(
     Object.keys(narrativeWalkthroughResponseSchema.properties),
   );
-  expect(narrativeWalkthroughResponseSchema.properties.context).toBeUndefined();
+  expect(narrativeWalkthroughResponseSchema.properties.agent).toBeUndefined();
+  expect(narrativeWalkthroughResponseSchema.properties.generatedAt).toBeUndefined();
+  expect(narrativeWalkthroughResponseSchema.properties.meta).toBeUndefined();
+  expect(narrativeWalkthroughResponseSchema.properties.repo).toBeUndefined();
   expect(narrativeWalkthroughResponseSchema.properties.source).toBeUndefined();
-  expect(narrativeWalkthroughResponseSchema.required).not.toContain('context');
-  expect(narrativeWalkthroughResponseSchema.required).not.toContain('source');
   expect(narrativeWalkthroughResponseSchema.properties.commit.required).toEqual(['body', 'title']);
   expect(narrativeWalkthroughResponseSchema.properties.commit.type).toContain('null');
-  expect(narrativeWalkthroughResponseSchema.properties.chapters.maxItems).toBe(6);
-  expect(
-    narrativeWalkthroughResponseSchema.properties.chapters.items.properties.title.maxLength,
-  ).toBe(16);
-  expect(
-    narrativeWalkthroughResponseSchema.properties.chapters.items.properties.stops.maxItems,
-  ).toBe(14);
-  expect(
-    narrativeWalkthroughResponseSchema.properties.chapters.items.properties.stops.items.properties
-      .anchors.maxItems,
-  ).toBe(8);
+
+  const chapters = narrativeWalkthroughResponseSchema.properties.chapters;
+  const stopProperties = chapters.items.properties.stops.items.properties;
+  expect(chapters.maxItems).toBe(6);
+  expect(chapters.items.properties.title.maxLength).toBe(16);
+  expect(chapters.items.properties.stops.maxItems).toBe(14);
+  expect(stopProperties.added).toBeUndefined();
+  expect(stopProperties.deleted).toBeUndefined();
+  expect(stopProperties.path).toBeUndefined();
+  expect(stopProperties.status).toBeUndefined();
+  expect(stopProperties.changeType.type).toContain('null');
+  expect(stopProperties.changeType.enum).toContain(null);
+  expect(stopProperties.hunkIds.minItems).toBe(1);
+  expect(stopProperties.hunkIds.maxItems).toBe(3);
+  expect(stopProperties.notes.items.required).toEqual(['body', 'hunkId']);
+  expect(stopProperties.comments).toBeUndefined();
 });
 
-test('prompts generated walkthroughs to stay grouped instead of file-per-stop', () => {
+test('prompts generated walkthroughs to use deterministic hunk groups', () => {
   const prompt = buildNarrativeWalkthroughPrompt({
     branch: 'main',
     files: Array.from({ length: 28 }, (_, index) => ({
@@ -173,244 +166,261 @@ test('prompts generated walkthroughs to stay grouped instead of file-per-stop', 
 
   expect(prompt).toContain('digest has 28 files');
   expect(prompt).toContain('Target 7-12 main-path stops');
-  expect(prompt).toContain('Coverage contract');
-  expect(prompt).toContain('Every file must appear exactly once');
-  expect(prompt).toContain('Chapter titles render in a compact top bar');
-  expect(prompt).toContain('Do not create one stop per file');
-  expect(prompt).toContain('can include up to 8 anchors');
-  expect(prompt).toContain('support[]');
+  expect(prompt).toContain('Define chapters[] in display order');
+  expect(prompt).toContain('Default to one hunkId per stop or support item');
+  expect(prompt).toContain('A stop or support item may contain at most 3 hunkIds');
+  expect(prompt).toContain('Put hunkIds in the exact display order');
+  expect(prompt).toContain('Use notes[] on a stop/support item');
+  expect(prompt).not.toContain('comments[]');
   expect(prompt).toContain('include commit.title and commit.body by default');
-  expect(prompt).toContain('Do not use generic filler');
+});
+
+test('repository digest exposes deterministic hunk ids and counts', () => {
+  const prompt = buildNarrativeWalkthroughPrompt({
+    branch: 'main',
+    files: files.slice(0, 1),
+    generatedAt: 1,
+    root: '/repo',
+    source: { type: 'working-tree' },
+  });
+
+  expect(prompt).toContain('"id": "src/App.tsx:staged:h1"');
+  expect(prompt).toContain('"added": 1');
+  expect(prompt).toContain('"deleted": 1');
+  expect(prompt).toContain('Do not provide added/deleted counts');
 });
 
 test('normalizes a well-formed narrative walkthrough', () => {
-  const result = normalizeNarrativeWalkthrough(baseInput(), files);
+  const result = normalizeNarrativeWalkthrough(baseInput(), files, {
+    agent: 'claude',
+    branch: 'fix/hunk-nav',
+    generatedAt: 1,
+    root: '/repo',
+    source: { type: 'working-tree' },
+  });
 
-  expect(result.version).toBe(3);
+  expect(result.version).toBe(4);
   expect(result.kind).toBe('narrative');
+  expect(result.agent).toBe('claude');
+  expect(result.generatedAt).toBe('1970-01-01T00:00:00.001Z');
+  expect(result.repo).toEqual({ branch: 'fix/hunk-nav', root: '/repo' });
+  expect(result.source).toEqual({ type: 'working-tree' });
+  expect(result.meta).toBe('2 stops · 1 chapters');
   expect(result.chapters).toHaveLength(1);
-  expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['stop-1', 'stop-2']);
-  expect(result.support[0].files[0].id).toBe('lock');
-  expect(result.chapters[0].stops[1].anchors[0].anchor.startLine).toBeUndefined();
+  expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['s1', 's6']);
+  expect(result.support.map((item: any) => item.id)).toEqual(['lock', 'support-2', 'support-3']);
+  expect(result.chapters[0].stops[0]).toMatchObject({
+    added: 1,
+    deleted: 1,
+    hunkIds: ['src/App.tsx:staged:h1'],
+  });
+  expect(result.chapters[0].stops[0].hunks[0]).toMatchObject({
+    added: 1,
+    additionEnd: 312,
+    additionStart: 310,
+    anchor: {
+      display: 'src/App.tsx:310-312',
+      sectionId: 'src/App.tsx:staged',
+      sectionKind: 'staged',
+    },
+    deleted: 1,
+    deletionEnd: 312,
+    deletionStart: 310,
+    path: 'src/App.tsx',
+    status: 'modified',
+  });
+  expect(result.chapters[0].stops[1]).toMatchObject({ added: 14, deleted: 0 });
+  expect(result.chapters[0].stops[1].hunks[0].anchor.startLine).toBe(1);
 });
 
-test('coerces flat anchor fields into the nested anchor shape', () => {
-  const input = baseInput();
-  input.chapters[0].stops[0].anchors[0] = {
-    ...anchor('flat', 'src/App.tsx'),
-    anchor: undefined,
-    display: 'src/App.tsx flat',
-    sectionId: 'src/App.tsx:staged',
-    sectionKind: 'staged',
-    side: 'both',
-  } as any;
+test('computes line counts and status from hunkIds instead of trusting agent math', () => {
+  const input = baseInput() as any;
+  input.chapters[0].stops[0].added = 110;
+  input.chapters[0].stops[0].deleted = 99;
+  input.chapters[0].stops[0].status = 'added';
 
   const result = normalizeNarrativeWalkthrough(input, files);
 
-  expect(result.chapters[0].stops[0].anchors[0].anchor).toMatchObject({
-    display: 'src/App.tsx flat',
-    sectionId: 'src/App.tsx:staged',
-    sectionKind: 'staged',
-    side: 'both',
+  expect(result.chapters[0].stops[0]).toMatchObject({
+    added: 1,
+    deleted: 1,
   });
+  expect(result.chapters[0].stops[0].hunks[0].status).toBe('modified');
 });
 
-test('drops stops and support files that reference unknown live paths', () => {
+test('normalizes hunk header notes only for selected hunks', () => {
+  const input = baseInput() as any;
+  input.chapters[0].stops[0].notes = [
+    { body: 'Explain the exact root-cause line.', hunkId: 'src/App.tsx:staged:h1' },
+    { body: 'Invalid stale note.', hunkId: 'src/App.tsx:staged:h2' },
+    { body: '', hunkId: 'src/App.tsx:staged:h1' },
+  ];
+
+  const result = normalizeNarrativeWalkthrough(input, files);
+
+  expect(result.chapters[0].stops[0].notes).toEqual([
+    { body: 'Explain the exact root-cause line.', hunkId: 'src/App.tsx:staged:h1' },
+  ]);
+});
+
+test('drops stops and support items with unresolvable hunk ids', () => {
   const input = baseInput();
   input.chapters[0].stops.push({
-    anchors: [anchor('ghost', 'src/removed.ts')],
-    body: 'Ghost.',
-    id: 'ghost-stop',
+    hunkIds: ['src/removed.ts:staged:h1'],
+    id: 'stale',
     importance: 'normal',
-    summary: 'Ghost.',
-    title: 'Ghost',
+    prose: 'Points at a stale file.',
+  });
+  input.support.push({ hunkIds: ['missing.ts:staged:h1'], id: 'missing', reason: 'Generated' });
+
+  const result = normalizeNarrativeWalkthrough(input, files);
+
+  expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['s1', 's6']);
+  expect(result.support.map((item: any) => item.id)).toEqual(['lock', 'support-2', 'support-3']);
+});
+
+test('drops hunk groups that overlap already-covered hunks', () => {
+  const input = baseInput();
+  input.chapters[0].stops.push({
+    hunkIds: ['src/App.tsx:staged:h1', 'wide.py:staged:h1'],
+    id: 'overlap',
+    importance: 'normal',
+    prose: 'Reuses an already annotated hunk.',
   });
   input.support.push({
-    files: [anchor('also-missing', 'src/also-removed.ts')],
-    id: 'missing',
-    title: 'Missing',
+    hunkIds: ['src/__tests__/hunkNavigation.test.ts:staged:h1'],
+    id: 'duplicate-support',
+    reason: 'Duplicate',
   });
 
   const result = normalizeNarrativeWalkthrough(input, files);
 
-  expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['stop-1', 'stop-2']);
-  expect(result.support.map((group: any) => group.id)).toEqual(['lockfiles']);
+  expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['s1', 's6']);
+  expect(result.support.map((item: any) => item.id)).toEqual(['lock', 'support-2', 'support-3']);
 });
 
-test('adds omitted live files to support so changed files remain visible', () => {
+test('adds unreferenced live hunks to support so changed code remains visible', () => {
   const input = baseInput();
   input.support = [];
 
   const result = normalizeNarrativeWalkthrough(input, files);
 
-  expect(result.support.at(-1)).toMatchObject({
-    id: '__missing',
-    note: 'Not included in the generated walkthrough.',
-    title: 'Other changes',
-  });
-  expect(result.support.at(-1).files.map((file: any) => file.path)).toEqual(['pnpm-lock.yaml']);
+  expect(result.support.map((item: any) => item.reason)).toEqual([
+    'Other changes',
+    'Other changes',
+    'Other changes',
+  ]);
+  expect(result.support.map((item: any) => item.hunkIds)).toEqual([
+    ['pnpm-lock.yaml:staged:h1'],
+    ['wide.py:staged:h1', 'wide.py:staged:h2', 'wide.py:staged:h3'],
+    ['wide.py:staged:h4'],
+  ]);
 });
 
-test('normalizes multiple anchors under the same stop', () => {
+test('normalizes ordered cross-file hunk groups under one stop', () => {
   const input = baseInput();
   input.chapters[0].stops = [
     {
-      anchors: [
-        input.chapters[0].stops[0].anchors[0],
-        input.chapters[0].stops[1].anchors[0],
-        anchor('missing', 'src/nope.ts'),
-      ],
-      body: 'The root cause and proof are one review idea.',
-      id: 'combined',
+      hunkIds: ['src/__tests__/hunkNavigation.test.ts:staged:h1', 'src/App.tsx:staged:h1'],
+      id: 'combo',
       importance: 'critical',
-      summary: 'The root cause and proof are one review idea.',
-      title: 'Flow',
+      prose: 'The proof and root cause are one review idea.',
     },
   ];
 
   const result = normalizeNarrativeWalkthrough(input, files);
+  const stop = result.chapters[0].stops[0];
 
-  expect(result.chapters[0].stops).toHaveLength(1);
-  expect(result.chapters[0].stops[0].anchors.map((item: any) => item.id)).toEqual(['a1', 'a2']);
-  expect(result.support.map((group: any) => group.id)).toEqual(['lockfiles']);
+  expect(stop).toMatchObject({
+    added: 15,
+    deleted: 1,
+    hunkIds: ['src/__tests__/hunkNavigation.test.ts:staged:h1', 'src/App.tsx:staged:h1'],
+  });
+  expect(stop.hunks.map((hunk: any) => hunk.path)).toEqual([
+    'src/__tests__/hunkNavigation.test.ts',
+    'src/App.tsx',
+  ]);
 });
 
-test('drops duplicate file paths after their first anchor', () => {
-  const input = baseInput();
-  input.chapters[0].stops[0].anchors.push(
-    anchor('duplicate-app', 'src/App.tsx', {
-      summary: 'A second anchor for the same file should not render twice.',
-    }),
-  );
-
-  const result = normalizeNarrativeWalkthrough(input, files);
-
-  expect(result.chapters[0].stops[0].anchors.map((item: any) => item.id)).toEqual(['a1']);
-});
-
-test('duplicate stop ids do not consume anchors from the kept coverage set', () => {
+test('drops hunk groups that exceed the hunk group size limit', () => {
   const input = baseInput();
   input.chapters[0].stops.push({
-    anchors: [
-      anchor('duplicate-stop-lock', 'pnpm-lock.yaml', {
-        summary: 'A duplicate stop id should not hide this file from support.',
-      }),
-    ],
-    body: 'Duplicate stop.',
-    id: 'stop-1',
+    hunkIds: ['wide.py:staged:h1', 'wide.py:staged:h2', 'wide.py:staged:h3', 'wide.py:staged:h4'],
+    id: 'wide',
     importance: 'normal',
-    summary: 'Duplicate stop.',
-    title: 'Duplicate',
+    prose: 'Too broad.',
   });
 
   const result = normalizeNarrativeWalkthrough(input, files);
 
-  expect(result.support.map((group: any) => group.id)).toEqual(['lockfiles']);
-  expect(result.support[0].files.map((file: any) => file.id)).toEqual(['lock']);
+  expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['s1', 's6']);
 });
 
-test('duplicate support group ids do not consume files from later coverage repair', () => {
+test('throws when no chapters have resolvable stops', () => {
   const input = baseInput();
-  const filesWithDocs = [
-    ...files,
-    {
-      path: 'docs/walkthrough.md',
-      sections: [
-        {
-          id: 'docs/walkthrough.md:staged',
-          kind: 'staged',
-          patch: '@@ -0,0 +1 @@\n+docs\n',
-        },
-      ],
-      status: 'added',
-    },
-  ];
-  input.support = [
-    {
-      files: [
-        anchor('lock-first', 'pnpm-lock.yaml', {
-          summary: 'First support group.',
-        }),
-      ],
-      id: 'duplicate',
-      title: 'First',
-    },
-    {
-      files: [
-        anchor('docs-skipped', 'docs/walkthrough.md', {
-          summary: 'Duplicate support group.',
-          status: 'added',
-        }),
-      ],
-      id: 'duplicate',
-      title: 'Second',
-    },
-    {
-      files: [
-        anchor('docs-kept', 'docs/walkthrough.md', {
-          summary: 'Unique support group.',
-          status: 'added',
-        }),
-      ],
-      id: 'docs',
-      title: 'Docs',
-    },
-  ];
+  input.chapters = input.chapters.map((chapter) => ({
+    ...chapter,
+    stops: chapter.stops.map((stop) => ({
+      ...stop,
+      hunkIds: ['nope.ts:staged:h1'],
+    })),
+  }));
 
-  const result = normalizeNarrativeWalkthrough(input, filesWithDocs);
-
-  expect(result.support.map((group: any) => group.id)).toEqual(['duplicate', 'docs']);
-  expect(result.support[1].files.map((file: any) => file.id)).toEqual(['docs-kept']);
+  expect(() => normalizeNarrativeWalkthrough(input, files)).toThrow(/no chapters/i);
 });
 
-test('repairs a missing or stale anchor sectionId against the live diff', () => {
-  const input = baseInput();
-  input.chapters[0].stops[0].anchors[0].anchor.sectionId = 'src/App.tsx:unstaged';
-  delete (input.chapters[0].stops[1].anchors[0].anchor as any).sectionId;
-
-  const result = normalizeNarrativeWalkthrough(input, files);
-
-  expect(result.chapters[0].stops[0].anchors[0].anchor.sectionId).toBe('src/App.tsx:staged');
-  expect(result.chapters[0].stops[1].anchors[0].anchor.sectionId).toBe(
-    'src/__tests__/hunkNavigation.test.ts:staged',
-  );
-});
-
-test('throws when no anchors match the diff and there are no live files', () => {
-  const input = baseInput();
-  input.chapters[0].stops[0].anchors[0].path = 'nope.ts';
-  input.chapters[0].stops[1].anchors[0].path = 'still-nope.ts';
-  input.support = [];
-
-  expect(() => normalizeNarrativeWalkthrough(input, [])).toThrow(/no anchors/i);
-});
-
-test('preserves embedded conversation context for in-app Q&A', () => {
-  const input = baseInput() as any;
-  input.context = {
-    objective: 'Stop hunk navigation skipping collapsed files.',
-    source: { generatedAt: '2026-06-05T00:00:00.000Z', type: 'claude-session' },
-    version: 1,
+test('throws an explicit error for legacy v3 anchor walkthroughs', () => {
+  const input = {
+    chapters: [
+      {
+        blurb: 'Legacy.',
+        icon: 'path',
+        id: 'legacy',
+        stops: [
+          {
+            anchors: [
+              {
+                added: 1,
+                anchor: { display: 'src/App.tsx:310' },
+                deleted: 1,
+                granularity: 'line',
+                id: 'a1',
+                path: 'src/App.tsx',
+                status: 'modified',
+              },
+            ],
+            body: 'Legacy body.',
+            id: 's1',
+            importance: 'normal',
+            summary: 'Legacy summary.',
+            title: 'Legacy',
+          },
+        ],
+        title: 'Legacy',
+      },
+    ],
+    focus: 'Legacy walkthrough.',
+    kind: 'narrative',
+    support: [],
+    title: 'Legacy',
+    version: 3,
   };
 
-  const result = normalizeNarrativeWalkthrough(input, files);
-
-  expect(result.context.objective).toBe('Stop hunk navigation skipping collapsed files.');
+  expect(() => normalizeNarrativeWalkthrough(input, files)).toThrow(/legacy v3 anchors\[\]/i);
+  expect(() => normalizeNarrativeWalkthrough(input, files)).toThrow(/v4 hunkIds\[\]/i);
 });
 
-test('normalizes per-anchor commit tags', () => {
+test('normalizes per-item commit tags', () => {
   const input = baseInput() as any;
-  input.chapters[0].stops[0].anchors[0].changeType = 'fix';
-  input.chapters[0].stops[0].anchors[0].commitNote = 'derive a collapse-independent hunk order';
-  input.support[0].files[0].changeType = 'not-a-tag';
+  input.chapters[0].stops[0].changeType = 'fix';
+  input.chapters[0].stops[0].commitNote = 'derive a collapse-independent hunk order';
+  input.support[0].changeType = 'not-a-tag';
 
   const result = normalizeNarrativeWalkthrough(input, files);
 
-  expect(result.chapters[0].stops[0].anchors[0].changeType).toBe('fix');
-  expect(result.chapters[0].stops[0].anchors[0].commitNote).toBe(
-    'derive a collapse-independent hunk order',
-  );
-  expect(result.support[0].files[0].changeType).toBeUndefined();
+  expect(result.chapters[0].stops[0].changeType).toBe('fix');
+  expect(result.chapters[0].stops[0].commitNote).toBe('derive a collapse-independent hunk order');
+  expect(result.support[0].changeType).toBeUndefined();
 });
 
 test('keeps the commit composer for a working-tree staging set', () => {
@@ -442,6 +452,21 @@ test('derives a missing commit title from a title-like body first line', () => {
   });
 });
 
+test('strips a duplicated commit title from the body', () => {
+  const input = baseInput() as any;
+  input.commit = {
+    body: 'Fix hunk nav\n\nNavigation expands a collapsed target before scrolling.',
+    title: 'Fix hunk nav',
+  };
+
+  const result = normalizeNarrativeWalkthrough(input, files);
+
+  expect(result.commit).toEqual({
+    body: 'Navigation expands a collapsed target before scrolling.',
+    title: 'Fix hunk nav',
+  });
+});
+
 test('adds an empty commit composer for a working-tree walkthrough without commit seeds', () => {
   const input = baseInput() as any;
   delete input.commit;
@@ -454,9 +479,10 @@ test('adds an empty commit composer for a working-tree walkthrough without commi
 test('strips the commit composer when the source is not a working tree', () => {
   const input = baseInput() as any;
   input.commit = { title: 'Fix hunk nav' };
-  input.source = { ref: 'abc1234', type: 'commit' };
 
-  const result = normalizeNarrativeWalkthrough(input, files);
+  const result = normalizeNarrativeWalkthrough(input, files, {
+    source: { ref: 'abc1234', type: 'commit' },
+  });
 
   expect(result.commit).toBeUndefined();
 });

--- a/electron/__tests__/narrative-walkthrough.test.ts
+++ b/electron/__tests__/narrative-walkthrough.test.ts
@@ -146,7 +146,7 @@ test('derives an OpenAI strict-compatible response schema', () => {
   expect(stopProperties.changeType.type).toContain('null');
   expect(stopProperties.changeType.enum).toContain(null);
   expect(stopProperties.hunkIds.minItems).toBe(1);
-  expect(stopProperties.hunkIds.maxItems).toBe(3);
+  expect(stopProperties.hunkIds.maxItems).toBe(14);
   expect(stopProperties.notes.items.required).toEqual(['body', 'hunkId']);
   expect(stopProperties.comments).toBeUndefined();
 });
@@ -168,7 +168,7 @@ test('prompts generated walkthroughs to use deterministic hunk groups', () => {
   expect(prompt).toContain('Target 7-12 main-path stops');
   expect(prompt).toContain('Define chapters[] in display order');
   expect(prompt).toContain('Default to one hunkId per stop or support item');
-  expect(prompt).toContain('A stop or support item may contain at most 3 hunkIds');
+  expect(prompt).toContain('A stop or support item may contain at most 14 hunkIds');
   expect(prompt).toContain('Put hunkIds in the exact display order');
   expect(prompt).toContain('Use notes[] on a stop/support item');
   expect(prompt).not.toContain('comments[]');
@@ -190,6 +190,63 @@ test('repository digest exposes deterministic hunk ids and counts', () => {
   expect(prompt).toContain('Do not provide added/deleted counts');
 });
 
+test('repository digest exposes synthetic hunk ids for non-text sections', () => {
+  const prompt = buildNarrativeWalkthroughPrompt({
+    branch: 'main',
+    files: [
+      {
+        path: 'public/logo.png',
+        sections: [
+          {
+            binary: true,
+            id: 'public/logo.png:staged',
+            kind: 'staged',
+            loadState: 'binary',
+            patch: '',
+            summary: { reason: 'Binary file changed.' },
+          },
+        ],
+        status: 'modified',
+      },
+    ],
+    generatedAt: 1,
+    root: '/repo',
+    source: { type: 'working-tree' },
+  });
+
+  expect(prompt).toContain('"id": "public/logo.png:staged:h1"');
+  expect(prompt).toContain('"kind": "synthetic"');
+  expect(prompt).toContain('"summary": "Binary file changed."');
+});
+
+test('repository digest exposes synthetic hunk ids for metadata-only renames', () => {
+  const prompt = buildNarrativeWalkthroughPrompt({
+    branch: 'main',
+    files: [
+      {
+        oldPath: 'old.txt',
+        path: 'new.txt',
+        sections: [
+          {
+            binary: false,
+            id: 'new.txt:staged',
+            kind: 'staged',
+            loadState: 'ready',
+            patch: '',
+          },
+        ],
+        status: 'renamed',
+      },
+    ],
+    generatedAt: 1,
+    root: '/repo',
+    source: { type: 'working-tree' },
+  });
+
+  expect(prompt).toContain('"id": "new.txt:staged:h1"');
+  expect(prompt).toContain('"kind": "synthetic"');
+});
+
 test('normalizes a well-formed narrative walkthrough', () => {
   const result = normalizeNarrativeWalkthrough(baseInput(), files, {
     agent: 'claude',
@@ -208,7 +265,7 @@ test('normalizes a well-formed narrative walkthrough', () => {
   expect(result.meta).toBe('2 stops · 1 chapters');
   expect(result.chapters).toHaveLength(1);
   expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['s1', 's6']);
-  expect(result.support.map((item: any) => item.id)).toEqual(['lock', 'support-2', 'support-3']);
+  expect(result.support.map((item: any) => item.id)).toEqual(['lock', 'support-2']);
   expect(result.chapters[0].stops[0]).toMatchObject({
     added: 1,
     deleted: 1,
@@ -231,6 +288,87 @@ test('normalizes a well-formed narrative walkthrough', () => {
   });
   expect(result.chapters[0].stops[1]).toMatchObject({ added: 14, deleted: 0 });
   expect(result.chapters[0].stops[1].hunks[0].anchor.startLine).toBe(1);
+});
+
+test('normalizes walkthroughs made only of synthetic hunks', () => {
+  const syntheticFiles = [
+    {
+      path: 'public/logo.png',
+      sections: [
+        {
+          binary: true,
+          id: 'public/logo.png:staged',
+          kind: 'staged',
+          loadState: 'binary',
+          patch: '',
+          summary: { reason: 'Binary file changed.' },
+        },
+      ],
+      status: 'modified',
+    },
+    {
+      path: 'large.txt',
+      sections: [
+        {
+          binary: false,
+          id: 'large.txt:unstaged',
+          kind: 'unstaged',
+          loadState: 'deferred',
+          patch: '',
+          summary: { canLoad: true, reason: 'File is 2 MiB and will be loaded on demand.' },
+        },
+      ],
+      status: 'modified',
+    },
+  ];
+  const result = normalizeNarrativeWalkthrough(
+    {
+      chapters: [
+        {
+          blurb: 'Non-text review units.',
+          icon: 'path',
+          id: 'assets',
+          stops: [
+            {
+              hunkIds: ['public/logo.png:staged:h1'],
+              id: 'logo',
+              importance: 'normal',
+              prose: 'Review the shipped image asset.',
+            },
+            {
+              hunkIds: ['large.txt:unstaged:h1'],
+              id: 'large',
+              importance: 'context',
+              prose: 'Review why this file is summarized.',
+            },
+          ],
+          title: 'Assets',
+        },
+      ],
+      focus: 'Review non-text changes.',
+      kind: 'narrative',
+      support: [],
+      title: 'Synthetic hunk walkthrough',
+      version: 4,
+    },
+    syntheticFiles as any,
+  );
+
+  expect(result.chapters[0].stops.map((stop: any) => stop.hunks[0])).toMatchObject([
+    {
+      added: 0,
+      anchor: { display: 'public/logo.png', sectionId: 'public/logo.png:staged' },
+      deleted: 0,
+      id: 'public/logo.png:staged:h1',
+      kind: 'synthetic',
+    },
+    {
+      anchor: { display: 'large.txt', sectionId: 'large.txt:unstaged' },
+      id: 'large.txt:unstaged:h1',
+      kind: 'synthetic',
+    },
+  ]);
+  expect(result.support).toEqual([]);
 });
 
 test('computes line counts and status from hunkIds instead of trusting agent math', () => {
@@ -276,7 +414,7 @@ test('drops stops and support items with unresolvable hunk ids', () => {
   const result = normalizeNarrativeWalkthrough(input, files);
 
   expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['s1', 's6']);
-  expect(result.support.map((item: any) => item.id)).toEqual(['lock', 'support-2', 'support-3']);
+  expect(result.support.map((item: any) => item.id)).toEqual(['lock', 'support-2']);
 });
 
 test('drops hunk groups that overlap already-covered hunks', () => {
@@ -296,7 +434,7 @@ test('drops hunk groups that overlap already-covered hunks', () => {
   const result = normalizeNarrativeWalkthrough(input, files);
 
   expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['s1', 's6']);
-  expect(result.support.map((item: any) => item.id)).toEqual(['lock', 'support-2', 'support-3']);
+  expect(result.support.map((item: any) => item.id)).toEqual(['lock', 'support-2']);
 });
 
 test('adds unreferenced live hunks to support so changed code remains visible', () => {
@@ -308,12 +446,10 @@ test('adds unreferenced live hunks to support so changed code remains visible', 
   expect(result.support.map((item: any) => item.reason)).toEqual([
     'Other changes',
     'Other changes',
-    'Other changes',
   ]);
   expect(result.support.map((item: any) => item.hunkIds)).toEqual([
     ['pnpm-lock.yaml:staged:h1'],
-    ['wide.py:staged:h1', 'wide.py:staged:h2', 'wide.py:staged:h3'],
-    ['wide.py:staged:h4'],
+    ['wide.py:staged:h1', 'wide.py:staged:h2', 'wide.py:staged:h3', 'wide.py:staged:h4'],
   ]);
 });
 
@@ -344,14 +480,23 @@ test('normalizes ordered cross-file hunk groups under one stop', () => {
 
 test('drops hunk groups that exceed the hunk group size limit', () => {
   const input = baseInput();
+  const overLimitPatch = Array.from(
+    { length: 15 },
+    (_, index) => `@@ -${index + 1} +${index + 1} @@\n-old ${index + 1}\n+new ${index + 1}\n`,
+  ).join('');
+  const overLimitFile = {
+    path: 'too-wide.py',
+    sections: [{ id: 'too-wide.py:staged', kind: 'staged', patch: overLimitPatch }],
+    status: 'modified',
+  };
   input.chapters[0].stops.push({
-    hunkIds: ['wide.py:staged:h1', 'wide.py:staged:h2', 'wide.py:staged:h3', 'wide.py:staged:h4'],
+    hunkIds: Array.from({ length: 15 }, (_, index) => `too-wide.py:staged:h${index + 1}`),
     id: 'wide',
     importance: 'normal',
     prose: 'Too broad.',
   });
 
-  const result = normalizeNarrativeWalkthrough(input, files);
+  const result = normalizeNarrativeWalkthrough(input, [...files, overLimitFile]);
 
   expect(result.chapters[0].stops.map((stop: any) => stop.id)).toEqual(['s1', 's6']);
 });

--- a/electron/codex.cjs
+++ b/electron/codex.cjs
@@ -14,7 +14,7 @@ const {
   truncate,
 } = require('./agent-shared.cjs');
 
-const CODEX_TIMEOUT_MS = 45_000;
+const CODEX_TIMEOUT_MS = 90_000;
 const DEFAULT_OPENAI_MODEL = 'gpt-5.3-codex-spark';
 const FALLBACK_OPENAI_MODEL = 'gpt-5.5';
 const CODEX_REASONING_EFFORT = 'high';

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -136,10 +136,6 @@ const normalizeCodeFontSize = (size) => {
 const normalizeLastRepositoryPath = (path) =>
   typeof path === 'string' && path.length > 0 ? path : '';
 
-/** @param {unknown} order */
-const normalizeWalkthroughOrder = (order) =>
-  typeof order === 'string' && order.length > 0 ? order : 'keys';
-
 /**
  * Accept a single combo string or a non-empty list of combo strings.
  * @param {unknown} binding
@@ -264,7 +260,6 @@ const mergeConfig = (raw) => {
           ? rawSettings.showWhitespace
           : defaults.settings.showWhitespace,
       theme: normalizeTheme(rawSettings.theme),
-      walkthroughOrder: normalizeWalkthroughOrder(rawSettings.walkthroughOrder),
       wordWrap:
         typeof rawSettings.wordWrap === 'boolean'
           ? rawSettings.wordWrap

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -558,31 +558,6 @@ const buildApplicationMenu = () =>
             ],
           },
           {
-            label: 'Walkthrough',
-            submenu: [
-              {
-                checked: config.settings.walkthroughOrder !== 'results',
-                click: () => {
-                  updateConfig({
-                    settings: { ...config.settings, walkthroughOrder: 'keys' },
-                  });
-                },
-                label: 'Key Changes',
-                type: 'radio',
-              },
-              {
-                checked: config.settings.walkthroughOrder === 'results',
-                click: () => {
-                  updateConfig({
-                    settings: { ...config.settings, walkthroughOrder: 'results' },
-                  });
-                },
-                label: 'Results First',
-                type: 'radio',
-              },
-            ],
-          },
-          {
             label: 'Comments',
             submenu: [
               {
@@ -995,7 +970,12 @@ ipcMain.handle('codiff:getNarrativeWalkthrough', async (event, source) => {
       try {
         return {
           status: 'ready',
-          walkthrough: normalizeNarrativeWalkthrough(input, state.files),
+          walkthrough: normalizeNarrativeWalkthrough(input, state.files, {
+            branch: state.branch,
+            generatedAt: state.generatedAt,
+            root: state.root,
+            source: state.source,
+          }),
         };
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
@@ -1094,15 +1074,6 @@ ipcMain.handle('codiff:setDiffStyle', (_event, value) => {
 
 ipcMain.handle('codiff:setShowOutdated', (_event, value) => {
   updateConfig({ settings: { ...config.settings, showOutdated: Boolean(value) } });
-});
-
-ipcMain.handle('codiff:setWalkthroughOrder', (_event, value) => {
-  updateConfig({
-    settings: {
-      ...config.settings,
-      walkthroughOrder: typeof value === 'string' && value.length > 0 ? value : 'keys',
-    },
-  });
 });
 
 ipcMain.handle('codiff:setWordWrap', (_event, value) => {

--- a/electron/narrative-walkthrough-schema.cjs
+++ b/electron/narrative-walkthrough-schema.cjs
@@ -1,0 +1,182 @@
+// @ts-check
+
+const IMPORTANCES = new Set(['critical', 'normal', 'context']);
+const ICONS = new Set(['bug', 'wrench', 'path', 'flask', 'beaker', 'doc', 'gear']);
+const AGENTS = new Set(['codex', 'claude']);
+const CHANGE_TYPES = new Set([
+  'fix',
+  'feature',
+  'refactor',
+  'test',
+  'generated',
+  'lockfile',
+  'snapshot',
+  'i18n',
+  'docs',
+]);
+
+const MAX_WALKTHROUGH_CHAPTERS = 6;
+const MAX_WALKTHROUGH_STOPS = 14;
+const MAX_HUNKS_PER_WALKTHROUGH_GROUP = 3;
+
+const hunkGroupProperties = {
+  changeType: { enum: [...CHANGE_TYPES], type: 'string' },
+  commitNote: { type: 'string' },
+  hunkIds: {
+    description:
+      'Deterministic hunk ids from the repository digest, in the display order Codiff should render them.',
+    items: { type: 'string' },
+    maxItems: MAX_HUNKS_PER_WALKTHROUGH_GROUP,
+    minItems: 1,
+    type: 'array',
+  },
+  id: { type: 'string' },
+  notes: {
+    description:
+      'Optional short header notes for selected hunk ids. Codiff renders each note under that focused diff header.',
+    items: {
+      additionalProperties: false,
+      properties: {
+        body: { type: 'string' },
+        hunkId: { type: 'string' },
+      },
+      required: ['hunkId', 'body'],
+      type: 'object',
+    },
+    type: 'array',
+  },
+  summary: { type: 'string' },
+  title: { type: 'string' },
+};
+
+// Keep in sync with src/walkthrough/narrative-walkthrough.schema.json;
+// electron/__tests__/narrative-walkthrough.test.ts enforces equality.
+// Authoring agents constrain output to it; the renderer trusts only the
+// normalized result, not the raw schema-valid input.
+const narrativeWalkthroughSchema = {
+  additionalProperties: false,
+  properties: {
+    commit: {
+      additionalProperties: false,
+      properties: {
+        body: { type: 'string' },
+        title: { type: 'string' },
+      },
+      type: 'object',
+    },
+    chapters: {
+      items: {
+        additionalProperties: false,
+        properties: {
+          blurb: { type: 'string' },
+          icon: { enum: [...ICONS], type: 'string' },
+          id: { type: 'string' },
+          stops: {
+            items: {
+              additionalProperties: false,
+              properties: {
+                ...hunkGroupProperties,
+                importance: { enum: [...IMPORTANCES], type: 'string' },
+                prose: { type: 'string' },
+              },
+              required: ['id', 'hunkIds', 'importance', 'prose'],
+              type: 'object',
+            },
+            maxItems: MAX_WALKTHROUGH_STOPS,
+            type: 'array',
+          },
+          title: { maxLength: 16, type: 'string' },
+        },
+        required: ['id', 'title', 'icon', 'blurb', 'stops'],
+        type: 'object',
+      },
+      maxItems: MAX_WALKTHROUGH_CHAPTERS,
+      type: 'array',
+    },
+    focus: { type: 'string' },
+    kind: { const: 'narrative', type: 'string' },
+    support: {
+      items: {
+        additionalProperties: false,
+        properties: {
+          ...hunkGroupProperties,
+          note: { type: 'string' },
+          reason: { type: 'string' },
+        },
+        required: ['id', 'hunkIds', 'reason'],
+        type: 'object',
+      },
+      type: 'array',
+    },
+    title: { type: 'string' },
+    version: { const: 4, type: 'number' },
+  },
+  required: ['version', 'kind', 'title', 'focus', 'chapters'],
+  type: 'object',
+};
+
+const toArray = (value) => (Array.isArray(value) ? value : value == null ? [] : [value]);
+
+/**
+ * OpenAI structured outputs require every object key to be listed in `required`.
+ * Keep Codiff's public schema ergonomic, and derive the stricter response-format
+ * schema only for agent calls. Originally optional properties become nullable.
+ * @param {any} schema
+ * @param {boolean} [optional]
+ */
+const strictResponseSchema = (schema, optional = false) => {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return schema;
+  }
+
+  const next = { ...schema };
+  const typeValues = toArray(next.type);
+  const isObject = typeValues.includes('object') || next.properties;
+
+  if (next.properties && typeof next.properties === 'object') {
+    const originalRequired = new Set(Array.isArray(next.required) ? next.required : []);
+    const properties = {};
+    for (const [key, value] of Object.entries(next.properties)) {
+      properties[key] = strictResponseSchema(value, !originalRequired.has(key));
+    }
+    next.properties = properties;
+  }
+
+  if (next.items) {
+    next.items = strictResponseSchema(next.items, false);
+  }
+
+  if (isObject) {
+    next.additionalProperties = false;
+    next.required = Object.keys(next.properties || {});
+  }
+
+  if (optional) {
+    if (Array.isArray(next.enum) && !next.enum.includes(null)) {
+      next.enum = [...next.enum, null];
+    }
+
+    if (next.type) {
+      next.type = [...new Set([...toArray(next.type), 'null'])];
+    } else if (next.const !== undefined) {
+      next.anyOf = [{ const: next.const }, { type: 'null' }];
+      delete next.const;
+    }
+  }
+
+  return next;
+};
+
+const narrativeWalkthroughResponseSchema = strictResponseSchema(narrativeWalkthroughSchema);
+
+module.exports = {
+  AGENTS,
+  CHANGE_TYPES,
+  ICONS,
+  IMPORTANCES,
+  MAX_WALKTHROUGH_CHAPTERS,
+  MAX_WALKTHROUGH_STOPS,
+  MAX_HUNKS_PER_WALKTHROUGH_GROUP,
+  narrativeWalkthroughResponseSchema,
+  narrativeWalkthroughSchema,
+};

--- a/electron/narrative-walkthrough-schema.cjs
+++ b/electron/narrative-walkthrough-schema.cjs
@@ -17,7 +17,7 @@ const CHANGE_TYPES = new Set([
 
 const MAX_WALKTHROUGH_CHAPTERS = 6;
 const MAX_WALKTHROUGH_STOPS = 14;
-const MAX_HUNKS_PER_WALKTHROUGH_GROUP = 3;
+const MAX_HUNKS_PER_WALKTHROUGH_GROUP = 14;
 
 const hunkGroupProperties = {
   changeType: { enum: [...CHANGE_TYPES], type: 'string' },

--- a/electron/narrative-walkthrough.cjs
+++ b/electron/narrative-walkthrough.cjs
@@ -1,10 +1,9 @@
 // @ts-check
 
-// Validation, generation, and normalization for the Narrative Walkthrough
-// (version 2) document. This module is the trust boundary: it validates and
-// repairs agent-authored documents against the live diff so the renderer always
-// gets a walkthrough whose references resolve.
+// Narrative walkthrough generation and normalization trust boundary.
 
+const { readFileSync } = require('node:fs');
+const { dirname, join } = require('node:path');
 const {
   cleanText,
   normalizeEnum,
@@ -12,6 +11,24 @@ const {
   parseJSONMessage,
   truncate,
 } = require('./agent-shared.cjs');
+const {
+  AGENTS,
+  CHANGE_TYPES,
+  ICONS,
+  IMPORTANCES,
+  MAX_HUNKS_PER_WALKTHROUGH_GROUP,
+  MAX_WALKTHROUGH_CHAPTERS,
+  MAX_WALKTHROUGH_STOPS,
+  narrativeWalkthroughResponseSchema,
+  narrativeWalkthroughSchema,
+} = require('./narrative-walkthrough-schema.cjs');
+const {
+  buildAnchorDisplay,
+  extractPatchHunks,
+  hunkDisplayEnd,
+  hunkDisplayStart,
+  sumHunkLineCounts,
+} = require('../shared/narrative-walkthrough-diff.cjs');
 
 /**
  * @typedef {import('../src/types.ts').ChangedFile} ChangedFile
@@ -24,242 +41,12 @@ const {
  * @typedef {import('./agent.cjs').AgentOptions} AgentOptions
  */
 
-const GRANULARITIES = new Set(['line', 'hunk', 'file']);
-const IMPORTANCES = new Set(['critical', 'normal', 'context']);
-const SIDES = new Set(['additions', 'deletions', 'both']);
-const COMMENT_SIDES = new Set(['additions', 'deletions']);
-const STATUSES = new Set(['added', 'deleted', 'modified', 'renamed', 'untracked']);
-const ICONS = new Set(['bug', 'wrench', 'path', 'flask', 'beaker', 'doc', 'gear']);
-const AGENTS = new Set(['codex', 'claude']);
-const SECTION_KINDS = new Set(['commit', 'pull-request', 'staged', 'unstaged']);
-const CHANGE_TYPES = new Set([
-  'fix',
-  'feature',
-  'refactor',
-  'test',
-  'generated',
-  'lockfile',
-  'snapshot',
-  'i18n',
-  'docs',
-]);
-
+const root = dirname(__dirname);
 const MAX_PROSE_CHARS = 4_000;
 const MAX_TOTAL_PATCH_CHARS = 60_000;
 const MAX_LARGE_TOTAL_PATCH_CHARS = 35_000;
 const MAX_SECTION_PATCH_CHARS = 2_500;
 const MAX_LARGE_SECTION_PATCH_CHARS = 700;
-const MAX_WALKTHROUGH_PHASES = 6;
-const MAX_WALKTHROUGH_STOPS = 14;
-
-const anchorTargetSchema = {
-  additionalProperties: false,
-  properties: {
-    added: { type: 'number' },
-    anchor: {
-      additionalProperties: false,
-      properties: {
-        display: { type: 'string' },
-        endLine: { type: 'number' },
-        sectionId: { type: 'string' },
-        sectionKind: { enum: [...SECTION_KINDS], type: 'string' },
-        side: { enum: [...SIDES], type: 'string' },
-        startLine: { type: 'number' },
-      },
-      required: ['display'],
-      type: 'object',
-    },
-    changeType: { enum: [...CHANGE_TYPES], type: 'string' },
-    comments: {
-      items: {
-        additionalProperties: false,
-        properties: {
-          author: { type: 'string' },
-          body: { type: 'string' },
-          id: { type: 'string' },
-          lineNumber: { type: 'number' },
-          side: { enum: [...COMMENT_SIDES], type: 'string' },
-          startLineNumber: { type: 'number' },
-          startSide: { enum: [...COMMENT_SIDES], type: 'string' },
-        },
-        required: ['id', 'body', 'side', 'lineNumber'],
-        type: 'object',
-      },
-      type: 'array',
-    },
-    commitNote: { type: 'string' },
-    deleted: { type: 'number' },
-    granularity: { enum: [...GRANULARITIES], type: 'string' },
-    id: { type: 'string' },
-    oldPath: { type: 'string' },
-    path: { type: 'string' },
-    status: { enum: [...STATUSES], type: 'string' },
-    summary: { type: 'string' },
-    title: { type: 'string' },
-  },
-  required: ['id', 'path', 'status', 'granularity', 'anchor', 'added', 'deleted'],
-  type: 'object',
-};
-
-// The narrative walkthrough JSON schema, kept in sync with src/walkthrough/
-// narrative-walkthrough.schema.json. Authoring agents constrain output to it; the
-// renderer trusts only the normalized result, not the raw schema-valid input.
-const narrativeWalkthroughSchema = {
-  additionalProperties: false,
-  properties: {
-    agent: { enum: ['codex', 'claude'], type: 'string' },
-    chapters: {
-      items: {
-        additionalProperties: false,
-        properties: {
-          blurb: { type: 'string' },
-          icon: { enum: [...ICONS], type: 'string' },
-          id: { type: 'string' },
-          stops: {
-            items: {
-              additionalProperties: false,
-              properties: {
-                anchors: {
-                  items: anchorTargetSchema,
-                  maxItems: 8,
-                  type: 'array',
-                },
-                body: { type: 'string' },
-                id: { type: 'string' },
-                importance: { enum: [...IMPORTANCES], type: 'string' },
-                summary: { type: 'string' },
-                title: { type: 'string' },
-              },
-              required: ['id', 'title', 'summary', 'body', 'importance', 'anchors'],
-              type: 'object',
-            },
-            maxItems: MAX_WALKTHROUGH_STOPS,
-            type: 'array',
-          },
-          title: { maxLength: 16, type: 'string' },
-        },
-        required: ['id', 'title', 'icon', 'blurb', 'stops'],
-        type: 'object',
-      },
-      maxItems: MAX_WALKTHROUGH_PHASES,
-      type: 'array',
-    },
-    commit: {
-      additionalProperties: false,
-      properties: {
-        body: { type: 'string' },
-        title: { type: 'string' },
-      },
-      type: 'object',
-    },
-    context: { type: 'object' },
-    focus: { type: 'string' },
-    generatedAt: { type: 'string' },
-    kind: { const: 'narrative', type: 'string' },
-    meta: { type: 'string' },
-    repo: {
-      additionalProperties: false,
-      properties: {
-        branch: { type: ['string', 'null'] },
-        root: { type: 'string' },
-      },
-      required: ['root', 'branch'],
-      type: 'object',
-    },
-    source: { type: 'object' },
-    support: {
-      items: {
-        additionalProperties: false,
-        properties: {
-          id: { type: 'string' },
-          files: {
-            items: anchorTargetSchema,
-            type: 'array',
-          },
-          note: { type: 'string' },
-          title: { type: 'string' },
-        },
-        required: ['id', 'title', 'files'],
-        type: 'object',
-      },
-      type: 'array',
-    },
-    title: { type: 'string' },
-    version: { const: 3, type: 'number' },
-  },
-  required: ['version', 'kind', 'agent', 'title', 'focus', 'repo', 'source', 'chapters', 'support'],
-  type: 'object',
-};
-
-const toArray = (value) => (Array.isArray(value) ? value : value == null ? [] : [value]);
-
-/**
- * OpenAI structured outputs require every object key to be listed in `required`.
- * Keep Codiff's public schema ergonomic, and derive the stricter response-format
- * schema only for agent calls. Originally optional properties become nullable.
- * @param {any} schema
- * @param {boolean} [optional]
- */
-const strictResponseSchema = (schema, optional = false) => {
-  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
-    return schema;
-  }
-
-  const next = { ...schema };
-  const typeValues = toArray(next.type);
-  const isObject = typeValues.includes('object') || next.properties;
-
-  if (next.properties && typeof next.properties === 'object') {
-    const originalRequired = new Set(Array.isArray(next.required) ? next.required : []);
-    const properties = {};
-    for (const [key, value] of Object.entries(next.properties)) {
-      properties[key] = strictResponseSchema(value, !originalRequired.has(key));
-    }
-    next.properties = properties;
-  }
-
-  if (next.items) {
-    next.items = strictResponseSchema(next.items, false);
-  }
-
-  if (isObject) {
-    next.additionalProperties = false;
-    next.required = Object.keys(next.properties || {});
-  }
-
-  if (optional) {
-    if (next.type) {
-      next.type = [...new Set([...toArray(next.type), 'null'])];
-    } else if (next.const !== undefined) {
-      next.anyOf = [{ const: next.const }, { type: 'null' }];
-      delete next.const;
-    }
-  }
-
-  return next;
-};
-
-/**
- * @param {any} schema
- * @param {ReadonlyArray<string>} keys
- */
-const omitSchemaProperties = (schema, keys) => {
-  const next = {
-    ...schema,
-    properties: { ...schema.properties },
-  };
-  for (const key of keys) {
-    delete next.properties[key];
-  }
-  next.required = (Array.isArray(schema.required) ? schema.required : []).filter(
-    (key) => !keys.includes(key),
-  );
-  return next;
-};
-
-const narrativeWalkthroughResponseSchema = strictResponseSchema(
-  omitSchemaProperties(narrativeWalkthroughSchema, ['context', 'source']),
-);
 
 /** @param {unknown} value @param {string} [fallback] */
 const cleanRich = (value, fallback = '') => {
@@ -296,12 +83,36 @@ const stripLeadingCommitTitle = (body, title) => {
 };
 
 /** @param {unknown} value */
-const coerceLine = (value) =>
-  typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.round(value)) : undefined;
+const normalizeStringArray = (value) => {
+  const strings = [];
+  for (const item of Array.isArray(value) ? value : []) {
+    const text = oneLine(item);
+    if (text && !strings.includes(text)) {
+      strings.push(text);
+    }
+  }
+  return strings;
+};
 
 /** @param {unknown} value */
-const coerceCount = (value) =>
-  typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0;
+const normalizeGeneratedAt = (value) => {
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  return '';
+};
+
+/** @param {any} input */
+const isLegacyV3Walkthrough = (input) =>
+  input?.version === 3 ||
+  (Array.isArray(input?.chapters) &&
+    input.chapters.some((chapter) =>
+      (chapter?.stops || []).some((stop) => Array.isArray(stop?.anchors)),
+    )) ||
+  (Array.isArray(input?.support) && input.support.some((item) => Array.isArray(item?.files)));
 
 /** @param {string} status */
 const defaultSideForStatus = (status) => {
@@ -318,54 +129,53 @@ const defaultSideForStatus = (status) => {
 
 /** @param {ReadonlyArray<ChangedFile>} files */
 const indexFiles = (files) => {
-  const byPath = new Map();
+  const hunkById = new Map();
   for (const file of files) {
-    const sections = (file.sections || []).map((section) => ({
-      id: section.id,
-      kind: section.kind,
-    }));
-    byPath.set(file.path, {
-      firstSection: sections[0],
-      oldPath: file.oldPath,
-      sectionById: new Map(sections.map((section) => [section.id, section])),
-      sections,
-      status: file.status,
-    });
+    for (const section of file.sections || []) {
+      extractPatchHunks(section.patch).forEach((hunk, index) => {
+        const id = `${section.id}:h${index + 1}`;
+        hunkById.set(id, {
+          ...hunk,
+          id,
+          index: index + 1,
+          oldPath: file.oldPath,
+          path: file.path,
+          sectionId: section.id,
+          sectionKind: section.kind,
+          status: file.status,
+        });
+      });
+    }
   }
 
-  return byPath;
+  return { hunkById };
 };
 
-/**
- * Pin an anchor to a real DiffSection for `path`, repairing a missing or stale
- * sectionId. Prefers a section whose kind matches the requested sectionKind.
- * @param {any} anchor @param {ReturnType<typeof indexFiles> extends Map<any, infer V> ? V : never} entry @param {string} status @param {string} granularity
- */
-const normalizeAnchor = (anchor, entry, status, granularity) => {
-  const requestedId = oneLine(anchor?.sectionId);
-  const requestedKind = normalizeEnum(anchor?.sectionKind, SECTION_KINDS, undefined);
-
-  let section = requestedId ? entry.sectionById.get(requestedId) : undefined;
-  if (!section && requestedKind) {
-    section = entry.sections.find((candidate) => candidate.kind === requestedKind);
+const resolveHunks = (hunkIds, index) => {
+  const hunks = [];
+  for (const hunkId of hunkIds) {
+    const hunk = index.hunkById.get(hunkId);
+    if (!hunk) {
+      return null;
+    }
+    hunks.push(hunk);
   }
-  if (!section) {
-    section = entry.firstSection;
-  }
+  return hunks;
+};
 
-  const side = normalizeEnum(anchor?.side, SIDES, defaultSideForStatus(status));
-  const startLine = granularity === 'file' ? undefined : coerceLine(anchor?.startLine);
-  const endLine = granularity === 'file' ? undefined : coerceLine(anchor?.endLine);
+const normalizeAnchor = (hunk) => {
+  const path = hunk.path;
+  const side = defaultSideForStatus(hunk.status);
+  const startLine = hunkDisplayStart(hunk);
+  const endLine = hunkDisplayEnd(hunk);
 
   /** @type {Record<string, unknown>} */
   const normalized = {
-    display: cleanText(anchor?.display),
+    display: buildAnchorDisplay(path, [hunk]),
     side,
+    sectionId: hunk.sectionId,
+    sectionKind: hunk.sectionKind,
   };
-  if (section) {
-    normalized.sectionId = section.id;
-    normalized.sectionKind = section.kind;
-  }
   if (startLine !== undefined) {
     normalized.startLine = startLine;
   }
@@ -376,175 +186,145 @@ const normalizeAnchor = (anchor, entry, status, granularity) => {
   return normalized;
 };
 
-/** @param {any} comment */
-const normalizeComment = (comment, index) => {
-  const lineNumber = coerceLine(comment?.lineNumber);
-  if (lineNumber === undefined) {
+const normalizeHunk = (hunk) => {
+  /** @type {Record<string, unknown>} */
+  const normalized = {
+    added: hunk.added,
+    anchor: normalizeAnchor(hunk),
+    additionEnd: hunk.additionEnd,
+    additionStart: hunk.additionStart,
+    deleted: hunk.deleted,
+    deletionEnd: hunk.deletionEnd,
+    deletionStart: hunk.deletionStart,
+    id: hunk.id,
+    path: hunk.path,
+    status: hunk.status,
+  };
+  if (hunk.oldPath) {
+    normalized.oldPath = hunk.oldPath;
+  }
+  return normalized;
+};
+
+/** @param {any} note @param {ReadonlySet<string>} hunkIds */
+const normalizeHunkNote = (note, hunkIds) => {
+  const hunkId = oneLine(note?.hunkId);
+  const body = cleanText(note?.body);
+  if (!hunkId || !body || !hunkIds.has(hunkId)) {
+    return null;
+  }
+  return { body, hunkId };
+};
+
+/** @param {any} item @param {string} fallbackId @param {ReturnType<typeof indexFiles>} index */
+const normalizeHunkGroup = (item, fallbackId, index) => {
+  const id = oneLine(item?.id) || fallbackId;
+  const hunkIds = normalizeStringArray(item?.hunkIds);
+  if (!id || hunkIds.length === 0 || hunkIds.length > MAX_HUNKS_PER_WALKTHROUGH_GROUP) {
     return null;
   }
 
+  const selectedHunks = resolveHunks(hunkIds, index);
+  if (!selectedHunks || selectedHunks.length !== hunkIds.length) {
+    return null;
+  }
+
+  const lineCount = sumHunkLineCounts(selectedHunks);
+  const selectedHunkIds = new Set(selectedHunks.map((hunk) => hunk.id));
+
   /** @type {Record<string, unknown>} */
   const normalized = {
-    body: typeof comment?.body === 'string' ? comment.body : '',
-    id: oneLine(comment?.id) || `c${index + 1}`,
-    lineNumber,
-    side: normalizeEnum(comment?.side, COMMENT_SIDES, 'additions'),
+    added: lineCount.added,
+    deleted: lineCount.deleted,
+    hunkIds: selectedHunks.map((hunk) => hunk.id),
+    hunks: selectedHunks.map(normalizeHunk),
+    id,
   };
 
-  const author = oneLine(comment?.author);
-  if (author) {
-    normalized.author = author;
+  const title = cleanText(item?.title);
+  if (title) {
+    normalized.title = title;
   }
-  const startLineNumber = coerceLine(comment?.startLineNumber);
-  if (startLineNumber !== undefined) {
-    normalized.startLineNumber = startLineNumber;
+  const summary = cleanText(item?.summary);
+  if (summary) {
+    normalized.summary = summary;
   }
-  const startSide = normalizeEnum(comment?.startSide, COMMENT_SIDES, undefined);
-  if (startSide) {
-    normalized.startSide = startSide;
+  const changeType = normalizeEnum(item?.changeType, CHANGE_TYPES, undefined);
+  if (changeType) {
+    normalized.changeType = changeType;
+  }
+  const commitNote = cleanText(item?.commitNote);
+  if (commitNote) {
+    normalized.commitNote = commitNote;
+  }
+
+  const notes = [];
+  const notedHunkIds = new Set();
+  for (const note of Array.isArray(item?.notes) ? item.notes : []) {
+    const normalizedNote = normalizeHunkNote(note, selectedHunkIds);
+    if (!normalizedNote || notedHunkIds.has(normalizedNote.hunkId)) {
+      continue;
+    }
+    notes.push(normalizedNote);
+    notedHunkIds.add(normalizedNote.hunkId);
+  }
+  if (notes.length > 0) {
+    normalized.notes = notes;
   }
 
   return normalized;
 };
 
-/** @param {any} segment */
-const getSegmentAnchor = (segment) => {
-  if (segment?.anchor && typeof segment.anchor === 'object') {
-    return segment.anchor;
-  }
+const hunkGroupKey = (group) => (group.hunkIds || []).join('\n');
 
-  return {
-    display: oneLine(segment?.display) || oneLine(segment?.path),
-    endLine: segment?.endLine,
-    sectionId: segment?.sectionId,
-    sectionKind: segment?.sectionKind,
-    side: segment?.side,
-    startLine: segment?.startLine,
-  };
-};
-
-/**
- * @param {ReadonlyArray<any>} targets
- * @param {ReadonlyArray<ChangedFile>} files
- * @param {Set<string>} usedIds
- * @param {Set<string>} usedPaths
- */
-const normalizeAnchorTargets = (targets, files, usedIds, usedPaths) => {
-  const byPath = indexFiles(files);
-  const normalizedTargets = [];
-
-  for (const segment of Array.isArray(targets) ? targets : []) {
-    const id = oneLine(segment?.id);
-    const path = oneLine(segment?.path);
-    const entry = byPath.get(path);
-    if (!id || usedIds.has(id) || usedPaths.has(path) || !entry) {
-      // Drop unidentified, duplicate, or stale-path anchors.
-      continue;
-    }
-
-    const granularity = normalizeEnum(segment?.granularity, GRANULARITIES, 'hunk');
-    const status = normalizeEnum(segment?.status, STATUSES, entry.status);
-
-    /** @type {Record<string, unknown>} */
-    const normalized = {
-      added: coerceCount(segment?.added),
-      anchor: normalizeAnchor(getSegmentAnchor(segment), entry, status, granularity),
-      deleted: coerceCount(segment?.deleted),
-      granularity,
-      id,
-      path,
-      status,
-    };
-
-    const oldPath = oneLine(segment?.oldPath) || entry.oldPath;
-    if (oldPath) {
-      normalized.oldPath = oldPath;
-    }
-    const title = cleanText(segment?.title);
-    if (title) {
-      normalized.title = title;
-    }
-    const summary = cleanText(segment?.summary);
-    if (summary) {
-      normalized.summary = summary;
-    }
-    const changeType = normalizeEnum(segment?.changeType, CHANGE_TYPES, undefined);
-    if (changeType) {
-      normalized.changeType = changeType;
-    }
-    const commitNote = cleanText(segment?.commitNote);
-    if (commitNote) {
-      normalized.commitNote = commitNote;
-    }
-    const comments = (Array.isArray(segment?.comments) ? segment.comments : [])
-      .map((comment, index) => normalizeComment(comment, index))
-      .filter(Boolean);
-    if (comments.length > 0) {
-      normalized.comments = comments;
-    }
-
-    normalizedTargets.push(normalized);
-    usedIds.add(id);
-    usedPaths.add(path);
-  }
-
-  return normalizedTargets;
-};
-
-/**
- * @param {any} input
- * @param {ReadonlyArray<ChangedFile>} files
- */
-const normalizeChapters = (input, files, usedIds, usedPaths) => {
+const normalizeChapters = (input, index, coveredHunkIds) => {
   const chapters = [];
   const chapterIds = new Set();
-  const stopIds = new Set();
+  const itemIds = new Set();
   let stopCount = 0;
 
-  for (const [chapterIndex, chapter] of (Array.isArray(input?.chapters)
-    ? input.chapters
-    : []
-  ).entries()) {
-    if (chapters.length >= MAX_WALKTHROUGH_PHASES) {
+  for (const chapter of Array.isArray(input?.chapters) ? input.chapters : []) {
+    if (chapters.length >= MAX_WALKTHROUGH_CHAPTERS || stopCount >= MAX_WALKTHROUGH_STOPS) {
       break;
     }
-    const id = oneLine(chapter?.id) || `chapter-${chapterIndex + 1}`;
-    if (chapterIds.has(id)) {
+
+    const id = oneLine(chapter?.id);
+    if (!id || chapterIds.has(id)) {
       continue;
     }
 
     const stops = [];
-    for (const [stopIndex, stop] of (Array.isArray(chapter?.stops)
-      ? chapter.stops
-      : []
-    ).entries()) {
+    const seenStopHunkGroups = new Set();
+    for (const stop of Array.isArray(chapter?.stops) ? chapter.stops : []) {
       if (stopCount >= MAX_WALKTHROUGH_STOPS) {
         break;
       }
-      const stopId = oneLine(stop?.id) || `${id}-stop-${stopIndex + 1}`;
-      if (stopIds.has(stopId)) {
+
+      const group = normalizeHunkGroup(stop, `${id}-stop-${stops.length + 1}`, index);
+      if (!group || itemIds.has(group.id)) {
         continue;
       }
-      const anchors = normalizeAnchorTargets(stop?.anchors, files, usedIds, usedPaths);
-      if (anchors.length === 0) {
+
+      const key = hunkGroupKey(group);
+      const overlapsCoveredHunk = group.hunkIds.some((hunkId) => coveredHunkIds.has(hunkId));
+      if (seenStopHunkGroups.has(key) || overlapsCoveredHunk) {
         continue;
       }
-      stopIds.add(stopId);
+
+      const prose = cleanRich(stop?.prose);
+      if (!prose) {
+        continue;
+      }
+
+      group.importance = normalizeEnum(stop?.importance, IMPORTANCES, 'normal');
+      group.prose = prose;
+      stops.push(group);
+      itemIds.add(group.id);
+      seenStopHunkGroups.add(key);
       stopCount += 1;
-      const title =
-        cleanText(stop?.title) ||
-        cleanText(anchors[0]?.title) ||
-        cleanText(anchors[0]?.path) ||
-        `Stop ${stopCount}`;
-      const summary = cleanText(stop?.summary) || cleanText(anchors[0]?.summary) || title;
-      stops.push({
-        anchors,
-        body: cleanRich(stop?.body || stop?.prose || summary),
-        id: stopId,
-        importance: normalizeEnum(stop?.importance, IMPORTANCES, 'normal'),
-        summary,
-        title,
-      });
+      for (const hunkId of group.hunkIds) {
+        coveredHunkIds.add(hunkId);
+      }
     }
 
     if (stops.length === 0) {
@@ -557,168 +337,125 @@ const normalizeChapters = (input, files, usedIds, usedPaths) => {
       icon: normalizeEnum(chapter?.icon, ICONS, 'path'),
       id,
       stops,
-      title: cleanText(chapter?.title, 'Review'),
+      title: cleanText(chapter?.title, 'Chapter'),
     });
   }
 
-  return chapters;
+  return { chapters, itemIds, stopCount };
 };
 
-/**
- * @param {any} input
- * @param {ReadonlyArray<ChangedFile>} files
- * @param {Set<string>} usedIds
- * @param {Set<string>} usedPaths
- */
-const normalizeSupport = (input, files, usedIds, usedPaths) => {
-  const groups = [];
-  const groupIds = new Set();
+const normalizeAuthoredSupport = (input, index, coveredHunkIds, itemIds) => {
+  const support = [];
+  const seenSupportHunkGroups = new Set();
+  for (const item of Array.isArray(input?.support) ? input.support : []) {
+    const group = normalizeHunkGroup(item, `support-${support.length + 1}`, index);
+    if (!group || itemIds.has(group.id)) {
+      continue;
+    }
 
-  for (const [groupIndex, group] of (Array.isArray(input?.support)
-    ? input.support
-    : []
-  ).entries()) {
-    const id = oneLine(group?.id) || `support-${groupIndex + 1}`;
-    if (groupIds.has(id)) {
+    const key = hunkGroupKey(group);
+    if (
+      seenSupportHunkGroups.has(key) ||
+      group.hunkIds.some((hunkId) => coveredHunkIds.has(hunkId))
+    ) {
       continue;
     }
-    const filesForGroup = normalizeAnchorTargets(group?.files, files, usedIds, usedPaths);
-    if (filesForGroup.length === 0) {
+
+    group.reason = cleanText(item?.reason, 'Other changes');
+    const note = cleanText(item?.note);
+    if (note) {
+      group.note = note;
+    }
+    support.push(group);
+    itemIds.add(group.id);
+    seenSupportHunkGroups.add(key);
+    for (const hunkId of group.hunkIds) {
+      coveredHunkIds.add(hunkId);
+    }
+  }
+  return support;
+};
+
+const addUnreferencedSupport = (support, index, coveredHunkIds, itemIds) => {
+  const groupsByPath = new Map();
+  for (const hunk of index.hunkById.values()) {
+    if (coveredHunkIds.has(hunk.id)) {
       continue;
     }
-    groupIds.add(id);
-    groups.push({
-      files: filesForGroup,
-      id,
-      note: cleanText(group?.note),
-      title: cleanText(group?.title, 'Other changes'),
-    });
+    const groups = groupsByPath.get(hunk.path) || [];
+    groups.push(hunk);
+    groupsByPath.set(hunk.path, groups);
   }
 
-  return groups;
-};
-
-/**
- * @param {ReadonlyArray<ChangedFile>} files
- * @param {ReadonlyArray<any>} chapters
- * @param {Array<any>} support
- */
-const addMissingFilesToSupport = (files, chapters, support) => {
-  const coveredPaths = new Set();
-  for (const chapter of chapters) {
-    for (const stop of chapter.stops || []) {
-      for (const target of stop.anchors || []) {
-        coveredPaths.add(target.path);
+  for (const [path, hunks] of groupsByPath) {
+    for (let start = 0; start < hunks.length; start += MAX_HUNKS_PER_WALKTHROUGH_GROUP) {
+      const chunk = hunks.slice(start, start + MAX_HUNKS_PER_WALKTHROUGH_GROUP);
+      const lineCount = sumHunkLineCounts(chunk);
+      let counter = support.length + 1;
+      let id = `support-${counter}`;
+      while (itemIds.has(id)) {
+        counter += 1;
+        id = `support-${counter}`;
+      }
+      support.push({
+        added: lineCount.added,
+        deleted: lineCount.deleted,
+        hunkIds: chunk.map((hunk) => hunk.id),
+        hunks: chunk.map(normalizeHunk),
+        id,
+        reason: 'Other changes',
+        title: path,
+      });
+      itemIds.add(id);
+      for (const hunk of chunk) {
+        coveredHunkIds.add(hunk.id);
       }
     }
   }
-  for (const group of support) {
-    for (const target of group.files || []) {
-      coveredPaths.add(target.path);
-    }
-  }
-
-  const missing = [];
-  for (const file of files) {
-    if (coveredPaths.has(file.path)) {
-      continue;
-    }
-    const section = file.sections?.[0];
-    const totals = (file.sections || []).reduce(
-      (sum, section) => {
-        const count = countPatchLines(section.patch || '');
-        return { added: sum.added + count.added, deleted: sum.deleted + count.deleted };
-      },
-      { added: 0, deleted: 0 },
-    );
-    missing.push({
-      added: totals.added,
-      anchor: normalizeAnchor(
-        { display: file.path, sectionId: section?.id, sectionKind: section?.kind },
-        {
-          firstSection: section,
-          oldPath: file.oldPath,
-          sectionById: new Map((file.sections || []).map((section) => [section.id, section])),
-          sections: (file.sections || []).map((section) => ({
-            id: section.id,
-            kind: section.kind,
-          })),
-          status: file.status,
-        },
-        file.status,
-        'file',
-      ),
-      deleted: totals.deleted,
-      granularity: 'file',
-      id: `__file:${file.path}`,
-      oldPath: file.oldPath,
-      path: file.path,
-      status: normalizeEnum(file.status, STATUSES, 'modified'),
-      summary: 'Not included in the generated walkthrough.',
-    });
-  }
-
-  if (missing.length > 0) {
-    support.push({
-      files: missing,
-      id: '__missing',
-      note: 'Not included in the generated walkthrough.',
-      title: 'Other changes',
-    });
-  }
 };
 
-/**
- * Validate and repair a narrative walkthrough against the current diff.
- * @param {any} input
- * @param {ReadonlyArray<ChangedFile>} files
- * @returns {NarrativeWalkthrough}
- */
-const normalizeNarrativeWalkthrough = (input, files) => {
+const normalizeNarrativeWalkthrough = (input, files, facts = {}) => {
   if (!input || typeof input !== 'object') {
     throw new Error('Narrative walkthrough is not an object.');
   }
-
-  const usedIds = new Set();
-  const usedPaths = new Set();
-  const chapters = normalizeChapters(input, files, usedIds, usedPaths);
-  const support = normalizeSupport(input, files, usedIds, usedPaths);
-  addMissingFilesToSupport(files, chapters, support);
-
-  if (chapters.length === 0 && support.length === 0) {
-    throw new Error('Narrative walkthrough has no anchors that match the current diff.');
+  if (isLegacyV3Walkthrough(input)) {
+    throw new Error(
+      'Narrative walkthrough uses the legacy v3 anchors[] schema. Regenerate it with the v4 hunkIds[] schema for this diff.',
+    );
   }
 
-  const branch =
-    typeof input.repo?.branch === 'string' || input.repo?.branch === null
-      ? input.repo.branch
-      : null;
+  const index = indexFiles(files);
+  const coveredHunkIds = new Set();
+  const { chapters, itemIds, stopCount } = normalizeChapters(input, index, coveredHunkIds);
+  if (chapters.length === 0 || stopCount === 0) {
+    throw new Error('Narrative walkthrough has no chapters with resolvable stops.');
+  }
+
+  const support = normalizeAuthoredSupport(input, index, coveredHunkIds, itemIds);
+  addUnreferencedSupport(support, index, coveredHunkIds, itemIds);
+
+  const branch = typeof facts.branch === 'string' || facts.branch === null ? facts.branch : null;
+  const source =
+    facts.source && typeof facts.source === 'object' ? facts.source : { type: 'working-tree' };
 
   /** @type {Record<string, unknown>} */
   const result = {
-    agent: normalizeEnum(input.agent, AGENTS, 'claude'),
-    focus: cleanText(input.focus, 'Walk through the change.'),
-    generatedAt: oneLine(input.generatedAt),
+    agent: normalizeEnum(facts.agent, AGENTS, 'codex'),
     chapters,
+    focus: cleanText(input.focus, 'Walk through the change.'),
+    generatedAt: normalizeGeneratedAt(facts.generatedAt),
     kind: 'narrative',
     repo: {
       branch,
-      root: oneLine(input.repo?.root),
+      root: oneLine(facts.root),
     },
-    source:
-      input.source && typeof input.source === 'object' ? input.source : { type: 'working-tree' },
+    source,
     support,
     title: cleanText(input.title, 'Walkthrough'),
-    version: 3,
+    version: 4,
   };
 
-  const meta = cleanText(input.meta);
-  if (meta) {
-    result.meta = meta;
-  }
-  if (input.context && typeof input.context === 'object') {
-    result.context = input.context;
-  }
+  result.meta = `${stopCount} stops · ${chapters.length} chapters`;
 
   // A commit composer only makes sense for a live staging set — never a past
   // commit, branch, or pull request. For working trees, always expose the
@@ -729,7 +466,7 @@ const normalizeNarrativeWalkthrough = (input, files) => {
     const commit = {};
     const inputCommit = input.commit && typeof input.commit === 'object' ? input.commit : {};
     const rawBody = cleanRich(inputCommit.body);
-    let title = cleanText(inputCommit.title || inputCommit.subjectSeed);
+    let title = cleanText(inputCommit.title);
     if (!title && rawBody) {
       const firstLine = rawBody
         .split(/\r?\n/)
@@ -752,7 +489,7 @@ const normalizeNarrativeWalkthrough = (input, files) => {
   return /** @type {NarrativeWalkthrough} */ (result);
 };
 
-/** @param {DiffSection} section @param {number} remainingBudget */
+/** @param {DiffSection} section @param {number} remainingBudget @param {number} sectionPatchBudget */
 const buildPatchExcerpt = (section, remainingBudget, sectionPatchBudget) => {
   const summary = section.summary?.reason ? `Summary: ${section.summary.reason}\n` : '';
   const patch = section.patch || '';
@@ -763,24 +500,6 @@ const buildPatchExcerpt = (section, remainingBudget, sectionPatchBudget) => {
   }
 
   return `${summary}${truncate(patch, maxLength)}`;
-};
-
-/** @param {string} patch */
-const countPatchLines = (patch) => {
-  let added = 0;
-  let deleted = 0;
-  for (const line of patch.split('\n')) {
-    if (line.startsWith('+++') || line.startsWith('---')) {
-      continue;
-    }
-    if (line.startsWith('+')) {
-      added += 1;
-    } else if (line.startsWith('-')) {
-      deleted += 1;
-    }
-  }
-
-  return { added, deleted };
 };
 
 /** @param {number} fileCount */
@@ -802,48 +521,45 @@ const buildPromptInput = (state) => {
 
   return {
     branch: state.branch,
-    commit: state.commitMetadata
-      ? {
-          stats: state.commitMetadata.stats,
-          subject: state.commitMetadata.subject,
-        }
-      : undefined,
-    files: state.files.map((file, index) => {
-      let added = 0;
-      let deleted = 0;
-      const sections = file.sections.map((section) => {
-        const stats = countPatchLines(section.patch || '');
-        added += stats.added;
-        deleted += stats.deleted;
+    files: state.files.map((file) => ({
+      oldPath: file.oldPath,
+      path: file.path,
+      sections: file.sections.map((section) => {
         const patchExcerpt = buildPatchExcerpt(section, remainingPatchBudget, patchBudget.section);
         remainingPatchBudget = Math.max(0, remainingPatchBudget - patchExcerpt.length);
+        const hunks = extractPatchHunks(section.patch).map((hunk, index) => ({
+          added: hunk.added,
+          deleted: hunk.deleted,
+          header: hunk.header,
+          id: `${section.id}:h${index + 1}`,
+          newLines:
+            hunk.additionStart === hunk.additionEnd
+              ? `${hunk.additionStart}`
+              : `${hunk.additionStart}-${hunk.additionEnd}`,
+          oldLines:
+            hunk.deletionStart === hunk.deletionEnd
+              ? `${hunk.deletionStart}`
+              : `${hunk.deletionStart}-${hunk.deletionEnd}`,
+        }));
 
         return {
           binary: section.binary,
+          hunks,
           id: section.id,
           kind: section.kind,
+          loadState: section.loadState,
           patchExcerpt,
           summary: section.summary?.reason,
         };
-      });
-
-      return {
-        added,
-        deleted,
-        index: index + 1,
-        oldPath: file.oldPath,
-        path: file.path,
-        sections,
-        status: file.status,
-      };
-    }),
+      }),
+      status: file.status,
+    })),
     generatedAt: state.generatedAt,
     root: state.root,
     source: state.source,
   };
 };
 
-/** @param {WalkthroughContext | null | undefined} context @param {string} agentLabel */
 const buildWalkthroughContextInput = (context, agentLabel) =>
   context
     ? `${agentLabel} conversation context:
@@ -855,50 +571,47 @@ If the context and digest conflict, trust the digest.
 `
     : '';
 
-/** @param {RepositoryState} state */
 const buildWalkthroughSizingGuidance = (state) => {
   const fileCount = state.files.length;
   const targetStops = fileCount <= 6 ? '3-6' : fileCount <= 16 ? '5-9' : '7-12';
   return `Coverage contract:
-- The digest has ${fileCount} files. Every file must appear exactly once in either a stop anchor or support.files.
-- Create anchor ids a1, a2, ... in digest.files order. Do not skip files. Do not invent files.
-- Use file granularity for broad file-level changes. Use hunk or line only for a truly pinpointed change.
-- Do not add comments unless there is an explicit review-comment need.
+- The digest has ${fileCount} files. Cover the changed hunks a reviewer should see, and put secondary/mechanical hunks in support[] rather than hiding them.
+- Define chapters[] in display order. Inside each chapter, define stops[] in display order.
+- Use stable item ids like s1, s2, ... for main stops and support-1, support-2, ... for supporting groups. Do not invent hunk ids.
+- Default to one hunkId per stop or support item.
 
 Grouping contract:
 - Target ${targetStops} main-path stops and at most ${MAX_WALKTHROUGH_STOPS}.
-- Use 2-${MAX_WALKTHROUGH_PHASES} chapters. Chapter titles render in a compact top bar: 1-2 short words and at most 16 characters, e.g. "UI", "CLI", "Tests", "Docs", "Runtime", "Cleanup".
-- Do not create one stop per file. Each stop should name one review idea and can include up to 8 anchors for files that belong to that idea.
-- Put generated files, lockfiles, snapshots, broad CSS churn, deleted legacy files, and repeated mechanical edits into support[] unless they are essential to the main review path.
-- Prefer fewer stronger stops over exhaustive prose.
-- Keep stop.summary to one concrete sentence. Keep stop.body short and specific. Do not use generic filler, broad assurance language, meta-explanatory labels, or markdown headings.
+- Use 2-${MAX_WALKTHROUGH_CHAPTERS} story chapters. A chapter is a conceptual group, not a file.
+- Chapter titles render in a compact top bar: keep each title to 1-2 short words and at most 16 characters, e.g. "UI", "CLI", "Tests", "Docs", "Runtime", "Cleanup".
+- A stop or support item may contain at most ${MAX_HUNKS_PER_WALKTHROUGH_GROUP} hunkIds. Use multiple hunkIds only when the prose needs those hunks read together to understand one invariant.
+- Split distant same-file hunks into separate consecutive stops when they deserve separate prose. Do not make a chapter-sized stop.
+- Put hunkIds in the exact display order you want Codiff to render. Out-of-line and cross-file order is allowed when it improves reviewer comprehension.
+- Use notes[] on a stop/support item for short per-hunk header notes: each note is { hunkId, body } and hunkId must be one of that item's hunkIds.
+- Do not provide added/deleted counts, status, oldPath, section ids, display labels, path, repo, source, generatedAt, agent, or meta; Codiff computes those.
+- Put secondary, mechanical, generated, docs-only, or repeated-pattern hunks in support[], grouped by reason.
 - For working-tree sources, include commit.title and commit.body by default unless there are no commit-worthy files. Put the subject line in commit.title, not as the first line of commit.body.
 `;
 };
 
-/** @param {RepositoryState} state @param {WalkthroughContext | null | undefined} [context] @param {string} [agentLabel] */
 const buildNarrativeWalkthroughPrompt = (
   state,
   context,
   agentLabel = 'Codex',
 ) => `You are authoring Codiff's narrative walkthrough JSON.
 
-Return JSON only and match the provided schema exactly. Do not inspect the repository or run shell commands; use only the optional conversation context and repository digest below.
+Return JSON only. Do not inspect the repository or run shell commands; use only the guide, optional conversation context, and repository digest below.
 
 ${buildWalkthroughSizingGuidance(state)}
 
+Current Codiff walkthrough guide:
+${readFileSync(join(root, 'bin/walkthrough-guide.md'), 'utf8').trim()}
+
 ${buildWalkthroughContextInput(context, agentLabel)}
 Repository change digest:
-${JSON.stringify(buildPromptInput(state))}
+${JSON.stringify(buildPromptInput(state), null, 2)}
 `;
 
-/**
- * @param {RepositoryState} state
- * @param {Agent} agent
- * @param {AgentOptions} agentOptions
- * @param {WalkthroughContext | null | undefined} [context]
- * @returns {Promise<NarrativeWalkthroughResult>}
- */
 const readNarrativeWalkthrough = async (state, agent, agentOptions, context) => {
   try {
     const response = await agent.run(
@@ -907,18 +620,16 @@ const readNarrativeWalkthrough = async (state, agent, agentOptions, context) => 
       narrativeWalkthroughResponseSchema,
       'walkthrough.json',
       `${agent.label} walkthrough timed out.`,
-      { ...agentOptions, reasoningEffort: 'low' },
+      agentOptions,
     );
     const parsed = parseJSONMessage(response);
-    const normalizedInput =
-      parsed && typeof parsed === 'object'
-        ? {
-            ...parsed,
-            ...(context ? { context } : {}),
-            source: state.source,
-          }
-        : parsed;
-    const walkthrough = normalizeNarrativeWalkthrough(normalizedInput, state.files);
+    const walkthrough = normalizeNarrativeWalkthrough(parsed, state.files, {
+      agent: agent.id,
+      branch: state.branch,
+      generatedAt: state.generatedAt,
+      root: state.root,
+      source: state.source,
+    });
     if (context && !walkthrough.context) {
       walkthrough.context = context;
     }

--- a/electron/narrative-walkthrough.cjs
+++ b/electron/narrative-walkthrough.cjs
@@ -24,9 +24,10 @@ const {
 } = require('./narrative-walkthrough-schema.cjs');
 const {
   buildAnchorDisplay,
-  extractPatchHunks,
+  getSectionWalkthroughHunks,
   hunkDisplayEnd,
   hunkDisplayStart,
+  isSyntheticWalkthroughHunk,
   sumHunkLineCounts,
 } = require('../shared/narrative-walkthrough-diff.cjs');
 
@@ -132,19 +133,9 @@ const indexFiles = (files) => {
   const hunkById = new Map();
   for (const file of files) {
     for (const section of file.sections || []) {
-      extractPatchHunks(section.patch).forEach((hunk, index) => {
-        const id = `${section.id}:h${index + 1}`;
-        hunkById.set(id, {
-          ...hunk,
-          id,
-          index: index + 1,
-          oldPath: file.oldPath,
-          path: file.path,
-          sectionId: section.id,
-          sectionKind: section.kind,
-          status: file.status,
-        });
-      });
+      for (const hunk of getSectionWalkthroughHunks(file, section)) {
+        hunkById.set(hunk.id, hunk);
+      }
     }
   }
 
@@ -197,6 +188,7 @@ const normalizeHunk = (hunk) => {
     deletionEnd: hunk.deletionEnd,
     deletionStart: hunk.deletionStart,
     id: hunk.id,
+    kind: isSyntheticWalkthroughHunk(hunk) ? 'synthetic' : 'patch',
     path: hunk.path,
     status: hunk.status,
   };
@@ -502,6 +494,32 @@ const buildPatchExcerpt = (section, remainingBudget, sectionPatchBudget) => {
   return `${summary}${truncate(patch, maxLength)}`;
 };
 
+/** @param {number} start @param {number} end */
+const formatPromptLineRange = (start, end) => (start === end ? `${start}` : `${start}-${end}`);
+
+/** @param {ReturnType<typeof getSectionWalkthroughHunks>[number]} hunk */
+const buildPromptHunkInput = (hunk) => {
+  if (isSyntheticWalkthroughHunk(hunk)) {
+    return {
+      added: hunk.added,
+      deleted: hunk.deleted,
+      id: hunk.id,
+      kind: 'synthetic',
+      summary: hunk.summary,
+    };
+  }
+
+  return {
+    added: hunk.added,
+    deleted: hunk.deleted,
+    header: hunk.header,
+    id: hunk.id,
+    kind: 'patch',
+    newLines: formatPromptLineRange(hunk.additionStart, hunk.additionEnd),
+    oldLines: formatPromptLineRange(hunk.deletionStart, hunk.deletionEnd),
+  };
+};
+
 /** @param {number} fileCount */
 const getPromptPatchBudgets = (fileCount) =>
   fileCount > 32
@@ -527,20 +545,7 @@ const buildPromptInput = (state) => {
       sections: file.sections.map((section) => {
         const patchExcerpt = buildPatchExcerpt(section, remainingPatchBudget, patchBudget.section);
         remainingPatchBudget = Math.max(0, remainingPatchBudget - patchExcerpt.length);
-        const hunks = extractPatchHunks(section.patch).map((hunk, index) => ({
-          added: hunk.added,
-          deleted: hunk.deleted,
-          header: hunk.header,
-          id: `${section.id}:h${index + 1}`,
-          newLines:
-            hunk.additionStart === hunk.additionEnd
-              ? `${hunk.additionStart}`
-              : `${hunk.additionStart}-${hunk.additionEnd}`,
-          oldLines:
-            hunk.deletionStart === hunk.deletionEnd
-              ? `${hunk.deletionStart}`
-              : `${hunk.deletionStart}-${hunk.deletionEnd}`,
-        }));
+        const hunks = getSectionWalkthroughHunks(file, section).map(buildPromptHunkInput);
 
         return {
           binary: section.binary,

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -65,7 +65,6 @@ const codiff = {
   openFile: (path) => ipcRenderer.invoke('codiff:openFile', path),
   setDiffStyle: (value) => ipcRenderer.invoke('codiff:setDiffStyle', value),
   setShowOutdated: (value) => ipcRenderer.invoke('codiff:setShowOutdated', value),
-  setWalkthroughOrder: (value) => ipcRenderer.invoke('codiff:setWalkthroughOrder', value),
   setWordWrap: (value) => ipcRenderer.invoke('codiff:setWordWrap', value),
   resetCodeFontSize: () => ipcRenderer.invoke('codiff:resetCodeFontSize'),
   showInFolder: (path) => ipcRenderer.invoke('codiff:showInFolder', path),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "config",
     "codex",
     "dist",
-    "electron"
+    "electron",
+    "shared"
   ],
   "type": "module",
   "main": "./electron/main.cjs",

--- a/shared/narrative-walkthrough-diff.cjs
+++ b/shared/narrative-walkthrough-diff.cjs
@@ -72,13 +72,28 @@ const sumHunkLineCounts = (hunks) =>
     { added: 0, deleted: 0 },
   );
 
-/** @param {ReturnType<typeof extractPatchHunks>[number]} hunk */
-const hunkDisplayStart = (hunk) => (hunk.added > 0 ? hunk.additionStart : hunk.deletionStart);
+/** @param {{kind?: string} | null | undefined} hunk */
+const isSyntheticWalkthroughHunk = (hunk) => hunk?.kind === 'synthetic';
 
-/** @param {ReturnType<typeof extractPatchHunks>[number]} hunk */
-const hunkDisplayEnd = (hunk) => (hunk.added > 0 ? hunk.additionEnd : hunk.deletionEnd);
+/** @param {ReturnType<typeof extractPatchHunks>[number] & {kind?: string}} hunk */
+const hunkDisplayStart = (hunk) => {
+  if (isSyntheticWalkthroughHunk(hunk)) {
+    return undefined;
+  }
 
-/** @param {string} path @param {ReadonlyArray<ReturnType<typeof extractPatchHunks>[number]>} hunks */
+  return hunk.added > 0 ? hunk.additionStart : hunk.deletionStart;
+};
+
+/** @param {ReturnType<typeof extractPatchHunks>[number] & {kind?: string}} hunk */
+const hunkDisplayEnd = (hunk) => {
+  if (isSyntheticWalkthroughHunk(hunk)) {
+    return undefined;
+  }
+
+  return hunk.added > 0 ? hunk.additionEnd : hunk.deletionEnd;
+};
+
+/** @param {string} path @param {ReadonlyArray<ReturnType<typeof extractPatchHunks>[number] & {kind?: string}>} hunks */
 const buildAnchorDisplay = (path, hunks) => {
   if (hunks.length === 0) {
     return path;
@@ -88,11 +103,83 @@ const buildAnchorDisplay = (path, hunks) => {
   if (!first || !last) {
     return path;
   }
+  if (isSyntheticWalkthroughHunk(first)) {
+    return path;
+  }
   const startLine = hunkDisplayStart(first);
   const endLine = hunkDisplayEnd(last);
   return startLine && endLine && endLine !== startLine
     ? `${path}:${startLine}-${endLine}`
     : `${path}:${startLine || 1}`;
+};
+
+/** @param {{oldPath?: string; path: string; status?: string}} file */
+const fileHasRenameMetadata = (file) =>
+  file.status === 'renamed' && file.oldPath != null && file.oldPath !== file.path;
+
+/**
+ * @param {{oldPath?: string; path: string; status?: string}} file
+ * @param {{binary?: boolean; loadState?: string; patch?: string; summary?: {reason?: string}}} section
+ */
+const shouldCreateSyntheticHunk = (file, section) => {
+  if (section.binary) {
+    return true;
+  }
+  if (section.loadState != null && section.loadState !== 'ready') {
+    return true;
+  }
+  if (fileHasRenameMetadata(file)) {
+    return true;
+  }
+
+  return typeof section.patch === 'string' && section.patch.trim().length > 0;
+};
+
+/**
+ * @param {{oldPath?: string; path: string; status: string}} file
+ * @param {{binary?: boolean; id: string; kind: string; loadState?: string; patch?: string; summary?: {reason?: string}}} section
+ */
+const createSyntheticSectionHunk = (file, section) => ({
+  added: 0,
+  deleted: 0,
+  id: `${section.id}:h1`,
+  index: 1,
+  kind: 'synthetic',
+  oldPath: file.oldPath,
+  path: file.path,
+  sectionId: section.id,
+  sectionKind: section.kind,
+  status: file.status,
+  summary: section.summary?.reason,
+});
+
+/**
+ * Codiff's walkthrough hunk ids identify the smallest reviewable diff unit.
+ * Most are textual patch hunks; non-text or metadata-only sections get one
+ * synthetic hunk so walkthroughs remain hunk-based for every visible change.
+ *
+ * @param {{oldPath?: string; path: string; status: string}} file
+ * @param {{binary?: boolean; id: string; kind: string; loadState?: string; patch?: string; summary?: {reason?: string}}} section
+ */
+const getSectionWalkthroughHunks = (file, section) => {
+  const patchHunks = extractPatchHunks(section.patch || '');
+  if (patchHunks.length > 0) {
+    return patchHunks.map((hunk, index) => ({
+      ...hunk,
+      id: `${section.id}:h${index + 1}`,
+      index: index + 1,
+      kind: 'patch',
+      oldPath: file.oldPath,
+      path: file.path,
+      sectionId: section.id,
+      sectionKind: section.kind,
+      status: file.status,
+    }));
+  }
+
+  return shouldCreateSyntheticHunk(file, section)
+    ? [createSyntheticSectionHunk(file, section)]
+    : [];
 };
 
 /** @param {string} sectionId @param {string} hunkId */
@@ -171,9 +258,11 @@ module.exports = {
   buildAnchorDisplay,
   extractPatchHunks,
   filterPatchToHunkIds,
+  getSectionWalkthroughHunks,
   HUNK_HEADER,
   hunkDisplayEnd,
   hunkDisplayStart,
+  isSyntheticWalkthroughHunk,
   parseHunkHeader,
   sumHunkLineCounts,
 };

--- a/shared/narrative-walkthrough-diff.cjs
+++ b/shared/narrative-walkthrough-diff.cjs
@@ -1,0 +1,179 @@
+// @ts-check
+
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+/** @param {string} line */
+const parseHunkHeader = (line) => {
+  const match = HUNK_HEADER.exec(line);
+  if (!match) {
+    return null;
+  }
+
+  const deletionStart = Number(match[1]);
+  const deletionCount = Number(match[2] ?? 1);
+  const additionStart = Number(match[3]);
+  const additionCount = Number(match[4] ?? 1);
+
+  return {
+    additionCount,
+    additionEnd: additionStart + Math.max(0, additionCount - 1),
+    additionStart,
+    deletionCount,
+    deletionEnd: deletionStart + Math.max(0, deletionCount - 1),
+    deletionStart,
+  };
+};
+
+/** @param {string} patch */
+const extractPatchHunks = (patch) => {
+  const lines = typeof patch === 'string' ? patch.split('\n') : [];
+  const hunks = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const header = lines[index] ?? '';
+    const parsed = parseHunkHeader(header);
+    if (!parsed) {
+      index += 1;
+      continue;
+    }
+
+    let additions = 0;
+    let deletions = 0;
+    index += 1;
+    while (index < lines.length && !parseHunkHeader(lines[index] ?? '')) {
+      const line = lines[index] ?? '';
+      if (line.startsWith('+')) {
+        additions += 1;
+      } else if (line.startsWith('-')) {
+        deletions += 1;
+      }
+      index += 1;
+    }
+
+    hunks.push({
+      ...parsed,
+      added: additions,
+      deleted: deletions,
+      header,
+    });
+  }
+
+  return hunks;
+};
+
+/** @param {ReadonlyArray<{added: number; deleted: number}>} hunks */
+const sumHunkLineCounts = (hunks) =>
+  hunks.reduce(
+    (totals, hunk) => ({
+      added: totals.added + hunk.added,
+      deleted: totals.deleted + hunk.deleted,
+    }),
+    { added: 0, deleted: 0 },
+  );
+
+/** @param {ReturnType<typeof extractPatchHunks>[number]} hunk */
+const hunkDisplayStart = (hunk) => (hunk.added > 0 ? hunk.additionStart : hunk.deletionStart);
+
+/** @param {ReturnType<typeof extractPatchHunks>[number]} hunk */
+const hunkDisplayEnd = (hunk) => (hunk.added > 0 ? hunk.additionEnd : hunk.deletionEnd);
+
+/** @param {string} path @param {ReadonlyArray<ReturnType<typeof extractPatchHunks>[number]>} hunks */
+const buildAnchorDisplay = (path, hunks) => {
+  if (hunks.length === 0) {
+    return path;
+  }
+  const first = hunks[0];
+  const last = hunks.at(-1);
+  if (!first || !last) {
+    return path;
+  }
+  const startLine = hunkDisplayStart(first);
+  const endLine = hunkDisplayEnd(last);
+  return startLine && endLine && endLine !== startLine
+    ? `${path}:${startLine}-${endLine}`
+    : `${path}:${startLine || 1}`;
+};
+
+/** @param {string} sectionId @param {string} hunkId */
+const getHunkOrdinal = (sectionId, hunkId) => {
+  const prefix = `${sectionId}:h`;
+  if (!hunkId.startsWith(prefix)) {
+    return null;
+  }
+  const ordinal = Number(hunkId.slice(prefix.length));
+  return Number.isInteger(ordinal) && ordinal > 0 ? ordinal : null;
+};
+
+/**
+ * @param {string} patch
+ * @param {string} sectionId
+ * @param {ReadonlyArray<string>} hunkIds
+ */
+const filterPatchToHunkIds = (patch, sectionId, hunkIds) => {
+  if (typeof patch !== 'string' || patch.trim().length === 0 || hunkIds.length === 0) {
+    return null;
+  }
+
+  const patchLines = patch.split('\n');
+  const headerLines = [];
+  const hunkLinesByOrdinal = new Map();
+  let index = 0;
+  let foundHunk = false;
+  let ordinal = 0;
+
+  while (index < patchLines.length) {
+    const parsedHeader = parseHunkHeader(patchLines[index] ?? '');
+    if (parsedHeader) {
+      foundHunk = true;
+      ordinal += 1;
+      const hunkStart = index;
+      index += 1;
+      while (index < patchLines.length && !parseHunkHeader(patchLines[index] ?? '')) {
+        index += 1;
+      }
+      hunkLinesByOrdinal.set(ordinal, patchLines.slice(hunkStart, index));
+      continue;
+    }
+
+    if (!foundHunk) {
+      headerLines.push(patchLines[index] ?? '');
+    }
+    index += 1;
+  }
+
+  if (!foundHunk) {
+    return null;
+  }
+
+  const selectedHunkLines = [];
+  for (const hunkId of hunkIds) {
+    const ordinal = getHunkOrdinal(sectionId, hunkId);
+    if (ordinal == null) {
+      return null;
+    }
+    const lines = hunkLinesByOrdinal.get(ordinal);
+    if (!lines) {
+      return null;
+    }
+    selectedHunkLines.push(...lines);
+  }
+
+  if (selectedHunkLines.length === 0) {
+    return null;
+  }
+
+  const focused = [...headerLines, ...selectedHunkLines].join('\n');
+  return patch.endsWith('\n') && !focused.endsWith('\n') ? `${focused}\n` : focused;
+};
+
+module.exports = {
+  buildAnchorDisplay,
+  extractPatchHunks,
+  filterPatchToHunkIds,
+  HUNK_HEADER,
+  hunkDisplayEnd,
+  hunkDisplayStart,
+  parseHunkHeader,
+  sumHunkLineCounts,
+};

--- a/src/App.css
+++ b/src/App.css
@@ -865,6 +865,7 @@
 }
 
 .code-view {
+  --codiff-diff-radius: 28px;
   contain: strict;
   display: block;
   flex: 1;
@@ -1164,10 +1165,9 @@
 
 .code-view diffs-container {
   background: var(--code-bg);
-  border-radius: 28px;
-  box-shadow:
-    0 0 0 1px var(--file-border),
-    6px 18px 80px -54px rgb(0 0 0 / 0.78);
+  background-clip: padding-box;
+  border-radius: var(--codiff-diff-radius);
+  box-shadow: inset 0 0 0 1px var(--file-border);
   contain: layout style;
   corner-shape: squircle;
   display: block;
@@ -1539,19 +1539,18 @@
   grid-template-columns: minmax(0, 1fr);
   min-width: 0;
   padding: 9px 10px;
-  transition: border-radius 120ms ease;
 }
 
 .codiff-file-header.selected {
   box-shadow:
     inset 0 -1px 0 var(--file-border),
     inset 0 0 0 1px rgb(61 135 245 / 0.52);
+  border-radius: var(--codiff-diff-radius) var(--codiff-diff-radius) 0 0;
   corner-shape: squircle;
-  border-radius: 28px 28px 0 0;
 }
 
 .codiff-file-header.collapsed {
-  border-radius: 28px;
+  border-radius: var(--codiff-diff-radius);
   box-shadow: none;
   corner-shape: squircle;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,14 @@ import {
   ReviewSourceLoading,
   WalkthroughOutdatedBanner,
 } from './app/components/Panels.tsx';
-import { ReviewCodeView } from './app/components/ReviewCodeView.tsx';
+import { ReviewCodeView, type ReviewDiffBlock } from './app/components/ReviewCodeView.tsx';
 import { Sidebar } from './app/components/Sidebar.tsx';
 import { CommitView } from './app/components/walkthrough/CommitView.tsx';
-import { NarrativeWalkthroughView } from './app/components/walkthrough/NarrativeWalkthroughView.tsx';
+import {
+  NarrativeWalkthroughView,
+  type WalkthroughBlockScrollTarget,
+  type WalkthroughReviewTarget,
+} from './app/components/walkthrough/NarrativeWalkthroughView.tsx';
 import { useNarrativeNavigation } from './app/components/walkthrough/useNarrativeNavigation.ts';
 import type { WalkthroughFileError } from './app/components/WalkthroughFileError.tsx';
 import { createDefaultConfig } from './config/defaults.ts';
@@ -40,6 +44,7 @@ import {
   type DiffSearchResult,
   type RepositoryLoadError,
   type ReviewComment,
+  type ReviewIdentity,
   type ReviewScrollBehavior,
   type ReviewScrollTarget,
   type SidebarMode,
@@ -68,12 +73,23 @@ import {
   writeReloadSelection,
 } from './lib/reload-selection.ts';
 import {
+  createReviewCommandTarget,
+  resolveReviewCommandTarget,
+  type ReviewCommandTarget,
+} from './lib/review-command-target.ts';
+import {
   buildReviewCommentsMarkdown,
   getCommentKey,
   getReviewCommentRangeProps,
   getReviewCommentsFromState,
   getVisibleReviewComments,
 } from './lib/review-comments.ts';
+import {
+  getFileReviewIdentity,
+  isReviewIdentityViewed,
+  updateReviewIdentityCollapsed,
+  updateReviewIdentityViewed,
+} from './lib/review-identity.ts';
 import {
   SIDEBAR_COLLAPSE_THRESHOLD,
   clampSidebarWidth,
@@ -115,6 +131,7 @@ import type {
 
 const emptyWalkthroughNotes = new Map<string, WalkthroughNote>();
 const emptyFiles: ReadonlyArray<ChangedFile> = [];
+const walkthroughCodeViewBottomInset = 96;
 type MainMode = 'review' | 'commit';
 const CODE_FONT_SIZE_DEFAULT = 13;
 const CODE_FONT_SIZE_MAX = 32;
@@ -149,15 +166,7 @@ const normalizeCodeFontSizePreference = (size: number) =>
 
 const getCodeFontLineHeight = (size: number) => Math.round((size * 20) / 13);
 
-const createInlineWalkthroughNote = (reason: string): WalkthroughNote => ({
-  action: 'review',
-  context: reason,
-  groupReason: 'Walkthrough',
-  groupTitle: 'Walkthrough',
-  impact: 'contained',
-  order: 0,
-  reason,
-});
+const ignoreWalkthroughPathScroll = () => {};
 
 const defaultPreferences = getPreferencesFromConfig(createDefaultConfig());
 
@@ -193,7 +202,7 @@ export default function App() {
   const [historyLimit, setHistoryLimit] = useState(HISTORY_PAGE_SIZE);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historySource, setHistorySource] = useState<ReviewSource | null>(null);
-  const [itemVersionByPath, setItemVersionByPath] = useState<Record<string, number>>({});
+  const [itemVersionByKey, setItemVersionByKey] = useState<Record<string, number>>({});
   const [localChangesDetected, setLocalChangesDetected] = useState(false);
   const [launchOptions, setLaunchOptions] = useState<CodiffLaunchOptions>(defaultLaunchOptions);
   const [codiffConfig, setCodiffConfig] = useState<CodiffConfig>(createDefaultConfig);
@@ -237,11 +246,13 @@ export default function App() {
   const programmaticScrollTimerRef = useRef<number | null>(null);
   const sourceSessionsRef = useRef<Map<string, SourceSession>>(new Map());
   const stateRef = useRef<RepositoryState | null>(null);
+  const activeReviewCommandTargetRef = useRef<ReviewCommandTarget | null>(null);
   const collapsedRef = useRef<Set<string>>(new Set());
   const preferencesRef = useRef<CodiffPreferences>(defaultPreferences);
   const reviewCommentsRef = useRef<ReadonlyArray<ReviewComment>>([]);
   const selectedPathRef = useRef<string | null>(null);
   const sidebarModeRef = useRef<SidebarMode>('tree');
+  const mainModeRef = useRef<MainMode>('review');
   const sourceRequestRef = useRef(0);
   const viewedRef = useRef<Record<string, string>>({});
   const narrativeWalkthroughRef = useRef<NarrativeWalkthrough | null>(null);
@@ -249,7 +260,6 @@ export default function App() {
   const narrativeNavigation = useNarrativeNavigation(
     narrativeWalkthrough,
     state?.files ?? emptyFiles,
-    preferences.walkthroughOrder,
     navigationResetKey,
   );
   const walkthroughErrorRef = useRef<WalkthroughError | null>(null);
@@ -269,10 +279,10 @@ export default function App() {
     }));
   }, []);
 
-  const bumpItemVersion = useCallback((path: string) => {
-    setItemVersionByPath((current) => ({
+  const bumpItemVersion = useCallback((key: string) => {
+    setItemVersionByKey((current) => ({
       ...current,
-      [path]: (current[path] ?? 0) + 1,
+      [key]: (current[key] ?? 0) + 1,
     }));
   }, []);
 
@@ -564,7 +574,7 @@ export default function App() {
             .map((file) => file.path),
         ),
       );
-      setItemVersionByPath({});
+      setItemVersionByKey({});
       setFocusCommentId(null);
       setFocusCommentRequest(0);
       setReloadDeltaPaths(nextReloadDeltaPaths);
@@ -866,6 +876,14 @@ export default function App() {
   }, [selectedPath]);
 
   useEffect(() => {
+    mainModeRef.current = mainMode;
+  }, [mainMode]);
+
+  useEffect(() => {
+    activeReviewCommandTargetRef.current = null;
+  }, [navigationResetKey]);
+
+  useEffect(() => {
     viewedRef.current = viewed;
   }, [viewed]);
 
@@ -968,15 +986,31 @@ export default function App() {
     void window.codiff.openFile(file.path).catch(() => {});
   }, []);
 
-  const openSelectedFile = useCallback(() => {
+  const getReviewCommandTarget = useCallback(() => {
     const currentState = stateRef.current;
-    const path = selectedPathRef.current;
-    const file = currentState?.files.find((candidate) => candidate.path === path);
-
-    if (file) {
-      openFile(file);
+    if (!currentState) {
+      return null;
     }
-  }, [openFile]);
+
+    return resolveReviewCommandTarget({
+      activeTarget: activeReviewCommandTargetRef.current,
+      files: currentState.files,
+      selectedPath: selectedPathRef.current,
+      source: currentState.source,
+      useActiveTarget:
+        mainModeRef.current === 'review' &&
+        sidebarModeRef.current === 'walkthrough' &&
+        narrativeWalkthroughRef.current != null,
+    });
+  }, []);
+
+  const openSelectedFile = useCallback(() => {
+    const target = getReviewCommandTarget();
+
+    if (target) {
+      openFile(target.file);
+    }
+  }, [getReviewCommandTarget, openFile]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -1246,7 +1280,7 @@ export default function App() {
           setState(orderedState);
           setHistorySource(getHistorySource(orderedState.source) ?? historySource);
           setCollapsed(new Set(nextCollapsed));
-          setItemVersionByPath({});
+          setItemVersionByKey({});
           setReviewComments(session?.reviewComments ?? getReviewCommentsFromState(orderedState));
           setReloadDeltaPaths(new Set());
           setViewed(nextViewed);
@@ -1411,6 +1445,42 @@ export default function App() {
     setMainMode('review');
   }, []);
 
+  const toggleViewed = useCallback(
+    (
+      file: ChangedFile,
+      isViewed: boolean,
+      reviewIdentity: ReviewIdentity = getFileReviewIdentity(file),
+    ) => {
+      const currentState = stateRef.current;
+      if (!currentState) {
+        return;
+      }
+
+      setViewed((current) => {
+        const next = updateReviewIdentityViewed(current, reviewIdentity, isViewed);
+        if (currentState.source.type === 'working-tree') {
+          writeViewed(currentState.root, next);
+        }
+        return next;
+      });
+
+      setCollapsed((current) => updateReviewIdentityCollapsed(current, reviewIdentity, isViewed));
+      bumpItemVersion(reviewIdentity.key);
+    },
+    [bumpItemVersion],
+  );
+
+  const updateActiveWalkthroughReviewTarget = useCallback(
+    (target: WalkthroughReviewTarget | null) => {
+      const currentState = stateRef.current;
+      activeReviewCommandTargetRef.current =
+        target && currentState
+          ? createReviewCommandTarget(currentState.source, target.file, target.reviewIdentity)
+          : null;
+    },
+    [],
+  );
+
   useEffect(() => {
     const registry = commandRegistryRef.current;
     const unregisterFns = [
@@ -1491,27 +1561,21 @@ export default function App() {
         title: 'Copy Review Comments and Close',
       }),
       registry.register({
-        description: () => selectedPathRef.current,
+        description: () => getReviewCommandTarget()?.file.path ?? null,
         execute: () => {
-          const currentState = stateRef.current;
-          const path = selectedPathRef.current;
-          if (!currentState || !path) {
+          const target = getReviewCommandTarget();
+          if (!target) {
             return;
           }
 
-          const file = currentState.files.find((f) => f.path === path);
-          if (!file) {
-            return;
-          }
-
-          const isViewed = viewedRef.current[file.path] === file.fingerprint;
-          setFileViewedState(currentState, file, !isViewed);
+          const isViewed = isReviewIdentityViewed(viewedRef.current, target.reviewIdentity);
+          toggleViewed(target.file, isViewed, target.reviewIdentity);
         },
         id: 'toggle-viewed',
         title: 'Toggle Viewed',
       }),
       registry.register({
-        description: () => selectedPathRef.current,
+        description: () => getReviewCommandTarget()?.file.path ?? null,
         execute: openSelectedFile,
         id: 'open-file',
         keymapAction: 'openFile',
@@ -1590,29 +1654,30 @@ export default function App() {
       }
     };
   }, [
-    bumpItemVersion,
     changeSidebarMode,
     expandSidebar,
+    getReviewCommandTarget,
     openDiffSearch,
     openSelectedFile,
     reloadWindow,
     setFileViewedState,
     toggleSidebar,
+    toggleViewed,
     toggleWordWrap,
   ]);
 
   const toggleCollapsed = useCallback(
-    (file: ChangedFile, isCollapsed: boolean) => {
+    (file: ChangedFile, isCollapsed: boolean, reviewKey = file.path) => {
       setCollapsed((current) => {
         const next = new Set(current);
         if (isCollapsed) {
-          next.delete(file.path);
+          next.delete(reviewKey);
         } else {
-          next.add(file.path);
+          next.add(reviewKey);
         }
         return next;
       });
-      bumpItemVersion(file.path);
+      bumpItemVersion(reviewKey);
     },
     [bumpItemVersion],
   );
@@ -1661,17 +1726,6 @@ export default function App() {
       }
     },
     [showWhitespace, visibleFiles],
-  );
-
-  const toggleViewed = useCallback(
-    (file: ChangedFile, isViewed: boolean) => {
-      if (!state) {
-        return;
-      }
-
-      setFileViewedState(state, file, !isViewed);
-    },
-    [setFileViewedState, state],
   );
 
   const createComment = useCallback(
@@ -1727,11 +1781,20 @@ export default function App() {
   );
 
   const updateComment = useCallback((commentId: string, body: string) => {
-    setReviewComments((current) =>
-      current.map((comment) =>
-        comment.id === commentId && !comment.isReadOnly ? { ...comment, body } : comment,
-      ),
-    );
+    const applyCommentBody = (current: ReadonlyArray<ReviewComment>) => {
+      let changed = false;
+      const next = current.map((comment) => {
+        if (comment.id !== commentId || comment.isReadOnly || comment.body === body) {
+          return comment;
+        }
+        changed = true;
+        return { ...comment, body };
+      });
+      return changed ? next : current;
+    };
+
+    reviewCommentsRef.current = applyCommentBody(reviewCommentsRef.current);
+    setReviewComments(applyCommentBody);
   }, []);
 
   const deleteComment = useCallback(
@@ -2017,8 +2080,8 @@ export default function App() {
   const emptySourceDetail = getEmptySourceDetail(state.source, state.root);
 
   const showNarrativeWalkthrough = narrativeWalkthrough != null && sidebarMode === 'walkthrough';
-  const plainCommitModel = narrativeNavigation.orderView
-    ? buildCommitModel(narrativeNavigation.orderView, state.files)
+  const plainCommitModel = narrativeNavigation.walkthroughView
+    ? buildCommitModel(narrativeNavigation.walkthroughView, state.files)
     : buildGenericCommitModel(state.files);
   const showPlainCommitView =
     mainMode === 'commit' && state.source.type === 'working-tree' && state.files.length > 0;
@@ -2041,7 +2104,7 @@ export default function App() {
     gitIdentity,
     hunkNavigation,
     isPullRequest,
-    itemVersionByPath,
+    itemVersionByKey,
     keymap: codiffConfig.keymap,
     loadingSectionIds,
     onAskCodex: askCodex,
@@ -2060,21 +2123,27 @@ export default function App() {
     viewed,
     wordWrap,
   };
-  // Render one changed file's live diff for a walkthrough stop / full-context reader.
-  const renderStopDiff = (file: ChangedFile, note?: string) => {
-    const walkthroughNotes = note
-      ? new Map([[file.path, createInlineWalkthroughNote(note)]])
-      : emptyWalkthroughNotes;
+  const renderWalkthroughDiffBlocks = (
+    blocks: ReadonlyArray<ReviewDiffBlock>,
+    blockScrollTarget: WalkthroughBlockScrollTarget | null,
+    onActiveBlockChange: (blockId: string) => void,
+  ) => {
     return (
-      <ReviewCodeView
-        {...commonReviewProps}
-        commitMetadata={null}
-        files={[file]}
-        forceExpandedPaths={diffSearchMatchPathSet}
-        scrollTarget={null}
-        selectedPath={null}
-        walkthroughNotes={walkthroughNotes}
-      />
+      <div className="wt-stop wt-diff-surface">
+        <ReviewCodeView
+          {...commonReviewProps}
+          blocks={blocks}
+          bottomInset={walkthroughCodeViewBottomInset}
+          commitMetadata={null}
+          files={[]}
+          forceExpandedPaths={diffSearchMatchPathSet}
+          onActiveBlockChange={onActiveBlockChange}
+          onSelectPathFromScroll={ignoreWalkthroughPathScroll}
+          scrollTarget={blockScrollTarget}
+          selectedPath={null}
+          walkthroughNotes={emptyWalkthroughNotes}
+        />
+      </div>
     );
   };
 
@@ -2239,9 +2308,10 @@ export default function App() {
           <NarrativeWalkthroughView
             files={state.files}
             navigation={narrativeNavigation}
+            onActiveReviewTargetChange={updateActiveWalkthroughReviewTarget}
             onCommit={commitWalkthrough}
             onUpdateCommitMessage={updateWalkthroughCommitMessage}
-            renderStopDiff={renderStopDiff}
+            renderDiffBlocks={renderWalkthroughDiffBlocks}
             showWhitespace={showWhitespace}
             walkthrough={narrativeWalkthrough}
           />

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -19,13 +19,13 @@ import type {
   RepositoryState,
   ReviewSource,
 } from '../types.ts';
+import { createChangedFile } from './helpers/fixtures.ts';
+import { waitFor } from './helpers/react.tsx';
 
 const reactActEnvironment = globalThis as typeof globalThis & {
-  IS_REACT_ACT_ENVIRONMENT?: boolean;
   ResizeObserver?: typeof ResizeObserver;
   Worker?: typeof Worker;
 };
-reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
 reactActEnvironment.ResizeObserver ??= class ResizeObserver {
   disconnect() {}
   observe() {}
@@ -84,39 +84,6 @@ const repositoryState = {
   source: { type: 'working-tree' },
 } satisfies RepositoryState;
 
-const createChangedFile = (path: string, fingerprint = `${path}:1`) =>
-  ({
-    fingerprint,
-    path,
-    sections: [
-      {
-        binary: false,
-        id: `${path}:unstaged`,
-        kind: 'unstaged',
-        patch: `diff --git a/${path} b/${path}\n@@ -1 +1 @@\n-old\n+new\n`,
-      },
-    ],
-    status: 'modified',
-  }) satisfies ChangedFile;
-
-const waitFor = async (assertion: () => void) => {
-  let lastError: unknown;
-
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    try {
-      assertion();
-      return;
-    } catch (error) {
-      lastError = error;
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-    }
-  }
-
-  throw lastError;
-};
-
 const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['codiff'] => ({
   askReviewAssistant: vi.fn(async () => ({
     reason: 'Unavailable in tests.',
@@ -164,7 +131,6 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
     showOutdated: false,
     showWhitespace: false,
     theme: 'system' as const,
-    walkthroughOrder: 'keys',
     wordWrap: false,
   })),
   getRepositoryHistory: vi.fn(async () => ({
@@ -196,7 +162,6 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
   resetCodeFontSize: vi.fn(async () => {}),
   setDiffStyle: vi.fn(async () => {}),
   setShowOutdated: vi.fn(async () => {}),
-  setWalkthroughOrder: vi.fn(async () => {}),
   setWordWrap: vi.fn(async () => {}),
   showInFolder: vi.fn(async () => {}),
   submitPullRequestComment: vi.fn(async () => {
@@ -659,9 +624,9 @@ test('repository reload does not let stale selection override launch source', as
 });
 
 test('repository reload colors only git status glyphs for files changed after reload', async () => {
-  const unchangedFile = createChangedFile('src/unchanged.ts', 'same');
-  const changedFileBeforeReload = createChangedFile('src/changed.ts', 'before');
-  const changedFileAfterReload = createChangedFile('src/changed.ts', 'after');
+  const unchangedFile = createChangedFile('src/unchanged.ts', { fingerprint: 'same' });
+  const changedFileBeforeReload = createChangedFile('src/changed.ts', { fingerprint: 'before' });
+  const changedFileAfterReload = createChangedFile('src/changed.ts', { fingerprint: 'after' });
   const previousState = {
     ...repositoryState,
     files: [unchangedFile, changedFileBeforeReload],
@@ -714,8 +679,8 @@ test('repository reload colors only git status glyphs for files changed after re
 });
 
 test('tree sidebar subtly mutes files currently marked viewed', async () => {
-  const viewedFile = createChangedFile('src/viewed.ts', 'viewed-current');
-  const staleViewedFile = createChangedFile('src/stale.ts', 'stale-current');
+  const viewedFile = createChangedFile('src/viewed.ts', { fingerprint: 'viewed-current' });
+  const staleViewedFile = createChangedFile('src/stale.ts', { fingerprint: 'stale-current' });
   const nextState = {
     ...repositoryState,
     files: [viewedFile, staleViewedFile],
@@ -1015,21 +980,22 @@ test('narrative walkthrough stops do not repeat commit details', async () => {
         id: 'impl',
         stops: [
           {
-            anchors: [
+            added: 1,
+            deleted: 1,
+            hunkIds: ['src/app.ts:unstaged:h1'],
+            hunks: [
               {
                 added: 1,
                 anchor: { display: 'src/app.ts', sectionId: 'src/app.ts:unstaged', side: 'both' },
                 deleted: 1,
-                granularity: 'file',
-                id: 's1',
+                id: 'src/app.ts:unstaged:h1',
                 path: 'src/app.ts',
                 status: 'modified',
               },
             ],
-            body: 'Review this file without repeating the commit header.',
-            id: 'implementation-path',
+            id: 's1',
             importance: 'critical',
-            summary: 'The implementation path carries the commit review.',
+            prose: 'Review this file without repeating the commit header.',
             title: 'Implementation path',
           },
         ],
@@ -1043,7 +1009,7 @@ test('narrative walkthrough stops do not repeat commit details', async () => {
     source,
     support: [],
     title: 'Narrative',
-    version: 3,
+    version: 4,
   } satisfies NarrativeWalkthrough;
 
   window.codiff = createCodiffMock({
@@ -1104,20 +1070,22 @@ test('a walkthrough file loads even without the walkthrough launch flag', async 
         id: 'impl',
         stops: [
           {
-            anchors: [
+            added: 1,
+            deleted: 1,
+            hunkIds: ['src/app.ts:unstaged:h1'],
+            hunks: [
               {
                 added: 1,
                 anchor: { display: 'src/app.ts', sectionId: 'src/app.ts:unstaged', side: 'both' },
                 deleted: 1,
-                granularity: 'file',
-                id: 's1',
+                id: 'src/app.ts:unstaged:h1',
                 path: 'src/app.ts',
                 status: 'modified',
               },
             ],
-            body: 'Review this file.',
             id: 'implementation-path',
             importance: 'critical',
+            prose: 'Review this file.',
             summary: 'The implementation path.',
             title: 'Implementation path',
           },
@@ -1132,7 +1100,7 @@ test('a walkthrough file loads even without the walkthrough launch flag', async 
     source,
     support: [],
     title: 'Narrative',
-    version: 3,
+    version: 4,
   } satisfies NarrativeWalkthrough;
 
   const getNarrativeWalkthrough = vi.fn(async () => ({

--- a/src/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/src/__tests__/ReviewCodeView-scroll.test.tsx
@@ -2,208 +2,127 @@
  * @vitest-environment jsdom
  */
 
-import type { CodeViewItem } from '@pierre/diffs';
-import { act } from 'react';
+import { act, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { expect, test, vi } from 'vite-plus/test';
-import { ReviewCodeView } from '../app/components/ReviewCodeView.tsx';
-import { defaultKeymap } from '../config/defaults.ts';
-import type { ReviewComment } from '../lib/app-types.ts';
-import type { ChangedFile, CommitMetadata, ReviewSource } from '../types.ts';
+import { beforeEach, expect, test, vi } from 'vite-plus/test';
+import type { ReviewComment, ReviewIdentity } from '../lib/app-types.ts';
+import {
+  updateReviewIdentityCollapsed,
+  updateReviewIdentityViewed,
+} from '../lib/review-identity.ts';
+import type { ChangedFile } from '../types.ts';
+import { createChangedFile, createChangedFileWithPatch } from './helpers/fixtures.ts';
+import { setInputValue, waitFor } from './helpers/react.tsx';
+import {
+  codeViewMock,
+  commitMetadata,
+  commitSource,
+  resetCodeViewMock,
+  ReviewCodeViewHarness,
+  type ReviewDiffBlock,
+} from './helpers/review-code-view.tsx';
 
-const codeViewMock = vi.hoisted(() => ({
-  scrollTo: vi.fn(),
-}));
-
-vi.mock('@pierre/diffs/react', async () => {
-  const React = await import('react');
-
-  return {
-    CodeView: React.forwardRef(function MockCodeView(
-      props: {
-        className?: string;
-        items: Array<CodeViewItem<unknown>>;
-        onScroll?: (scrollTop: number, viewer: unknown) => void;
-        renderAnnotation?: (
-          annotation: { metadata: unknown },
-          item: CodeViewItem<unknown>,
-        ) => React.ReactNode;
-        renderCustomHeader?: (item: CodeViewItem<unknown>) => React.ReactNode;
-      },
-      ref: React.ForwardedRef<unknown>,
-    ) {
-      const itemsRef = React.useRef(props.items);
-      const renderedIdsRef = React.useRef(new Set<string>());
-      const scrollAttemptByIdRef = React.useRef(new Map<string, number>());
-      const scrollTopRef = React.useRef(0);
-      itemsRef.current = props.items;
-
-      const viewer = React.useMemo(
-        () => ({
-          getRenderedItems: () =>
-            itemsRef.current
-              .filter((item) => renderedIdsRef.current.has(item.id))
-              .map((item) => ({
-                element: document.createElement('div'),
-                id: item.id,
-                instance: {},
-                item,
-                type: item.type,
-                version: item.version,
-              })),
-          getScrollTop: () => scrollTopRef.current,
-          getTopForItem: (id: string) => {
-            const index = itemsRef.current.findIndex((item) => item.id === id);
-            return index === -1 ? undefined : index * 200 + 20;
-          },
-        }),
-        [],
-      );
-
-      React.useImperativeHandle(
-        ref,
-        () => ({
-          clearSelectedLines: () => {},
-          getInstance: () => viewer,
-          scrollTo: (target: { behavior?: string; id: string; offset?: number }) => {
-            codeViewMock.scrollTo(target);
-            const attempts = (scrollAttemptByIdRef.current.get(target.id) ?? 0) + 1;
-            scrollAttemptByIdRef.current.set(target.id, attempts);
-            const itemTop = viewer.getTopForItem(target.id) ?? 0;
-            scrollTopRef.current = Math.max(0, itemTop - (target.offset ?? 0));
-            if (attempts >= 2) {
-              renderedIdsRef.current.add(target.id);
-            }
-            props.onScroll?.(scrollTopRef.current, viewer);
-          },
-        }),
-        [props, viewer],
-      );
-
-      return React.createElement(
-        'div',
-        { className: props.className },
-        props.items.map((item) =>
-          React.createElement(
-            'div',
-            { key: item.id },
-            props.renderCustomHeader ? props.renderCustomHeader(item) : null,
-            'annotations' in item && Array.isArray(item.annotations)
-              ? item.annotations.map((annotation, index) =>
-                  React.createElement(
-                    React.Fragment,
-                    { key: index },
-                    props.renderAnnotation?.(annotation, item),
-                  ),
-                )
-              : null,
-          ),
-        ),
-      );
-    }),
-    WorkerPoolContextProvider: ({ children }: { children: React.ReactNode }) =>
-      React.createElement(React.Fragment, null, children),
-  };
+beforeEach(() => {
+  resetCodeViewMock();
 });
 
-const createChangedFile = (path: string) =>
-  ({
-    fingerprint: `${path}:1`,
-    path,
-    sections: [
-      {
-        binary: false,
-        id: `${path}:unstaged`,
-        kind: 'unstaged',
-        patch: `diff --git a/${path} b/${path}\n@@ -1 +1 @@\n-old\n+new\n`,
-      },
-    ],
-    status: 'modified',
-  }) satisfies ChangedFile;
+test('walkthrough header chrome does not leak inline styles onto reused diff nodes', async () => {
+  const file = createChangedFile('src/reused.ts');
+  const headerBlock: ReviewDiffBlock = {
+    file,
+    header: <div>Header</div>,
+    id: 'walkthrough-stop',
+  };
 
-const createChangedFileWithPatch = (path: string, patch: string) =>
-  ({
-    fingerprint: `${path}:1`,
-    path,
-    sections: [
-      {
-        binary: false,
-        id: `${path}:unstaged`,
-        kind: 'unstaged',
-        patch,
-      },
-    ],
-    status: 'modified',
-  }) satisfies ChangedFile;
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
 
-const source = { type: 'working-tree' } satisfies ReviewSource;
-const commitSource = { ref: 'abc1234', type: 'commit' } satisfies ReviewSource;
-const commitMetadata = {
-  author: {
-    date: '2026-01-01T12:00:00Z',
-    email: 'author@example.com',
-    name: 'Author',
-  },
-  body: '',
-  committer: {
-    date: '2026-01-01T12:00:00Z',
-    email: 'committer@example.com',
-    name: 'Committer',
-  },
-  files: [
-    {
-      additions: 1,
-      binary: false,
-      deletions: 1,
-      path: 'src/second.ts',
-      status: 'modified' as const,
-    },
-    {
-      additions: 1,
-      binary: false,
-      deletions: 0,
-      path: 'src/hidden.ts',
-      status: 'modified' as const,
-    },
-  ],
-  parents: ['parent-sha'],
-  ref: 'abc1234',
-  refs: ['main'],
-  shortRef: 'abc1234',
-  signature: {
-    status: 'N',
-  },
-  stats: {
-    additions: 2,
-    binaryFiles: 0,
-    deletions: 1,
-    files: 2,
-    renamedFiles: 0,
-  },
-  subject: 'Commit subject',
-  trailers: [],
-} satisfies CommitMetadata;
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<ReviewCodeViewHarness blocks={[headerBlock]} files={[file]} />);
+    });
 
-const waitFor = async (assertion: () => void) => {
-  let lastError: unknown;
+    expect(
+      codeViewMock.postRenderNodes[0]?.classList.contains('codiff-walkthrough-header-item'),
+    ).toBe(true);
 
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    try {
-      assertion();
-      return;
-    } catch (error) {
-      lastError = error;
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+    await act(async () => {
+      root?.render(<ReviewCodeViewHarness files={[file]} />);
+    });
+
+    const reusedNode = codeViewMock.postRenderNodes[0];
+    expect(reusedNode?.classList.contains('codiff-walkthrough-header-item')).toBe(false);
+    expect(container.textContent).not.toContain('Header');
+    expect(container.querySelector('.codiff-file-header')).not.toBeNull();
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
     }
+    container.remove();
   }
+});
 
-  throw lastError;
-};
+test('header-only walkthrough blocks render and can be scroll targets', async () => {
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
 
-test('reload scroll target is retried until the selected item renders', async () => {
-  codeViewMock.scrollTo.mockClear();
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <ReviewCodeViewHarness
+          blocks={[
+            {
+              header: <div>Missing stop</div>,
+              id: 'walkthrough:s1:missing',
+              selected: true,
+            },
+          ]}
+          files={[]}
+          scrollTarget={{ blockId: 'walkthrough:s1:missing', request: 1 }}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Missing stop');
+    await waitFor(() => {
+      expect(codeViewMock.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'walkthrough:s1:missing:walkthrough-header',
+          type: 'item',
+        }),
+      );
+    });
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('focused walkthrough blocks render only global comments visible in the focused patch', async () => {
+  const file = createChangedFileWithPatch(
+    'src/commented.ts',
+    'diff --git a/src/commented.ts b/src/commented.ts\n@@ -1 +1 @@\n-old\n+focused\n',
+  );
+  const visibleComment = {
+    body: 'Visible focused comment.',
+    filePath: file.path,
+    id: 'visible-comment',
+    lineNumber: 1,
+    sectionId: file.sections[0].id,
+    side: 'additions',
+  } satisfies ReviewComment;
+  const offHunkComment = {
+    ...visibleComment,
+    body: 'Off-hunk comment should stay out.',
+    id: 'off-hunk-comment',
+    lineNumber: 20,
+  } satisfies ReviewComment;
 
   const container = document.createElement('div');
   document.body.append(container);
@@ -213,48 +132,267 @@ test('reload scroll target is retried until the selected item renders', async ()
     await act(async () => {
       root = createRoot(container);
       root.render(
-        <ReviewCodeView
-          activeSearchMatch={null}
-          agentId="codex"
-          agentLabel="Codex"
-          collapsed={new Set()}
-          comments={[]}
-          commitMetadata={null}
-          diffStyle="split"
-          files={[createChangedFile('src/first.ts'), createChangedFile('src/second.ts')]}
-          focusCommentId={null}
-          focusCommentRequest={0}
-          forceExpandedPaths={new Set()}
-          gitIdentity={null}
-          hunkNavigation={null}
-          isPullRequest={false}
-          itemVersionByPath={{}}
-          keymap={defaultKeymap}
-          loadingSectionIds={new Set()}
-          onAskCodex={() => {}}
-          onCreateComment={() => {}}
-          onDeleteComment={() => {}}
-          onLoadSection={() => {}}
-          onOpenFile={() => {}}
-          onSelectPathFromScroll={() => {}}
-          onSubmitComment={() => {}}
-          onToggleCollapsed={() => {}}
-          onToggleViewed={() => {}}
-          onUpdateComment={() => {}}
-          scrollTarget={{ path: 'src/second.ts', request: 1 }}
-          searchQuery=""
-          selectedPath="src/second.ts"
-          showWhitespace={false}
-          source={source}
-          viewed={{}}
-          walkthroughNotes={new Map()}
-          wordWrap={false}
+        <ReviewCodeViewHarness
+          blocks={[{ file, id: 'walkthrough:s1:0', itemIdPrefix: 'walkthrough:s1:0' }]}
+          comments={[visibleComment, offHunkComment]}
+          files={[file]}
+        />,
+      );
+    });
+
+    const textareas = [...container.querySelectorAll<HTMLTextAreaElement>('textarea')];
+    expect(textareas.map((textarea) => textarea.value)).toEqual([visibleComment.body]);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('focused walkthrough blocks keep cross-side comments when their rendered anchor is visible', async () => {
+  const file = createChangedFileWithPatch(
+    'src/ranged-comment.ts',
+    'diff --git a/src/ranged-comment.ts b/src/ranged-comment.ts\n@@ -8,3 +8,3 @@\n context\n-old\n+new\n',
+  );
+  const rangedComment = {
+    body: 'Cross-side comment.',
+    filePath: file.path,
+    id: 'cross-side-comment',
+    lineNumber: 10,
+    sectionId: file.sections[0].id,
+    side: 'additions',
+    startLineNumber: 7,
+    startSide: 'deletions',
+  } satisfies ReviewComment;
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <ReviewCodeViewHarness
+          blocks={[{ file, id: 'walkthrough:s1:0', itemIdPrefix: 'walkthrough:s1:0' }]}
+          comments={[rangedComment]}
+          files={[file]}
+        />,
+      );
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>('textarea');
+    expect(textarea?.value).toBe(rangedComment.body);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('focused walkthrough blocks resolve active search matches to rendered item ids', async () => {
+  const file = createChangedFileWithPatch(
+    'src/search.ts',
+    'diff --git a/src/search.ts b/src/search.ts\n@@ -1 +1 @@\n-old\n+needle\n',
+  );
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <ReviewCodeViewHarness
+          activeSearchMatch={{
+            filePath: file.path,
+            itemId: `diff:${file.sections[0].id}`,
+            lineNumber: 1,
+            side: 'additions',
+          }}
+          blocks={[{ file, id: 'walkthrough:s1:0', itemIdPrefix: 'walkthrough:s1:0' }]}
+          files={[file]}
         />,
       );
     });
 
     await waitFor(() => {
-      expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(2);
+      expect(codeViewMock.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: `walkthrough:s1:0:diff:${file.sections[0].id}`,
+          lineNumber: 1,
+          side: 'additions',
+          type: 'line',
+        }),
+      );
+    });
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('review comment drafts resync clean external updates and reset on comment switch', async () => {
+  const file = createChangedFile('src/draft.ts');
+  const baseComment = {
+    body: 'Original body',
+    filePath: file.path,
+    id: 'comment-1',
+    lineNumber: 1,
+    sectionId: file.sections[0].id,
+    side: 'additions',
+  } satisfies ReviewComment;
+  const onUpdateComment = vi.fn();
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+  const renderComment = (comment: ReviewComment) =>
+    root?.render(
+      <ReviewCodeViewHarness
+        comments={[comment]}
+        files={[file]}
+        focusCommentId={comment.id}
+        onUpdateComment={onUpdateComment}
+      />,
+    );
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      renderComment(baseComment);
+    });
+
+    const textarea = () => container.querySelector<HTMLTextAreaElement>('textarea')!;
+    expect(textarea().value).toBe('Original body');
+
+    await act(async () => {
+      renderComment({ ...baseComment, body: 'Clean external body' });
+    });
+    expect(textarea().value).toBe('Clean external body');
+
+    await setInputValue(textarea(), 'Unsaved local draft');
+    expect(textarea().value).toBe('Unsaved local draft');
+
+    await act(async () => {
+      renderComment({ ...baseComment, body: 'Ignored while dirty' });
+    });
+    expect(textarea().value).toBe('Unsaved local draft');
+
+    await act(async () => {
+      renderComment({ ...baseComment, body: 'Second comment body', id: 'comment-2' });
+    });
+    expect(textarea().value).toBe('Second comment body');
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('walkthrough hunk viewed state is keyed independently from file path', async () => {
+  const filePath = 'src/shared.ts';
+  const firstFile = { ...createChangedFile(filePath), fingerprint: 'first-hunk' };
+  const secondFile = { ...createChangedFile(filePath), fingerprint: 'second-hunk' };
+  const firstIdentity = { fingerprint: firstFile.fingerprint, key: 'walkthrough:s1:h1' };
+  const secondIdentity = { fingerprint: secondFile.fingerprint, key: 'walkthrough:s2:h2' };
+
+  function Harness() {
+    const [viewed, setViewed] = useState<Record<string, string>>({});
+    const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+    const [itemVersionByKey, setItemVersionByKey] = useState<Record<string, number>>({});
+
+    const toggleViewed = (
+      _file: ChangedFile,
+      isViewed: boolean,
+      reviewIdentity: ReviewIdentity,
+    ) => {
+      setViewed((current) => updateReviewIdentityViewed(current, reviewIdentity, isViewed));
+      setCollapsed((current) => updateReviewIdentityCollapsed(current, reviewIdentity, isViewed));
+      setItemVersionByKey((current) => ({
+        ...current,
+        [reviewIdentity.key]: (current[reviewIdentity.key] ?? 0) + 1,
+      }));
+    };
+
+    return (
+      <>
+        <ReviewCodeViewHarness
+          collapsed={collapsed}
+          files={[firstFile]}
+          itemVersionByKey={itemVersionByKey}
+          onToggleViewed={toggleViewed}
+          reviewIdentityByPath={new Map([[filePath, firstIdentity]])}
+          viewed={viewed}
+        />
+        <ReviewCodeViewHarness
+          collapsed={collapsed}
+          files={[secondFile]}
+          itemVersionByKey={itemVersionByKey}
+          onToggleViewed={toggleViewed}
+          reviewIdentityByPath={new Map([[filePath, secondIdentity]])}
+          viewed={viewed}
+        />
+      </>
+    );
+  }
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Harness />);
+    });
+
+    const viewedButtons = () => [
+      ...container.querySelectorAll<HTMLButtonElement>('.codiff-viewed-button'),
+    ];
+    expect(viewedButtons()).toHaveLength(2);
+
+    await act(async () => {
+      viewedButtons()[0].click();
+    });
+
+    await waitFor(() => {
+      expect(viewedButtons()[0].getAttribute('aria-pressed')).toBe('true');
+      expect(viewedButtons()[1].getAttribute('aria-pressed')).toBe('false');
+    });
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('reload scroll target is retried until the selected item renders', async () => {
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <ReviewCodeViewHarness
+          files={[createChangedFile('src/first.ts'), createChangedFile('src/second.ts')]}
+          scrollTarget={{ path: 'src/second.ts', request: 1 }}
+          selectedPath="src/second.ts"
+        />,
+      );
+    });
+
+    await waitFor(() => {
+      expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(1);
     });
     expect(codeViewMock.scrollTo).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -271,9 +409,47 @@ test('reload scroll target is retried until the selected item renders', async ()
   }
 });
 
-test('commit metadata file rows scroll to the matching diff', async () => {
-  codeViewMock.scrollTo.mockClear();
+test('scroll targets issue one command per request even before render visibility catches up', async () => {
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+  const scrollTarget = { behavior: 'smooth' as const, path: 'src/second.ts', request: 1 };
 
+  const renderView = () => (
+    <ReviewCodeViewHarness
+      files={[createChangedFile('src/first.ts'), createChangedFile('src/second.ts')]}
+      scrollTarget={scrollTarget}
+    />
+  );
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(renderView());
+    });
+
+    await waitFor(() => {
+      expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      root?.render(renderView());
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(1);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('commit metadata file rows scroll to the matching diff', async () => {
   const container = document.createElement('div');
   document.body.append(container);
   let root: Root | null = null;
@@ -282,42 +458,10 @@ test('commit metadata file rows scroll to the matching diff', async () => {
     await act(async () => {
       root = createRoot(container);
       root.render(
-        <ReviewCodeView
-          activeSearchMatch={null}
-          agentId="codex"
-          agentLabel="Codex"
-          collapsed={new Set()}
-          comments={[]}
+        <ReviewCodeViewHarness
           commitMetadata={commitMetadata}
-          diffStyle="split"
           files={[createChangedFile('src/first.ts'), createChangedFile('src/second.ts')]}
-          focusCommentId={null}
-          focusCommentRequest={0}
-          forceExpandedPaths={new Set()}
-          gitIdentity={null}
-          hunkNavigation={null}
-          isPullRequest={false}
-          itemVersionByPath={{}}
-          keymap={defaultKeymap}
-          loadingSectionIds={new Set()}
-          onAskCodex={() => {}}
-          onCreateComment={() => {}}
-          onDeleteComment={() => {}}
-          onLoadSection={() => {}}
-          onOpenFile={() => {}}
-          onSelectPathFromScroll={() => {}}
-          onSubmitComment={() => {}}
-          onToggleCollapsed={() => {}}
-          onToggleViewed={() => {}}
-          onUpdateComment={() => {}}
-          scrollTarget={null}
-          searchQuery=""
-          selectedPath={null}
-          showWhitespace={false}
           source={commitSource}
-          viewed={{}}
-          walkthroughNotes={new Map()}
-          wordWrap={false}
         />,
       );
     });
@@ -363,8 +507,6 @@ test('commit metadata file rows scroll to the matching diff', async () => {
 });
 
 test('hunk navigation skips stale requests when the review view remounts', async () => {
-  codeViewMock.scrollTo.mockClear();
-
   const container = document.createElement('div');
   document.body.append(container);
   let root: Root | null = null;
@@ -373,42 +515,10 @@ test('hunk navigation skips stale requests when the review view remounts', async
     await act(async () => {
       root = createRoot(container);
       root.render(
-        <ReviewCodeView
-          activeSearchMatch={null}
-          agentId="codex"
-          agentLabel="Codex"
-          collapsed={new Set()}
-          comments={[]}
-          commitMetadata={null}
+        <ReviewCodeViewHarness
           diffStyle="unified"
           files={[createChangedFile('src/first.ts')]}
-          focusCommentId={null}
-          focusCommentRequest={0}
-          forceExpandedPaths={new Set()}
-          gitIdentity={null}
           hunkNavigation={{ direction: 1, request: 1 }}
-          isPullRequest={false}
-          itemVersionByPath={{}}
-          keymap={defaultKeymap}
-          loadingSectionIds={new Set()}
-          onAskCodex={() => {}}
-          onCreateComment={() => {}}
-          onDeleteComment={() => {}}
-          onLoadSection={() => {}}
-          onOpenFile={() => {}}
-          onSelectPathFromScroll={() => {}}
-          onSubmitComment={() => {}}
-          onToggleCollapsed={() => {}}
-          onToggleViewed={() => {}}
-          onUpdateComment={() => {}}
-          scrollTarget={null}
-          searchQuery=""
-          selectedPath={null}
-          showWhitespace={false}
-          source={source}
-          viewed={{}}
-          walkthroughNotes={new Map()}
-          wordWrap={false}
         />,
       );
     });
@@ -421,42 +531,10 @@ test('hunk navigation skips stale requests when the review view remounts', async
 
     await act(async () => {
       root?.render(
-        <ReviewCodeView
-          activeSearchMatch={null}
-          agentId="codex"
-          agentLabel="Codex"
-          collapsed={new Set()}
-          comments={[]}
-          commitMetadata={null}
+        <ReviewCodeViewHarness
           diffStyle="unified"
           files={[createChangedFile('src/first.ts')]}
-          focusCommentId={null}
-          focusCommentRequest={0}
-          forceExpandedPaths={new Set()}
-          gitIdentity={null}
           hunkNavigation={{ direction: 1, request: 2 }}
-          isPullRequest={false}
-          itemVersionByPath={{}}
-          keymap={defaultKeymap}
-          loadingSectionIds={new Set()}
-          onAskCodex={() => {}}
-          onCreateComment={() => {}}
-          onDeleteComment={() => {}}
-          onLoadSection={() => {}}
-          onOpenFile={() => {}}
-          onSelectPathFromScroll={() => {}}
-          onSubmitComment={() => {}}
-          onToggleCollapsed={() => {}}
-          onToggleViewed={() => {}}
-          onUpdateComment={() => {}}
-          scrollTarget={null}
-          searchQuery=""
-          selectedPath={null}
-          showWhitespace={false}
-          source={source}
-          viewed={{}}
-          walkthroughNotes={new Map()}
-          wordWrap={false}
         />,
       );
     });
@@ -478,8 +556,6 @@ test('hunk navigation skips stale requests when the review view remounts', async
 });
 
 test('hunk navigation orders deletion comments before added rows in unified changes', async () => {
-  codeViewMock.scrollTo.mockClear();
-
   const file = createChangedFileWithPatch(
     'src/first.ts',
     'diff --git a/src/first.ts b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n',
@@ -499,42 +575,11 @@ test('hunk navigation orders deletion comments before added rows in unified chan
 
   const render = (request: number) =>
     root?.render(
-      <ReviewCodeView
-        activeSearchMatch={null}
-        agentId="codex"
-        agentLabel="Codex"
-        collapsed={new Set()}
+      <ReviewCodeViewHarness
         comments={[comment]}
-        commitMetadata={null}
         diffStyle="unified"
         files={[file]}
-        focusCommentId={null}
-        focusCommentRequest={0}
-        forceExpandedPaths={new Set()}
-        gitIdentity={null}
         hunkNavigation={{ direction: 1, request }}
-        isPullRequest={false}
-        itemVersionByPath={{}}
-        keymap={defaultKeymap}
-        loadingSectionIds={new Set()}
-        onAskCodex={() => {}}
-        onCreateComment={() => {}}
-        onDeleteComment={() => {}}
-        onLoadSection={() => {}}
-        onOpenFile={() => {}}
-        onSelectPathFromScroll={() => {}}
-        onSubmitComment={() => {}}
-        onToggleCollapsed={() => {}}
-        onToggleViewed={() => {}}
-        onUpdateComment={() => {}}
-        scrollTarget={null}
-        searchQuery=""
-        selectedPath={null}
-        showWhitespace={false}
-        source={source}
-        viewed={{}}
-        walkthroughNotes={new Map()}
-        wordWrap={false}
       />,
     );
 
@@ -576,9 +621,67 @@ test('hunk navigation orders deletion comments before added rows in unified chan
   }
 });
 
-test('Enter on a focused review control is not converted into a hunk comment', async () => {
-  codeViewMock.scrollTo.mockClear();
+test('review comment typing stays local until a comment action commits it', async () => {
+  const file = createChangedFile('src/comment.ts');
+  const comment = {
+    body: '',
+    filePath: file.path,
+    id: 'comment-1',
+    lineNumber: 1,
+    sectionId: 'src/comment.ts:unstaged',
+    side: 'additions',
+  } satisfies ReviewComment;
+  const onAskCodex = vi.fn();
+  const onUpdateComment = vi.fn();
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
 
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <ReviewCodeViewHarness
+          comments={[comment]}
+          diffStyle="unified"
+          files={[file]}
+          onAskCodex={onAskCodex}
+          onUpdateComment={onUpdateComment}
+        />,
+      );
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>('.review-comment-input');
+    if (!textarea) {
+      throw new Error('Expected review comment textarea.');
+    }
+
+    await setInputValue(textarea, 'Please check this.');
+
+    expect(onUpdateComment).not.toHaveBeenCalled();
+
+    const askButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent === 'Ask',
+    );
+    if (!askButton) {
+      throw new Error('Expected Ask button.');
+    }
+
+    await act(async () => {
+      askButton.click();
+    });
+
+    expect(onUpdateComment).toHaveBeenCalledWith('comment-1', 'Please check this.');
+    expect(onAskCodex).toHaveBeenCalledWith('comment-1');
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('Enter on a focused review control is not converted into a hunk comment', async () => {
   const onCreateComment = vi.fn();
   const onOpenFile = vi.fn();
   const container = document.createElement('div');
@@ -587,42 +690,12 @@ test('Enter on a focused review control is not converted into a hunk comment', a
 
   const render = (request: number) =>
     root?.render(
-      <ReviewCodeView
-        activeSearchMatch={null}
-        agentId="codex"
-        agentLabel="Codex"
-        collapsed={new Set()}
-        comments={[]}
-        commitMetadata={null}
+      <ReviewCodeViewHarness
         diffStyle="unified"
         files={[createChangedFile('src/first.ts')]}
-        focusCommentId={null}
-        focusCommentRequest={0}
-        forceExpandedPaths={new Set()}
-        gitIdentity={null}
         hunkNavigation={{ direction: 1, request }}
-        isPullRequest={false}
-        itemVersionByPath={{}}
-        keymap={defaultKeymap}
-        loadingSectionIds={new Set()}
-        onAskCodex={() => {}}
         onCreateComment={onCreateComment}
-        onDeleteComment={() => {}}
-        onLoadSection={() => {}}
         onOpenFile={onOpenFile}
-        onSelectPathFromScroll={() => {}}
-        onSubmitComment={() => {}}
-        onToggleCollapsed={() => {}}
-        onToggleViewed={() => {}}
-        onUpdateComment={() => {}}
-        scrollTarget={null}
-        searchQuery=""
-        selectedPath={null}
-        showWhitespace={false}
-        source={source}
-        viewed={{}}
-        walkthroughNotes={new Map()}
-        wordWrap={false}
       />,
     );
 

--- a/src/__tests__/codiff-cli.test.ts
+++ b/src/__tests__/codiff-cli.test.ts
@@ -1,15 +1,56 @@
 import { execFile } from 'node:child_process';
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { promisify } from 'node:util';
-import { expect, test } from 'vite-plus/test';
+import { afterAll, beforeAll, expect, test } from 'vite-plus/test';
 import { formatHelpText, parseArguments, resolvePullRequestUrl } from '../../bin/arguments.js';
+import { createFakeCommandLogger, createFakeOpenLogger } from './helpers/cli.ts';
 
 const execFileAsync = promisify(execFile);
 
 const git = async (repo: string, args: ReadonlyArray<string>) => {
-  await execFileAsync('git', ['-C', repo, ...args], { encoding: 'utf8' });
+  await execFileAsync(
+    'git',
+    ['-c', 'commit.gpgsign=false', '-c', 'tag.gpgsign=false', '-C', repo, ...args],
+    { encoding: 'utf8' },
+  );
+};
+
+let refRepositoryPath = '';
+let refRepositoryShortHash = '';
+
+beforeAll(async () => {
+  refRepositoryPath = await realpath(await mkdtemp(join(tmpdir(), 'codiff-cli-refs-')));
+  await git(refRepositoryPath, ['init']);
+  await git(refRepositoryPath, ['config', 'user.email', 'codiff@example.com']);
+  await git(refRepositoryPath, ['config', 'user.name', 'Codiff Test']);
+  await git(refRepositoryPath, ['commit', '--allow-empty', '-m', 'first']);
+  await git(refRepositoryPath, ['branch', 'base']);
+  await git(refRepositoryPath, ['commit', '--allow-empty', '-m', 'second']);
+  await git(refRepositoryPath, ['branch', 'feature']);
+  const { stdout } = await execFileAsync('git', ['-C', refRepositoryPath, 'rev-parse', 'HEAD'], {
+    encoding: 'utf8',
+  });
+  refRepositoryShortHash = stdout.trim().slice(0, 8);
+  await git(refRepositoryPath, ['branch', refRepositoryShortHash]);
+  await git(refRepositoryPath, ['branch', 'target']);
+});
+
+afterAll(async () => {
+  if (refRepositoryPath) {
+    await rm(refRepositoryPath, { force: true, recursive: true });
+  }
+});
+
+const withCwd = async <T>(cwd: string, callback: () => T | Promise<T>) => {
+  const previousCwd = process.cwd();
+  try {
+    process.chdir(cwd);
+    return await callback();
+  } finally {
+    process.chdir(previousCwd);
+  }
 };
 
 test('parseArguments treats a hash positional as a commit ref', () => {
@@ -49,63 +90,33 @@ test('parseArguments treats HEAD positional revisions as commit refs', () => {
 });
 
 test('parseArguments treats plain branch refs as branch refs', async () => {
-  const repositoryPath = await realpath(await mkdtemp(join(tmpdir(), 'codiff-cli-')));
-  const previousCwd = process.cwd();
-
-  try {
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['config', 'user.email', 'codiff@example.com']);
-    await git(repositoryPath, ['config', 'user.name', 'Codiff Test']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'initial commit']);
-    await git(repositoryPath, ['checkout', '-b', 'feature']);
-    process.chdir(repositoryPath);
-
+  await withCwd(refRepositoryPath, () => {
     expect(parseArguments(['feature'])).toEqual({
       branchRef: 'feature',
       commitRef: null,
       help: false,
       pullRequestNumber: null,
       pullRequestUrl: null,
-      requestedPath: repositoryPath,
+      requestedPath: refRepositoryPath,
       version: false,
       walkthrough: false,
     });
-  } finally {
-    process.chdir(previousCwd);
-    await rm(repositoryPath, { force: true, recursive: true });
-  }
+  });
 });
 
 test('parseArguments treats hex-like refs as commits before branches', async () => {
-  const repositoryPath = await realpath(await mkdtemp(join(tmpdir(), 'codiff-cli-')));
-  const previousCwd = process.cwd();
-
-  try {
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['config', 'user.email', 'codiff@example.com']);
-    await git(repositoryPath, ['config', 'user.name', 'Codiff Test']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'initial commit']);
-    const { stdout } = await execFileAsync('git', ['-C', repositoryPath, 'rev-parse', 'HEAD'], {
-      encoding: 'utf8',
-    });
-    const shortHash = stdout.trim().slice(0, 8);
-    await git(repositoryPath, ['branch', shortHash]);
-    process.chdir(repositoryPath);
-
-    expect(parseArguments([shortHash])).toMatchObject({
-      commitRef: shortHash,
-      requestedPath: repositoryPath,
+  await withCwd(refRepositoryPath, () => {
+    expect(parseArguments([refRepositoryShortHash])).toMatchObject({
+      commitRef: refRepositoryShortHash,
+      requestedPath: refRepositoryPath,
     });
 
-    expect(parseArguments(['--branch', shortHash])).toMatchObject({
-      branchRef: shortHash,
+    expect(parseArguments(['--branch', refRepositoryShortHash])).toMatchObject({
+      branchRef: refRepositoryShortHash,
       commitRef: null,
-      requestedPath: repositoryPath,
+      requestedPath: refRepositoryPath,
     });
-  } finally {
-    process.chdir(previousCwd);
-    await rm(repositoryPath, { force: true, recursive: true });
-  }
+  });
 });
 
 test('parseArguments keeps existing hash-like paths as repository paths', async () => {
@@ -251,30 +262,17 @@ test('resolvePullRequestUrl builds GitHub PR URLs from the origin remote', async
 });
 
 test('packaged terminal helper forwards --commit HEAD to Electron', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
-  const fakeBin = join(directory, 'bin');
-  const logPath = join(directory, 'open-args.txt');
-  const repositoryPath = join(directory, 'repo');
-  const openPath = join(fakeBin, 'open');
+  const logger = await createFakeOpenLogger();
+  const repositoryPath = join(logger.directory, 'repo');
 
   try {
-    await mkdir(fakeBin);
     await mkdir(repositoryPath);
-    await writeFile(
-      openPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(openPath, 0o755);
 
     await execFileAsync(resolve('bin/codiff-app'), ['--commit', 'HEAD', repositoryPath], {
-      env: {
-        ...process.env,
-        OPEN_ARGS_FILE: logPath,
-        PATH: `${fakeBin}:${process.env.PATH}`,
-      },
+      env: logger.env,
     });
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-n',
       resolve('bin/../../../..'),
       '--args',
@@ -283,33 +281,19 @@ test('packaged terminal helper forwards --commit HEAD to Electron', async () => 
       repositoryPath,
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('packaged terminal helper forwards HEAD^1 to Electron as a commit', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
-  const fakeBin = join(directory, 'bin');
-  const logPath = join(directory, 'open-args.txt');
-  const openPath = join(fakeBin, 'open');
+  const logger = await createFakeOpenLogger();
 
   try {
-    await mkdir(fakeBin);
-    await writeFile(
-      openPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(openPath, 0o755);
-
     await execFileAsync(resolve('bin/codiff-app'), ['HEAD^1'], {
-      env: {
-        ...process.env,
-        OPEN_ARGS_FILE: logPath,
-        PATH: `${fakeBin}:${process.env.PATH}`,
-      },
+      env: logger.env,
     });
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-n',
       resolve('bin/../../../..'),
       '--args',
@@ -318,130 +302,69 @@ test('packaged terminal helper forwards HEAD^1 to Electron as a commit', async (
       process.cwd(),
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('packaged terminal helper forwards branch names to Electron as branches', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
-  const fakeBin = join(directory, 'bin');
-  const logPath = join(directory, 'open-args.txt');
-  const openPath = join(fakeBin, 'open');
-  const repositoryPath = join(directory, 'repo');
+  const logger = await createFakeOpenLogger();
 
   try {
-    await mkdir(fakeBin);
-    await mkdir(repositoryPath);
-    const realRepositoryPath = await realpath(repositoryPath);
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['config', 'user.email', 'codiff@example.com']);
-    await git(repositoryPath, ['config', 'user.name', 'Codiff Test']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'initial commit']);
-    await git(repositoryPath, ['checkout', '-b', 'feature']);
-    await writeFile(
-      openPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(openPath, 0o755);
-
     await execFileAsync(resolve('bin/codiff-app'), ['feature'], {
-      cwd: realRepositoryPath,
-      env: {
-        ...process.env,
-        OPEN_ARGS_FILE: logPath,
-        PATH: `${fakeBin}:${process.env.PATH}`,
-      },
+      cwd: refRepositoryPath,
+      env: logger.env,
     });
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-n',
       resolve('bin/../../../..'),
       '--args',
       '--branch',
       'feature',
-      realRepositoryPath,
+      refRepositoryPath,
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('packaged terminal helper forwards hex refs to Electron as commits', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
-  const fakeBin = join(directory, 'bin');
-  const logPath = join(directory, 'open-args.txt');
-  const openPath = join(fakeBin, 'open');
-  const repositoryPath = join(directory, 'repo');
+  const logger = await createFakeOpenLogger();
 
   try {
-    await mkdir(fakeBin);
-    await mkdir(repositoryPath);
-    const realRepositoryPath = await realpath(repositoryPath);
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['config', 'user.email', 'codiff@example.com']);
-    await git(repositoryPath, ['config', 'user.name', 'Codiff Test']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'initial commit']);
-    const { stdout } = await execFileAsync('git', ['-C', repositoryPath, 'rev-parse', 'HEAD'], {
-      encoding: 'utf8',
-    });
-    const shortHash = stdout.trim().slice(0, 8);
-    await git(repositoryPath, ['branch', shortHash]);
-    await writeFile(
-      openPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(openPath, 0o755);
-
-    await execFileAsync(resolve('bin/codiff-app'), [shortHash], {
-      cwd: realRepositoryPath,
-      env: {
-        ...process.env,
-        OPEN_ARGS_FILE: logPath,
-        PATH: `${fakeBin}:${process.env.PATH}`,
-      },
+    await execFileAsync(resolve('bin/codiff-app'), [refRepositoryShortHash], {
+      cwd: refRepositoryPath,
+      env: logger.env,
     });
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-n',
       resolve('bin/../../../..'),
       '--args',
       '--commit',
-      shortHash,
-      realRepositoryPath,
+      refRepositoryShortHash,
+      refRepositoryPath,
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('packaged terminal helper forwards relative repository paths as absolute paths', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
-  const fakeBin = join(directory, 'bin');
-  const logPath = join(directory, 'open-args.txt');
-  const repositoryPath = join(directory, 'repo');
-  const openPath = join(fakeBin, 'open');
+  const logger = await createFakeOpenLogger();
+  const repositoryPath = join(logger.directory, 'repo');
 
   try {
-    await mkdir(fakeBin);
     await mkdir(join(repositoryPath, 'sub'), { recursive: true });
     const actualRepositoryPath = await realpath(repositoryPath);
-    await writeFile(
-      openPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(openPath, 0o755);
 
     const runHelper = async (args: ReadonlyArray<string>) => {
-      await writeFile(logPath, '');
+      await logger.reset();
       await execFileAsync(resolve('bin/codiff-app'), args, {
         cwd: repositoryPath,
-        env: {
-          ...process.env,
-          OPEN_ARGS_FILE: logPath,
-          PATH: `${fakeBin}:${process.env.PATH}`,
-        },
+        env: logger.env,
       });
-      return (await readFile(logPath, 'utf8')).trim().split('\n');
+      return logger.readArgs();
     };
 
     expect(await runHelper(['.'])).toEqual([
@@ -464,27 +387,18 @@ test('packaged terminal helper forwards relative repository paths as absolute pa
       `${actualRepositoryPath}/.`,
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('packaged terminal helper forwards Codex walkthrough seed options', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
-  const fakeBin = join(directory, 'bin');
-  const logPath = join(directory, 'open-args.txt');
-  const repositoryPath = join(directory, 'repo');
-  const openPath = join(fakeBin, 'open');
-  const contextPath = join(directory, 'seed.json');
+  const logger = await createFakeOpenLogger();
+  const repositoryPath = join(logger.directory, 'repo');
+  const contextPath = join(logger.directory, 'seed.json');
 
   try {
-    await mkdir(fakeBin);
     await mkdir(repositoryPath);
     await writeFile(contextPath, '{}');
-    await writeFile(
-      openPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(openPath, 0o755);
 
     await execFileAsync(
       resolve('bin/codiff-app'),
@@ -497,15 +411,11 @@ test('packaged terminal helper forwards Codex walkthrough seed options', async (
         repositoryPath,
       ],
       {
-        env: {
-          ...process.env,
-          OPEN_ARGS_FILE: logPath,
-          PATH: `${fakeBin}:${process.env.PATH}`,
-        },
+        env: logger.env,
       },
     );
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-n',
       resolve('bin/../../../..'),
       '--args',
@@ -517,20 +427,18 @@ test('packaged terminal helper forwards Codex walkthrough seed options', async (
       repositoryPath,
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('Codex skill launcher uses the session cwd as the repository target', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-skill-launcher-'));
-  const home = join(directory, 'home');
-  const repositoryPath = join(directory, 'repo');
+  const logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
+  const home = join(logger.directory, 'home');
+  const repositoryPath = join(logger.directory, 'repo');
   const sessionDirectory = join(home, '.codex', 'sessions', '2026', '05', '25');
   const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
   const sessionPath = join(sessionDirectory, `rollout-${sessionId}.jsonl`);
-  const fakeCodiff = join(directory, 'codiff');
-  const logPath = join(directory, 'args.txt');
-  const walkthroughFile = join(directory, 'walkthrough.json');
+  const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
   try {
     await mkdir(repositoryPath, { recursive: true });
@@ -543,11 +451,6 @@ test('Codex skill launcher uses the session cwd as the repository target', async
         type: 'turn_context',
       })}\n`,
     );
-    await writeFile(
-      fakeCodiff,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(fakeCodiff, 0o755);
 
     await execFileAsync(
       process.execPath,
@@ -555,16 +458,15 @@ test('Codex skill launcher uses the session cwd as the repository target', async
       {
         cwd: resolve('codex/skills/codiff'),
         env: {
-          ...process.env,
+          ...logger.env,
           CODEX_HOME: join(home, '.codex'),
           CODEX_THREAD_ID: sessionId,
-          CODIFF_COMMAND: fakeCodiff,
-          OPEN_ARGS_FILE: logPath,
+          CODIFF_COMMAND: logger.commandPath,
         },
       },
     );
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-w',
       '--walkthrough-file',
       walkthroughFile,
@@ -574,23 +476,16 @@ test('Codex skill launcher uses the session cwd as the repository target', async
       repositoryPath,
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('Codex skill launcher falls back to the source repo when run from the skill directory', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-skill-launcher-'));
-  const fakeCodiff = join(directory, 'codiff');
-  const logPath = join(directory, 'args.txt');
-  const walkthroughFile = join(directory, 'walkthrough.json');
+  const logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
+  const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
   try {
     await writeFile(walkthroughFile, '{}');
-    await writeFile(
-      fakeCodiff,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(fakeCodiff, 0o755);
 
     await execFileAsync(
       process.execPath,
@@ -598,43 +493,35 @@ test('Codex skill launcher falls back to the source repo when run from the skill
       {
         cwd: resolve('codex/skills/codiff'),
         env: {
-          ...process.env,
-          CODEX_HOME: join(directory, 'home', '.codex'),
+          ...logger.env,
+          CODEX_HOME: join(logger.directory, 'home', '.codex'),
           CODEX_THREAD_ID: '',
-          CODIFF_COMMAND: fakeCodiff,
-          OPEN_ARGS_FILE: logPath,
+          CODIFF_COMMAND: logger.commandPath,
         },
       },
     );
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-w',
       '--walkthrough-file',
       walkthroughFile,
       resolve('.'),
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('Codex skill launcher does not override explicit repository targets', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-skill-launcher-'));
-  const sessionRepositoryPath = join(directory, 'session-repo');
-  const explicitRepositoryPath = join(directory, 'explicit-repo');
-  const fakeCodiff = join(directory, 'codiff');
-  const logPath = join(directory, 'args.txt');
-  const walkthroughFile = join(directory, 'walkthrough.json');
+  const logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
+  const sessionRepositoryPath = join(logger.directory, 'session-repo');
+  const explicitRepositoryPath = join(logger.directory, 'explicit-repo');
+  const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
   try {
     await mkdir(sessionRepositoryPath, { recursive: true });
     await mkdir(explicitRepositoryPath, { recursive: true });
     await writeFile(walkthroughFile, '{}');
-    await writeFile(
-      fakeCodiff,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(fakeCodiff, 0o755);
 
     await execFileAsync(
       process.execPath,
@@ -647,47 +534,39 @@ test('Codex skill launcher does not override explicit repository targets', async
       {
         cwd: resolve('codex/skills/codiff'),
         env: {
-          ...process.env,
+          ...logger.env,
           CODEX_SESSION_CWD: sessionRepositoryPath,
           CODEX_THREAD_ID: '',
-          CODIFF_COMMAND: fakeCodiff,
-          OPEN_ARGS_FILE: logPath,
+          CODIFF_COMMAND: logger.commandPath,
         },
       },
     );
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-w',
       '--walkthrough-file',
       walkthroughFile,
       explicitRepositoryPath,
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('Claude skill launcher uses the session cwd and forwards --agent claude', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-claude-launcher-'));
-  const home = join(directory, 'home');
-  const repositoryPath = join(directory, 'repo');
+  const logger = await createFakeCommandLogger('codiff-claude-launcher-', 'codiff');
+  const home = join(logger.directory, 'home');
+  const repositoryPath = join(logger.directory, 'repo');
   const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
   const projectDirectory = join(home, '.claude', 'projects', '-tmp-repo');
   const sessionPath = join(projectDirectory, `${sessionId}.jsonl`);
-  const fakeCodiff = join(directory, 'codiff');
-  const logPath = join(directory, 'args.txt');
-  const walkthroughFile = join(directory, 'walkthrough.json');
+  const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
   try {
     await mkdir(repositoryPath, { recursive: true });
     await mkdir(projectDirectory, { recursive: true });
     await writeFile(walkthroughFile, '{}');
     await writeFile(sessionPath, `${JSON.stringify({ cwd: repositoryPath })}\n`);
-    await writeFile(
-      fakeCodiff,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(fakeCodiff, 0o755);
 
     await execFileAsync(
       process.execPath,
@@ -695,16 +574,15 @@ test('Claude skill launcher uses the session cwd and forwards --agent claude', a
       {
         cwd: resolve('claude/skills/codiff'),
         env: {
-          ...process.env,
+          ...logger.env,
           CLAUDE_CONFIG_DIR: join(home, '.claude'),
           CLAUDE_SESSION_ID: sessionId,
-          CODIFF_COMMAND: fakeCodiff,
-          OPEN_ARGS_FILE: logPath,
+          CODIFF_COMMAND: logger.commandPath,
         },
       },
     );
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-w',
       '--agent',
       'claude',
@@ -716,40 +594,27 @@ test('Claude skill launcher uses the session cwd and forwards --agent claude', a
       repositoryPath,
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
 test('packaged terminal helper forwards the agent and Claude session to Electron', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
-  const fakeBin = join(directory, 'bin');
-  const logPath = join(directory, 'open-args.txt');
-  const repositoryPath = join(directory, 'repo');
-  const openPath = join(fakeBin, 'open');
+  const logger = await createFakeOpenLogger();
+  const repositoryPath = join(logger.directory, 'repo');
   const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
 
   try {
-    await mkdir(fakeBin);
     await mkdir(repositoryPath);
-    await writeFile(
-      openPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n',
-    );
-    await chmod(openPath, 0o755);
 
     await execFileAsync(
       resolve('bin/codiff-app'),
       ['-w', '--agent', 'claude', '--claude-session', sessionId, repositoryPath],
       {
-        env: {
-          ...process.env,
-          OPEN_ARGS_FILE: logPath,
-          PATH: `${fakeBin}:${process.env.PATH}`,
-        },
+        env: logger.env,
       },
     );
 
-    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+    expect(await logger.readArgs()).toEqual([
       '-n',
       resolve('bin/../../../..'),
       '--args',
@@ -761,7 +626,7 @@ test('packaged terminal helper forwards the agent and Claude session to Electron
       repositoryPath,
     ]);
   } finally {
-    await rm(directory, { force: true, recursive: true });
+    await logger.cleanup();
   }
 });
 
@@ -810,7 +675,7 @@ test('formatHelpText styles titles and descriptions', () => {
   expect(text).toContain('\u001b[90mStart with an LLM narrative walkthrough.\u001b[0m');
 });
 
-test('codiff-app --help prints help text and exits 0', async () => {
+test('codiff-app prints help text and exits 0', async () => {
   const { stdout } = await execFileAsync(resolve('bin/codiff-app'), ['--help'], {
     encoding: 'utf8',
   });
@@ -821,22 +686,8 @@ test('codiff-app --help prints help text and exits 0', async () => {
   expect(stdout).toContain('\u001b[90mShow this help message and exit.\u001b[0m');
 });
 
-test('codiff-app -h prints help text and exits 0', async () => {
-  const { stdout } = await execFileAsync(resolve('bin/codiff-app'), ['-h'], {
-    encoding: 'utf8',
-  });
-  expect(stdout).toContain('Usage:');
-});
-
-test('codiff-app --version prints version and exits 0', async () => {
+test('codiff-app prints version and exits 0', async () => {
   const { stdout } = await execFileAsync(resolve('bin/codiff-app'), ['--version'], {
-    encoding: 'utf8',
-  });
-  expect(stdout).toMatch(/^codiff v\d+\.\d+\.\d+\n$/);
-});
-
-test('codiff-app -v prints version and exits 0', async () => {
-  const { stdout } = await execFileAsync(resolve('bin/codiff-app'), ['-v'], {
     encoding: 'utf8',
   });
   expect(stdout).toMatch(/^codiff v\d+\.\d+\.\d+\n$/);
@@ -859,41 +710,20 @@ test('codiff --walkthrough-guide prints the guide and embedded schema, then exit
   // ...followed by the live JSON schema, embedded as a fenced block.
   expect(stdout).toContain('```json');
   expect(stdout).toContain('"chapters"');
-  expect(stdout).toContain('"const": 3');
+  expect(stdout).toContain('"hunkId"');
+  expect(stdout).toContain('"const": 4');
 });
 
-test('the walkthrough authoring guide file exists and is non-trivial', async () => {
-  const guide = await readFile(resolve('bin/walkthrough-guide.md'), 'utf8');
-  expect(guide.length).toBeGreaterThan(500);
-  expect(guide).toContain('chapters');
-  expect(guide).toContain('support');
-});
-
-test('parseArguments reads base...head and base..head as a range', async () => {
-  const repositoryPath = await realpath(await mkdtemp(join(tmpdir(), 'codiff-cli-')));
-  const previousCwd = process.cwd();
-
-  try {
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['config', 'user.email', 'codiff@example.com']);
-    await git(repositoryPath, ['config', 'user.name', 'Codiff Test']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'first']);
-    await git(repositoryPath, ['branch', 'base']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'second']);
-    await git(repositoryPath, ['branch', 'head']);
-    process.chdir(repositoryPath);
-
-    expect(parseArguments(['-w', 'base...head'])).toMatchObject({
-      range: { base: 'base', head: 'head', symmetric: true },
-      requestedPath: repositoryPath,
+test('parseArguments reads base...target and base..target as a range', async () => {
+  await withCwd(refRepositoryPath, () => {
+    expect(parseArguments(['-w', 'base...target'])).toMatchObject({
+      range: { base: 'base', head: 'target', symmetric: true },
+      requestedPath: refRepositoryPath,
     });
-    expect(parseArguments(['base..head'])).toMatchObject({
-      range: { base: 'base', head: 'head', symmetric: false },
+    expect(parseArguments(['base..target'])).toMatchObject({
+      range: { base: 'base', head: 'target', symmetric: false },
     });
     // Unresolved refs fall back instead of being silently read as a range.
     expect(parseArguments(['nope...nada']).range).toBeUndefined();
-  } finally {
-    process.chdir(previousCwd);
-    await rm(repositoryPath, { force: true, recursive: true });
-  }
+  });
 });

--- a/src/__tests__/helpers/cli.ts
+++ b/src/__tests__/helpers/cli.ts
@@ -1,0 +1,49 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const loggerScript =
+  '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n';
+
+export const createFakeOpenLogger = async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
+  const fakeBin = join(directory, 'bin');
+  const logPath = join(directory, 'open-args.txt');
+  const openPath = join(fakeBin, 'open');
+
+  await mkdir(fakeBin);
+  await writeFile(openPath, loggerScript);
+  await chmod(openPath, 0o755);
+
+  return {
+    cleanup: () => rm(directory, { force: true, recursive: true }),
+    directory,
+    env: {
+      ...process.env,
+      OPEN_ARGS_FILE: logPath,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+    },
+    readArgs: async () => (await readFile(logPath, 'utf8')).trim().split('\n'),
+    reset: () => writeFile(logPath, ''),
+  };
+};
+
+export const createFakeCommandLogger = async (prefix: string, commandName: string) => {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  const commandPath = join(directory, commandName);
+  const logPath = join(directory, 'args.txt');
+
+  await writeFile(commandPath, loggerScript);
+  await chmod(commandPath, 0o755);
+
+  return {
+    cleanup: () => rm(directory, { force: true, recursive: true }),
+    commandPath,
+    directory,
+    env: {
+      ...process.env,
+      OPEN_ARGS_FILE: logPath,
+    },
+    readArgs: async () => (await readFile(logPath, 'utf8')).trim().split('\n'),
+  };
+};

--- a/src/__tests__/helpers/fixtures.ts
+++ b/src/__tests__/helpers/fixtures.ts
@@ -1,0 +1,34 @@
+import type { ChangedFile } from '../../types.ts';
+
+type ChangedFileOptions = {
+  fingerprint?: string;
+  kind?: ChangedFile['sections'][number]['kind'];
+  patch?: string;
+  status?: ChangedFile['status'];
+};
+
+export const createChangedFile = (
+  path: string,
+  {
+    fingerprint = `${path}:1`,
+    kind = 'unstaged',
+    patch,
+    status = 'modified',
+  }: ChangedFileOptions = {},
+) =>
+  ({
+    fingerprint,
+    path,
+    sections: [
+      {
+        binary: false,
+        id: `${path}:${kind}`,
+        kind,
+        patch: patch ?? `diff --git a/${path} b/${path}\n@@ -1 +1 @@\n-old\n+new\n`,
+      },
+    ],
+    status,
+  }) satisfies ChangedFile;
+
+export const createChangedFileWithPatch = (path: string, patch: string) =>
+  createChangedFile(path, { patch });

--- a/src/__tests__/helpers/react.tsx
+++ b/src/__tests__/helpers/react.tsx
@@ -1,0 +1,59 @@
+import { act, type ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+export const renderReact = async (element: ReactNode) => {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(element);
+  });
+
+  return {
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+    container,
+    rerender: async (nextElement: ReactNode) => {
+      await act(async () => {
+        root.render(nextElement);
+      });
+    },
+  };
+};
+
+export const setInputValue = async (
+  input: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) => {
+  await act(async () => {
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(input) as HTMLInputElement | HTMLTextAreaElement,
+      'value',
+    )?.set;
+    valueSetter?.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+};
+
+export const waitFor = async (assertion: () => void) => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+  }
+
+  throw lastError;
+};

--- a/src/__tests__/helpers/review-code-view.tsx
+++ b/src/__tests__/helpers/review-code-view.tsx
@@ -1,0 +1,222 @@
+import type { CodeViewItem } from '@pierre/diffs';
+import React, { type ComponentProps } from 'react';
+import { vi } from 'vite-plus/test';
+import { ReviewCodeView } from '../../app/components/ReviewCodeView.tsx';
+import { defaultKeymap } from '../../config/defaults.ts';
+import type { ChangedFile, CommitMetadata, ReviewSource } from '../../types.ts';
+
+export type { ReviewDiffBlock } from '../../app/components/ReviewCodeView.tsx';
+
+const codeViewMockState = vi.hoisted(() => ({
+  postRenderNodes: [] as Array<HTMLElement>,
+  scrollTo: vi.fn(),
+}));
+export const codeViewMock = codeViewMockState;
+
+export const resetCodeViewMock = () => {
+  codeViewMock.postRenderNodes = [];
+  codeViewMock.scrollTo.mockClear();
+};
+
+vi.mock('@pierre/diffs/react', async () => {
+  const React = await import('react');
+
+  return {
+    CodeView: React.forwardRef(function MockCodeView(
+      props: {
+        className?: string;
+        items: Array<CodeViewItem<unknown>>;
+        onScroll?: (scrollTop: number, viewer: unknown) => void;
+        options?: {
+          onPostRender?: (
+            node: HTMLElement,
+            instance: unknown,
+            phase: unknown,
+            context: { item: CodeViewItem<unknown> },
+          ) => void;
+        };
+        renderAnnotation?: (
+          annotation: { metadata: unknown },
+          item: CodeViewItem<unknown>,
+        ) => React.ReactNode;
+        renderCustomHeader?: (item: CodeViewItem<unknown>) => React.ReactNode;
+      },
+      ref: React.ForwardedRef<unknown>,
+    ) {
+      const itemsRef = React.useRef(props.items);
+      const renderedIdsRef = React.useRef(new Set<string>());
+      const scrollAttemptByIdRef = React.useRef(new Map<string, number>());
+      const scrollTopRef = React.useRef(0);
+
+      React.useLayoutEffect(() => {
+        itemsRef.current = props.items;
+        codeViewMock.postRenderNodes.length = props.items.length;
+        props.items.forEach((item, index) => {
+          const node = codeViewMock.postRenderNodes[index] ?? document.createElement('div');
+          codeViewMock.postRenderNodes[index] = node;
+          props.options?.onPostRender?.(node, {}, 'update', { item });
+        });
+      }, [props.items, props.options]);
+
+      const viewer = React.useMemo(
+        () => ({
+          getRenderedItems: () =>
+            itemsRef.current
+              .filter((item) => renderedIdsRef.current.has(item.id))
+              .map((item) => ({
+                element: document.createElement('div'),
+                id: item.id,
+                instance: {},
+                item,
+                type: item.type,
+                version: item.version,
+              })),
+          getScrollTop: () => scrollTopRef.current,
+          getTopForItem: (id: string) => {
+            const index = itemsRef.current.findIndex((item) => item.id === id);
+            return index === -1 ? undefined : index * 200 + 20;
+          },
+        }),
+        [],
+      );
+
+      React.useImperativeHandle(
+        ref,
+        () => ({
+          clearSelectedLines: () => {},
+          getInstance: () => viewer,
+          scrollTo: (target: { behavior?: string; id: string; offset?: number }) => {
+            codeViewMock.scrollTo(target);
+            const attempts = (scrollAttemptByIdRef.current.get(target.id) ?? 0) + 1;
+            scrollAttemptByIdRef.current.set(target.id, attempts);
+            const itemTop = viewer.getTopForItem(target.id) ?? 0;
+            scrollTopRef.current = Math.max(0, itemTop - (target.offset ?? 0));
+            if (attempts >= 2) {
+              renderedIdsRef.current.add(target.id);
+            }
+            props.onScroll?.(scrollTopRef.current, viewer);
+          },
+        }),
+        [props, viewer],
+      );
+
+      return React.createElement(
+        'div',
+        { className: props.className },
+        props.items.map((item) =>
+          React.createElement(
+            'div',
+            { key: item.id },
+            props.renderCustomHeader ? props.renderCustomHeader(item) : null,
+            'annotations' in item && Array.isArray(item.annotations)
+              ? item.annotations.map((annotation, index) =>
+                  React.createElement(
+                    React.Fragment,
+                    { key: index },
+                    props.renderAnnotation?.(annotation, item),
+                  ),
+                )
+              : null,
+          ),
+        ),
+      );
+    }),
+    WorkerPoolContextProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+export const source = { type: 'working-tree' } satisfies ReviewSource;
+export const commitSource = { ref: 'abc1234', type: 'commit' } satisfies ReviewSource;
+export const commitMetadata = {
+  author: {
+    date: '2026-01-01T12:00:00Z',
+    email: 'author@example.com',
+    name: 'Author',
+  },
+  body: '',
+  committer: {
+    date: '2026-01-01T12:00:00Z',
+    email: 'committer@example.com',
+    name: 'Committer',
+  },
+  files: [
+    {
+      additions: 1,
+      binary: false,
+      deletions: 1,
+      path: 'src/second.ts',
+      status: 'modified' as const,
+    },
+    {
+      additions: 1,
+      binary: false,
+      deletions: 0,
+      path: 'src/hidden.ts',
+      status: 'modified' as const,
+    },
+  ],
+  parents: ['parent-sha'],
+  ref: 'abc1234',
+  refs: ['main'],
+  shortRef: 'abc1234',
+  signature: {
+    status: 'N',
+  },
+  stats: {
+    additions: 2,
+    binaryFiles: 0,
+    deletions: 1,
+    files: 2,
+    renamedFiles: 0,
+  },
+  subject: 'Commit subject',
+  trailers: [],
+} satisfies CommitMetadata;
+
+type ReviewCodeViewHarnessProps = Partial<ComponentProps<typeof ReviewCodeView>> & {
+  files: ReadonlyArray<ChangedFile>;
+};
+
+export function ReviewCodeViewHarness({ files, ...overrides }: ReviewCodeViewHarnessProps) {
+  return (
+    <ReviewCodeView
+      activeSearchMatch={null}
+      agentId="codex"
+      agentLabel="Codex"
+      collapsed={new Set()}
+      comments={[]}
+      commitMetadata={null}
+      diffStyle="split"
+      files={files}
+      focusCommentId={null}
+      focusCommentRequest={0}
+      forceExpandedPaths={new Set()}
+      gitIdentity={null}
+      hunkNavigation={null}
+      isPullRequest={false}
+      itemVersionByKey={{}}
+      keymap={defaultKeymap}
+      loadingSectionIds={new Set()}
+      onAskCodex={() => {}}
+      onCreateComment={() => {}}
+      onDeleteComment={() => {}}
+      onLoadSection={() => {}}
+      onOpenFile={() => {}}
+      onSelectPathFromScroll={() => {}}
+      onSubmitComment={() => {}}
+      onToggleCollapsed={() => {}}
+      onToggleViewed={() => {}}
+      onUpdateComment={() => {}}
+      scrollTarget={null}
+      searchQuery=""
+      selectedPath={null}
+      showWhitespace={false}
+      source={source}
+      viewed={{}}
+      walkthroughNotes={new Map()}
+      wordWrap={false}
+      {...overrides}
+    />
+  );
+}

--- a/src/__tests__/narrative-walkthrough-view.test.ts
+++ b/src/__tests__/narrative-walkthrough-view.test.ts
@@ -601,10 +601,8 @@ const multiHunkFile = (): ChangedFile => ({
   status: 'modified',
 });
 
-test('uncovered walkthrough files preserve uncovered hunks from partially covered sections', () => {
-  const file = multiHunkFile();
-  const section = file.sections[0];
-  const view = buildWalkthroughView({
+const walkthroughViewCovering = (coveredHunk: WalkthroughHunk) =>
+  buildWalkthroughView({
     ...walkthrough(),
     chapters: [
       {
@@ -613,19 +611,9 @@ test('uncovered walkthrough files preserve uncovered hunks from partially covere
         id: 'main',
         stops: [
           {
-            ...group({
-              hunks: [
-                {
-                  ...appHunk,
-                  anchor: { ...appHunk.anchor, sectionId: section.id },
-                  id: `${section.id}:h1`,
-                  path: file.path,
-                },
-              ],
-              id: 'covered-first-hunk',
-            }),
+            ...group({ hunks: [coveredHunk], id: `covered-${coveredHunk.id}` }),
             importance: 'normal',
-            prose: 'Covers the first hunk.',
+            prose: 'Covers the hunk.',
           },
         ],
         title: 'Main',
@@ -633,6 +621,16 @@ test('uncovered walkthrough files preserve uncovered hunks from partially covere
     ],
     support: [],
   })!;
+
+test('uncovered walkthrough files preserve uncovered hunks from partially covered sections', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+  const view = walkthroughViewCovering({
+    ...appHunk,
+    anchor: { ...appHunk.anchor, sectionId: section.id },
+    id: `${section.id}:h1`,
+    path: file.path,
+  });
 
   const uncoveredFiles = getUncoveredWalkthroughFiles([file], view, false);
 
@@ -647,6 +645,43 @@ test('uncovered walkthrough files preserve uncovered hunks from partially covere
   expect(getUncoveredWalkthroughFileLineItems([file], view, false)).toEqual([
     { added: 2, deleted: 2, path: file.path },
   ]);
+});
+
+test('uncovered walkthrough file fingerprints change with the uncovered hunk set', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+  const viewCoveringFirst = walkthroughViewCovering(
+    hunk({
+      added: 1,
+      deleted: 1,
+      display: 'database_search.py:2',
+      id: `${section.id}:h1`,
+      path: file.path,
+      sectionId: section.id,
+      status: 'modified',
+    }),
+  );
+  const viewCoveringSecond = walkthroughViewCovering(
+    hunk({
+      added: 1,
+      deleted: 1,
+      display: 'database_search.py:8',
+      id: `${section.id}:h2`,
+      path: file.path,
+      sectionId: section.id,
+      status: 'modified',
+    }),
+  );
+
+  const uncoveredAfterFirst = getUncoveredWalkthroughFiles([file], viewCoveringFirst, false);
+  const uncoveredAfterSecond = getUncoveredWalkthroughFiles([file], viewCoveringSecond, false);
+
+  expect(uncoveredAfterFirst).toHaveLength(1);
+  expect(uncoveredAfterSecond).toHaveLength(1);
+  expect(uncoveredAfterFirst[0].sections.map((section) => section.id)).toEqual(
+    uncoveredAfterSecond[0].sections.map((section) => section.id),
+  );
+  expect(uncoveredAfterFirst[0].fingerprint).not.toBe(uncoveredAfterSecond[0].fingerprint);
 });
 
 test('focusChangedFileForHunks renders only the matching hunk', () => {

--- a/src/__tests__/narrative-walkthrough-view.test.ts
+++ b/src/__tests__/narrative-walkthrough-view.test.ts
@@ -33,6 +33,7 @@ const hunk = ({
   deletionStart,
   display,
   id,
+  kind,
   path,
   sectionId,
   status,
@@ -45,6 +46,7 @@ const hunk = ({
   deletionStart?: number;
   display: string;
   id: string;
+  kind?: WalkthroughHunk['kind'];
   path: string;
   sectionId: string;
   status: WalkthroughHunk['status'];
@@ -57,6 +59,7 @@ const hunk = ({
   deletionEnd,
   deletionStart,
   id,
+  ...(kind ? { kind } : {}),
   path,
   status,
 });
@@ -440,6 +443,92 @@ test('uncovered walkthrough files keep visible non-hunk sections in support fall
   ]);
 });
 
+test('covered synthetic hunks do not reappear in support fallback', () => {
+  const file: ChangedFile = {
+    fingerprint: 'binary',
+    path: 'public/logo.png',
+    sections: [
+      {
+        binary: true,
+        id: 'public/logo.png:staged',
+        kind: 'staged',
+        loadState: 'binary',
+        patch: '',
+        summary: { reason: 'Binary file changed.' },
+      },
+    ],
+    status: 'modified',
+  };
+  const synthetic = hunk({
+    added: 0,
+    deleted: 0,
+    display: 'public/logo.png',
+    id: 'public/logo.png:staged:h1',
+    kind: 'synthetic',
+    path: 'public/logo.png',
+    sectionId: 'public/logo.png:staged',
+    status: 'modified',
+  });
+  const view = buildWalkthroughView({
+    ...walkthrough(),
+    chapters: [
+      {
+        blurb: 'Assets',
+        icon: 'path',
+        id: 'assets',
+        stops: [
+          {
+            ...group({ hunks: [synthetic], id: 'logo' }),
+            importance: 'normal',
+            prose: 'Review the image asset.',
+          },
+        ],
+        title: 'Assets',
+      },
+    ],
+    support: [],
+  })!;
+
+  expect(getUncoveredWalkthroughFiles([file], view, false)).toEqual([]);
+});
+
+test('covered synthetic sections do not reappear after content loads', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+  const synthetic = hunk({
+    added: 0,
+    deleted: 0,
+    display: file.path,
+    id: `${section.id}:h1`,
+    kind: 'synthetic',
+    path: file.path,
+    sectionId: section.id,
+    status: 'modified',
+  });
+  const view = buildWalkthroughView({
+    ...walkthrough(),
+    chapters: [
+      {
+        blurb: 'Loaded',
+        icon: 'path',
+        id: 'loaded',
+        stops: [
+          {
+            ...group({ hunks: [synthetic], id: 'loaded-section' }),
+            importance: 'normal',
+            prose: 'Review the loaded section.',
+          },
+        ],
+        title: 'Loaded',
+      },
+    ],
+    support: [],
+  })!;
+
+  expect(parseSectionDiffWithOptions(file, section, false).hunks.length).toBeGreaterThan(1);
+  expect(getUncoveredWalkthroughFiles([file], view, false)).toEqual([]);
+});
+
 test('buildGenericCommitModel creates a commit group from live tree files', () => {
   const model = buildGenericCommitModel([
     {
@@ -810,6 +899,32 @@ test('focusChangedFileForHunks keeps deferred hunk sections visible and loadable
   });
 });
 
+test('focusChangedFileForHunks keeps synthetic hunks as whole sections after content loads', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+  const focused = focusChangedFileForHunks(file, section, [
+    hunk({
+      added: 0,
+      deleted: 0,
+      display: 'database_search.py',
+      id: `${section.id}:h1`,
+      kind: 'synthetic',
+      path: file.path,
+      sectionId: section.id,
+      status: 'modified',
+    }),
+  ]);
+
+  expect(focused).not.toBeNull();
+  expect(focused!.sections).toHaveLength(1);
+  expect(focused!.sections[0].patch).toBe(section.patch);
+  expect(focused!.sections[0].newFile).toBe(section.newFile);
+  expect(focused!.sections[0].oldFile).toBe(section.oldFile);
+  expect(
+    parseSectionDiffWithOptions(focused!, focused!.sections[0], false).hunks.length,
+  ).toBeGreaterThan(1);
+});
+
 test('focusChangedFileForHunks fails closed for unresolved hunk ids', () => {
   const file = multiHunkFile();
   const section = file.sections[0];
@@ -936,6 +1051,6 @@ test('getWalkthroughRunNote combines header notes for grouped hunks', () => {
 
   expect(runs).toHaveLength(1);
   expect(getWalkthroughRunNote(item, runs[0])).toBe(
-    'This line turns the widget into a reorderable list. • This hunk persists the final order.',
+    'This line turns the widget into a reorderable list. This hunk persists the final order.',
   );
 });

--- a/src/__tests__/narrative-walkthrough-view.test.ts
+++ b/src/__tests__/narrative-walkthrough-view.test.ts
@@ -1,14 +1,138 @@
 import { expect, test } from 'vite-plus/test';
+import { getWalkthroughNavigationKeyDirection } from '../app/components/walkthrough/NarrativeWalkthroughView.tsx';
+import { parseSectionDiffWithOptions } from '../lib/diff.ts';
 import {
   buildCommitModel,
   buildGenericCommitModel,
-  buildOrderView,
-  collectWalkthroughSegments,
+  buildWalkthroughView,
+  focusChangedFileForHunks,
+  formatWalkthroughFileLineRows,
+  formatWalkthroughFileList,
+  getCommitSelectionPaths,
+  getUncoveredWalkthroughFileLineItems,
+  getUncoveredWalkthroughFiles,
+  getWalkthroughRunNote,
   isWalkthroughCommittable,
-  resolveOrder,
-  resolveSegmentFile,
+  resolveWalkthroughHunkFile,
+  resolveWalkthroughHunkRuns,
+  walkthroughItemPaths,
 } from '../lib/narrative-walkthrough.ts';
-import type { ChangedFile, NarrativeWalkthrough } from '../types.ts';
+import type {
+  ChangedFile,
+  NarrativeWalkthrough,
+  WalkthroughHunk,
+  WalkthroughHunkGroup,
+} from '../types.ts';
+
+const hunk = ({
+  added,
+  additionEnd,
+  additionStart,
+  deleted,
+  deletionEnd,
+  deletionStart,
+  display,
+  id,
+  path,
+  sectionId,
+  status,
+}: {
+  added: number;
+  additionEnd?: number;
+  additionStart?: number;
+  deleted: number;
+  deletionEnd?: number;
+  deletionStart?: number;
+  display: string;
+  id: string;
+  path: string;
+  sectionId: string;
+  status: WalkthroughHunk['status'];
+}): WalkthroughHunk => ({
+  added,
+  additionEnd,
+  additionStart,
+  anchor: { display, sectionId, side: 'both' },
+  deleted,
+  deletionEnd,
+  deletionStart,
+  id,
+  path,
+  status,
+});
+
+const appHunk = hunk({
+  added: 1,
+  deleted: 1,
+  display: 'src/App.tsx:311',
+  id: 'src/App.tsx:staged:h1',
+  path: 'src/App.tsx',
+  sectionId: 'src/App.tsx:staged',
+  status: 'modified',
+});
+
+const testHunk = hunk({
+  added: 14,
+  deleted: 0,
+  display: 'test.ts (new)',
+  id: 'src/test.ts:staged:h1',
+  path: 'src/test.ts',
+  sectionId: 'src/test.ts:staged',
+  status: 'added',
+});
+
+const lockHunk = hunk({
+  added: 312,
+  deleted: 180,
+  display: 'pnpm-lock.yaml',
+  id: 'pnpm-lock.yaml:staged:h1',
+  path: 'pnpm-lock.yaml',
+  sectionId: 'pnpm-lock.yaml:staged',
+  status: 'modified',
+});
+
+const mirrorHunk = hunk({
+  added: 5,
+  deleted: 0,
+  display: 'mirror.ts',
+  id: 'mirror.ts:staged:h1',
+  path: 'mirror.ts',
+  sectionId: 'mirror.ts:staged',
+  status: 'added',
+});
+
+const keyEvent = (
+  key: string,
+  modifiers: Partial<{
+    altKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
+  }> = {},
+) => ({
+  altKey: modifiers.altKey ?? false,
+  ctrlKey: modifiers.ctrlKey ?? false,
+  key,
+  metaKey: modifiers.metaKey ?? false,
+  shiftKey: modifiers.shiftKey ?? false,
+});
+
+const group = ({
+  hunks,
+  id,
+  title,
+}: {
+  hunks: ReadonlyArray<WalkthroughHunk>;
+  id: string;
+  title?: string;
+}): WalkthroughHunkGroup => ({
+  added: hunks.reduce((total, hunk) => total + hunk.added, 0),
+  deleted: hunks.reduce((total, hunk) => total + hunk.deleted, 0),
+  hunkIds: hunks.map((hunk) => hunk.id),
+  hunks,
+  id,
+  title,
+});
 
 const walkthrough = (): NarrativeWalkthrough => ({
   agent: 'claude',
@@ -19,26 +143,9 @@ const walkthrough = (): NarrativeWalkthrough => ({
       id: 'bug',
       stops: [
         {
-          anchors: [
-            {
-              added: 1,
-              anchor: {
-                display: 'src/App.tsx:311',
-                sectionId: 'src/App.tsx:staged',
-                side: 'both',
-              },
-              deleted: 1,
-              granularity: 'line',
-              id: 's1',
-              path: 'src/App.tsx',
-              status: 'modified',
-            },
-          ],
-          body: 'Bug.',
-          id: 'stop-1',
+          ...group({ hunks: [appHunk], id: 's1' }),
           importance: 'critical',
-          summary: 'The current file order drives navigation.',
-          title: 'Bug',
+          prose: 'Bug.',
         },
       ],
       title: 'The bug',
@@ -49,22 +156,9 @@ const walkthrough = (): NarrativeWalkthrough => ({
       id: 'proof',
       stops: [
         {
-          anchors: [
-            {
-              added: 14,
-              anchor: { display: 'test.ts (new)' },
-              deleted: 0,
-              granularity: 'file',
-              id: 's2',
-              path: 'src/test.ts',
-              status: 'added',
-            },
-          ],
-          body: 'Test.',
-          id: 'stop-2',
+          ...group({ hunks: [testHunk], id: 's2' }),
           importance: 'normal',
-          summary: 'The regression test locks the navigation order.',
-          title: 'Proof',
+          prose: 'Test.',
         },
       ],
       title: 'Proof',
@@ -76,65 +170,81 @@ const walkthrough = (): NarrativeWalkthrough => ({
   repo: { branch: 'main', root: '/repo' },
   source: { type: 'working-tree' },
   support: [
-    {
-      files: [
-        {
-          added: 312,
-          anchor: { display: 'pnpm-lock.yaml' },
-          deleted: 180,
-          granularity: 'file',
-          id: 'lock',
-          path: 'pnpm-lock.yaml',
-          status: 'modified',
-        },
-      ],
-      id: 'lockfiles',
-      note: 'Regenerated.',
-      title: 'Lockfile',
-    },
-    {
-      files: [
-        {
-          added: 5,
-          anchor: { display: 'mirror.ts' },
-          deleted: 0,
-          granularity: 'file',
-          id: 'mirror',
-          path: 'mirror.ts',
-          status: 'added',
-        },
-      ],
-      id: 'mechanical',
-      note: 'Mirror.',
-      title: 'Mechanical',
-    },
+    { ...group({ hunks: [lockHunk], id: 'lock' }), note: 'Regenerated.', reason: 'Lockfile' },
+    { ...group({ hunks: [mirrorHunk], id: 'mirror' }), note: 'Mirror.', reason: 'Mechanical' },
   ],
   title: 'Title',
-  version: 3,
+  version: 4,
 });
 
-test('resolveOrder builds the UI adapter order', () => {
-  const order = resolveOrder(walkthrough(), 'anything')!;
+test('formatWalkthroughFileList shows filenames up to five unique files', () => {
+  expect(
+    formatWalkthroughFileList(['src/App.tsx', 'src/App.tsx', 'tests/App.test.tsx', 'README.md']),
+  ).toEqual({
+    label: 'App.tsx, App.test.tsx, README.md',
+    title: 'src/App.tsx\ntests/App.test.tsx\nREADME.md',
+  });
 
-  expect(order.id).toBe('walkthrough');
-  expect(order.phases.map((phase) => phase.id)).toEqual(['bug', 'proof']);
-  expect(order.sequence.map((stop) => stop.segmentIds)).toEqual([['s1'], ['s2']]);
-  expect(order.rest.map((item) => item.segmentId)).toEqual(['lock', 'mirror']);
+  expect(formatWalkthroughFileList(['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts', 'f.ts']).label).toBe(
+    '6 files',
+  );
 });
 
-test('buildOrderView indexes stops, fills phases, and resolves anchors', () => {
-  const view = buildOrderView(walkthrough(), 'keys')!;
+test('walkthrough keyboard navigation ignores editor shortcut chords', () => {
+  expect(getWalkthroughNavigationKeyDirection(keyEvent('j'))).toBe(1);
+  expect(getWalkthroughNavigationKeyDirection(keyEvent('k'))).toBe(-1);
+  expect(getWalkthroughNavigationKeyDirection(keyEvent('ArrowDown', { ctrlKey: true }))).toBe(1);
+  expect(getWalkthroughNavigationKeyDirection(keyEvent('ArrowUp', { ctrlKey: true }))).toBe(-1);
+  expect(getWalkthroughNavigationKeyDirection(keyEvent('k', { metaKey: true }))).toBe(0);
+  expect(getWalkthroughNavigationKeyDirection(keyEvent('k', { ctrlKey: true }))).toBe(0);
+  expect(getWalkthroughNavigationKeyDirection(keyEvent('j', { shiftKey: true }))).toBe(0);
+});
 
-  expect(view.sequence.map((stop) => stop.index)).toEqual([0, 1]);
-  expect(view.sequence[0].segment.path).toBe('src/App.tsx');
-  expect(view.phases.map((phase) => phase.stops.map((stop) => stop.segmentId))).toEqual([
+test('formatWalkthroughFileLineRows gives each visible file its own count', () => {
+  expect(formatWalkthroughFileLineRows([])).toEqual([
+    { added: 0, deleted: 0, label: '0 files', title: '' },
+  ]);
+
+  expect(
+    formatWalkthroughFileLineRows([
+      { added: 1, deleted: 0, path: 'src/App.tsx' },
+      { added: 2, deleted: 1, path: 'src/App.tsx' },
+      { added: 3, deleted: 0, path: 'tests/App.test.tsx' },
+    ]),
+  ).toEqual([
+    {
+      added: 3,
+      deleted: 1,
+      label: 'App.tsx',
+      path: 'src/App.tsx',
+      title: 'src/App.tsx',
+    },
+    {
+      added: 3,
+      deleted: 0,
+      label: 'App.test.tsx',
+      path: 'tests/App.test.tsx',
+      title: 'tests/App.test.tsx',
+    },
+  ]);
+});
+
+test('buildWalkthroughView indexes stops and groups support by reason', () => {
+  const view = buildWalkthroughView(walkthrough())!;
+
+  expect(view.sequence.map((stop) => [stop.id, stop.index, stop.chapterId])).toEqual([
+    ['s1', 0, 'bug'],
+    ['s2', 1, 'proof'],
+  ]);
+  expect(walkthroughItemPaths(view.sequence[0])).toEqual(['src/App.tsx']);
+  expect(view.chapters.map((chapter) => chapter.stops.map((stop) => stop.id))).toEqual([
     ['s1'],
     ['s2'],
   ]);
-  expect(view.totals).toEqual({ added: 15, deleted: 1 });
+  expect(view.supportByReason.map((support) => support.reason)).toEqual(['Lockfile', 'Mechanical']);
 });
 
-test('buildOrderView keeps multiple anchors under the same stop', () => {
+test('buildWalkthroughView preserves cross-file hunk groups in one stop', () => {
   const base = walkthrough();
   const wt: NarrativeWalkthrough = {
     ...base,
@@ -143,37 +253,27 @@ test('buildOrderView keeps multiple anchors under the same stop', () => {
         ...base.chapters[0],
         stops: [
           {
-            ...base.chapters[0].stops[0],
-            anchors: [base.chapters[0].stops[0].anchors[0], base.chapters[1].stops[0].anchors[0]],
-            body: 'Bug and proof belong together.',
+            ...group({ hunks: [appHunk, testHunk], id: 'combo' }),
+            importance: 'critical',
+            prose: 'Bug and proof belong together.',
           },
         ],
       },
     ],
-    support: base.support,
   };
 
-  const view = buildOrderView(wt, 'keys')!;
+  const view = buildWalkthroughView(wt)!;
 
   expect(view.sequence).toHaveLength(1);
-  expect(view.sequence[0].segmentId).toBe('s1');
-  expect(view.sequence[0].relatedSegments.map((segment) => segment.id)).toEqual(['s2']);
-  expect(view.totals).toEqual({ added: 15, deleted: 1 });
+  expect(view.sequence[0].id).toBe('combo');
+  expect(walkthroughItemPaths(view.sequence[0])).toEqual(['src/App.tsx', 'src/test.ts']);
+  expect(view.chapters[0].stops.map((stop) => stop.id)).toEqual(['combo']);
 });
 
-test('buildOrderView groups support by title and totals it', () => {
-  const view = buildOrderView(walkthrough(), 'keys')!;
+test('buildCommitModel collapses chapters plus support into unique file groups', () => {
+  const model = buildCommitModel(buildWalkthroughView(walkthrough())!);
 
-  expect(view.restByReason.map((group) => group.reason)).toEqual(['Lockfile', 'Mechanical']);
-  expect(view.restByReason[0].files[0].segment.path).toBe('pnpm-lock.yaml');
-  expect(view.restTotals).toEqual({ added: 317, deleted: 180 });
-});
-
-test('buildCommitModel collapses chapters plus support into commit groups', () => {
-  const view = buildOrderView(walkthrough(), 'keys')!;
-  const model = buildCommitModel(view);
-
-  expect(model.groups.map((group) => [group.title, group.isRest])).toEqual([
+  expect(model.groups.map((group) => [group.title, group.isSupport])).toEqual([
     ['The bug', false],
     ['Proof', false],
     ['Support', true],
@@ -189,31 +289,34 @@ test('buildCommitModel collapses chapters plus support into commit groups', () =
 
 test('buildCommitModel carries per-file change-type tags and notes onto rows', () => {
   const base = walkthrough();
-  const withTags: NarrativeWalkthrough = {
+  const wt: NarrativeWalkthrough = {
     ...base,
-    chapters: base.chapters.map((chapter) => ({
-      ...chapter,
-      stops: chapter.stops.map((stop) => ({
-        ...stop,
-        anchors: stop.anchors.map((anchor) =>
-          anchor.id === 's1'
-            ? { ...anchor, changeType: 'fix', commitNote: 'reorder the hunks' }
-            : anchor.id === 's2'
-              ? { ...anchor, changeType: 'test', commitNote: 'lock the regression' }
-              : anchor,
-        ),
-      })),
-    })),
-    support: base.support.map((group) => ({
-      ...group,
-      files: group.files.map((file) =>
-        file.id === 'lock' ? { ...file, changeType: 'lockfile' } : file,
-      ),
-    })),
+    chapters: [
+      {
+        ...base.chapters[0],
+        stops: [
+          {
+            ...base.chapters[0].stops[0],
+            changeType: 'fix',
+            commitNote: 'reorder the hunks',
+          },
+        ],
+      },
+      {
+        ...base.chapters[1],
+        stops: [
+          {
+            ...base.chapters[1].stops[0],
+            changeType: 'test',
+            commitNote: 'lock the regression',
+          },
+        ],
+      },
+    ],
+    support: [{ ...base.support[0], changeType: 'lockfile' }, base.support[1]],
   };
-  const byPath = new Map(
-    buildCommitModel(buildOrderView(withTags, 'keys')!).files.map((file) => [file.path, file]),
-  );
+  const model = buildCommitModel(buildWalkthroughView(wt)!);
+  const byPath = new Map(model.files.map((file) => [file.path, file]));
 
   expect(byPath.get('src/App.tsx')).toMatchObject({ changeType: 'fix', note: 'reorder the hunks' });
   expect(byPath.get('src/test.ts')).toMatchObject({
@@ -253,7 +356,7 @@ test('buildCommitModel appends live tree files missing from the walkthrough', ()
     },
   ];
 
-  const model = buildCommitModel(buildOrderView(walkthrough(), 'keys')!, files);
+  const model = buildCommitModel(buildWalkthroughView(walkthrough())!, files);
   const missing = model.files.find((file) => file.path === 'src/missed.ts');
 
   expect(missing).toMatchObject({
@@ -265,6 +368,76 @@ test('buildCommitModel appends live tree files missing from the walkthrough', ()
     id: '__missing',
     title: 'Other changes',
   });
+});
+
+test('getCommitSelectionPaths follows commit model ordering and fallback files', () => {
+  const files: ReadonlyArray<ChangedFile> = [
+    {
+      fingerprint: 'a',
+      path: 'src/App.tsx',
+      sections: [],
+      status: 'modified',
+    },
+    {
+      fingerprint: 'missing',
+      path: 'src/missed.ts',
+      sections: [],
+      status: 'added',
+    },
+  ];
+  const view = buildWalkthroughView(walkthrough())!;
+
+  expect(getCommitSelectionPaths(view, files)).toEqual([
+    'src/App.tsx',
+    'src/test.ts',
+    'pnpm-lock.yaml',
+    'mirror.ts',
+    'src/missed.ts',
+  ]);
+  expect(getCommitSelectionPaths(null, files)).toEqual(['src/App.tsx', 'src/missed.ts']);
+});
+
+test('uncovered walkthrough files keep visible non-hunk sections in support fallback', () => {
+  const view = buildWalkthroughView(walkthrough())!;
+  const files: ReadonlyArray<ChangedFile> = [
+    {
+      fingerprint: 'covered',
+      path: 'src/App.tsx',
+      sections: [
+        {
+          binary: false,
+          id: 'src/App.tsx:staged',
+          kind: 'staged',
+          patch: '@@ -1 +1 @@\n-a\n+b\n',
+        },
+      ],
+      status: 'modified',
+    },
+    {
+      fingerprint: 'binary',
+      path: 'public/logo.png',
+      sections: [
+        {
+          binary: true,
+          id: 'public/logo.png:staged',
+          kind: 'staged',
+          patch: '',
+          summary: { reason: 'Binary file changed.' },
+        },
+      ],
+      status: 'modified',
+    },
+  ];
+
+  const uncoveredFiles = getUncoveredWalkthroughFiles(files, view, false);
+
+  expect(uncoveredFiles.map((file) => file.path)).toEqual(['public/logo.png']);
+  expect(uncoveredFiles[0].sections.map((section) => section.id)).toEqual([
+    'public/logo.png:staged',
+  ]);
+  expect(getUncoveredWalkthroughFileLineItems(files, view, false)).toEqual([
+    { added: 0, deleted: 0, path: 'public/logo.png' },
+  ]);
 });
 
 test('buildGenericCommitModel creates a commit group from live tree files', () => {
@@ -320,7 +493,7 @@ test('working-tree walkthroughs are committable even without commit seed text', 
   expect(isWalkthroughCommittable(committedReview)).toBe(false);
 });
 
-test('resolveSegmentFile prefers the anchor section then the first visible one', () => {
+test('resolveWalkthroughHunkFile requires exact anchor section', () => {
   const files: ReadonlyArray<ChangedFile> = [
     {
       fingerprint: 'a',
@@ -337,12 +510,397 @@ test('resolveSegmentFile prefers the anchor section then the first visible one',
       status: 'modified',
     },
   ];
-  const segments = collectWalkthroughSegments(walkthrough());
-  const segment = segments.find((s) => s.id === 's1')!;
 
-  const resolved = resolveSegmentFile(segment, files, false);
+  const resolved = resolveWalkthroughHunkFile(appHunk, files);
   expect(resolved?.section.id).toBe('src/App.tsx:staged');
 
-  const missing = segments.find((s) => s.id === 's2')!;
-  expect(resolveSegmentFile(missing, files, false)).toBeNull();
+  expect(
+    resolveWalkthroughHunkFile(
+      { ...appHunk, anchor: { ...appHunk.anchor, sectionId: 'src/App.tsx:missing' } },
+      files,
+    ),
+  ).toBeNull();
+  expect(resolveWalkthroughHunkFile(testHunk, files)).toBeNull();
+});
+
+const multiHunkFile = (): ChangedFile => ({
+  fingerprint: 'database-search',
+  path: 'database_search.py',
+  sections: [
+    {
+      binary: false,
+      id: 'database_search.py:unstaged',
+      kind: 'unstaged',
+      loadState: 'ready',
+      newFile: {
+        cacheKey: 'new',
+        contents: [
+          'line 1',
+          'favorite.drag()',
+          'line 3',
+          'line 4',
+          'line 5',
+          'line 6',
+          'line 7',
+          'favorite.count()',
+          'line 9',
+          'line 10',
+          'line 11',
+          'database.commit_order()',
+          'line 13',
+        ].join('\n'),
+        name: 'database_search.py',
+      },
+      oldFile: {
+        cacheKey: 'old',
+        contents: [
+          'line 1',
+          'favorite.click()',
+          'line 3',
+          'line 4',
+          'line 5',
+          'line 6',
+          'line 7',
+          'favorite.count()',
+          'line 9',
+          'line 10',
+          'line 11',
+          'database.write_order()',
+          'line 13',
+        ].join('\n'),
+        name: 'database_search.py',
+      },
+      patch: [
+        'diff --git a/database_search.py b/database_search.py',
+        'index 1111111..2222222 100644',
+        '--- a/database_search.py',
+        '+++ b/database_search.py',
+        '@@ -1,5 +1,5 @@',
+        ' line 1',
+        '-favorite.click()',
+        '+favorite.drag()',
+        ' line 3',
+        ' line 4',
+        ' line 5',
+        '@@ -6,5 +6,5 @@',
+        ' line 6',
+        ' line 7',
+        '-favorite.count()',
+        '+favorite.row_count()',
+        ' line 9',
+        ' line 10',
+        '@@ -11,3 +11,3 @@',
+        ' line 11',
+        '-database.write_order()',
+        '+database.commit_order()',
+        ' line 13',
+        '',
+      ].join('\n'),
+    },
+  ],
+  status: 'modified',
+});
+
+test('uncovered walkthrough files preserve uncovered hunks from partially covered sections', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+  const view = buildWalkthroughView({
+    ...walkthrough(),
+    chapters: [
+      {
+        blurb: 'Main',
+        icon: 'path',
+        id: 'main',
+        stops: [
+          {
+            ...group({
+              hunks: [
+                {
+                  ...appHunk,
+                  anchor: { ...appHunk.anchor, sectionId: section.id },
+                  id: `${section.id}:h1`,
+                  path: file.path,
+                },
+              ],
+              id: 'covered-first-hunk',
+            }),
+            importance: 'normal',
+            prose: 'Covers the first hunk.',
+          },
+        ],
+        title: 'Main',
+      },
+    ],
+    support: [],
+  })!;
+
+  const uncoveredFiles = getUncoveredWalkthroughFiles([file], view, false);
+
+  expect(uncoveredFiles).toHaveLength(1);
+  expect(uncoveredFiles[0].sections).toHaveLength(1);
+  expect(uncoveredFiles[0].sections[0].patch).not.toContain('favorite.drag()');
+  expect(uncoveredFiles[0].sections[0].patch).toContain('favorite.row_count()');
+  expect(uncoveredFiles[0].sections[0].patch).toContain('database.commit_order()');
+  expect(
+    parseSectionDiffWithOptions(uncoveredFiles[0], uncoveredFiles[0].sections[0], false).hunks,
+  ).toHaveLength(2);
+  expect(getUncoveredWalkthroughFileLineItems([file], view, false)).toEqual([
+    { added: 2, deleted: 2, path: file.path },
+  ]);
+});
+
+test('focusChangedFileForHunks renders only the matching hunk', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+  const focused = focusChangedFileForHunks(file, section, [
+    hunk({
+      added: 1,
+      deleted: 1,
+      display: 'database_search.py:2',
+      id: `${section.id}:h1`,
+      path: file.path,
+      sectionId: section.id,
+      status: 'modified',
+    }),
+  ]);
+
+  expect(focused).not.toBeNull();
+  expect(focused!.fingerprint).not.toBe(file.fingerprint);
+  expect(focused!.sections).toHaveLength(1);
+  expect(focused!.sections[0].id).toBe(section.id);
+  expect(focused!.sections[0].newFile).toBeUndefined();
+  expect(focused!.sections[0].oldFile).toBeUndefined();
+  expect(focused!.sections[0].patch).toContain('favorite.drag()');
+  expect(focused!.sections[0].patch).not.toContain('database.commit_order()');
+
+  const parsed = parseSectionDiffWithOptions(focused!, focused!.sections[0], false);
+  expect(parsed.hunks).toHaveLength(1);
+  expect(parsed.hunks[0].additionStart).toBe(1);
+});
+
+test('focusChangedFileForHunks renders selected hunks in agent order', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+  const focused = focusChangedFileForHunks(file, section, [
+    hunk({
+      added: 1,
+      deleted: 1,
+      display: 'database_search.py:12',
+      id: `${section.id}:h3`,
+      path: file.path,
+      sectionId: section.id,
+      status: 'modified',
+    }),
+    hunk({
+      added: 1,
+      deleted: 1,
+      display: 'database_search.py:2',
+      id: `${section.id}:h1`,
+      path: file.path,
+      sectionId: section.id,
+      status: 'modified',
+    }),
+  ]);
+
+  expect(focused).not.toBeNull();
+  expect(focused!.sections[0].patch).toContain('database.commit_order()');
+  expect(focused!.sections[0].patch).toContain('favorite.drag()');
+  expect(focused!.sections[0].patch).not.toContain('favorite.row_count()');
+  expect(focused!.sections[0].patch.indexOf('database.commit_order()')).toBeLessThan(
+    focused!.sections[0].patch.indexOf('favorite.drag()'),
+  );
+  expect(parseSectionDiffWithOptions(focused!, focused!.sections[0], false).hunks).toHaveLength(2);
+});
+
+test('focusChangedFileForHunks uses exact hunk ids instead of broad anchor ranges', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+  const focused = focusChangedFileForHunks(file, section, [
+    {
+      added: 1,
+      anchor: {
+        display: 'database_search.py:12',
+        endLine: 12,
+        sectionId: section.id,
+        side: 'additions',
+        startLine: 2,
+      },
+      deleted: 1,
+      id: `${section.id}:h3`,
+      path: file.path,
+      status: 'modified',
+    },
+  ]);
+
+  expect(focused).not.toBeNull();
+  expect(focused!.sections[0].patch).toContain('database.commit_order()');
+  expect(focused!.sections[0].patch).not.toContain('favorite.drag()');
+  expect(focused!.sections[0].patch).not.toContain('favorite.row_count()');
+});
+
+test('focusChangedFileForHunks keeps deferred hunk sections visible and loadable', () => {
+  const file = multiHunkFile();
+  const section = {
+    ...file.sections[0],
+    loadState: 'deferred' as const,
+    summary: {
+      canLoad: true,
+      reason: 'File is 2 MiB and will be loaded on demand.',
+      size: 2_000_000,
+    },
+  };
+  const focused = focusChangedFileForHunks({ ...file, sections: [section] }, section, [
+    hunk({
+      added: 1,
+      deleted: 1,
+      display: 'database_search.py:2',
+      id: `${section.id}:h1`,
+      path: file.path,
+      sectionId: section.id,
+      status: 'modified',
+    }),
+  ]);
+
+  expect(focused).not.toBeNull();
+  expect(focused!.fingerprint).not.toBe(file.fingerprint);
+  expect(focused!.sections).toHaveLength(1);
+  expect(focused!.sections[0]).toMatchObject({
+    id: section.id,
+    loadState: 'deferred',
+    patch: section.patch,
+    summary: {
+      canLoad: true,
+      reason: 'File is 2 MiB and will be loaded on demand.',
+    },
+  });
+});
+
+test('focusChangedFileForHunks fails closed for unresolved hunk ids', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+
+  expect(
+    focusChangedFileForHunks(file, section, [
+      hunk({
+        added: 1,
+        deleted: 1,
+        display: 'database_search.py:12',
+        id: `${section.id}:h99`,
+        path: file.path,
+        sectionId: section.id,
+        status: 'modified',
+      }),
+    ]),
+  ).toBeNull();
+});
+
+test('resolveWalkthroughHunkRuns groups adjacent same-file hunks without reordering', () => {
+  const file = multiHunkFile();
+  const other: ChangedFile = {
+    fingerprint: 'other',
+    path: 'other.py',
+    sections: [
+      {
+        binary: false,
+        id: 'other.py:unstaged',
+        kind: 'unstaged',
+        loadState: 'ready',
+        patch: '@@ -1 +1 @@\n-old\n+new\n',
+      },
+    ],
+    status: 'modified',
+  };
+  const item = {
+    ...group({
+      hunks: [
+        hunk({
+          added: 1,
+          deleted: 1,
+          display: 'database_search.py:2',
+          id: 'database_search.py:unstaged:h1',
+          path: 'database_search.py',
+          sectionId: 'database_search.py:unstaged',
+          status: 'modified',
+        }),
+        hunk({
+          added: 1,
+          deleted: 1,
+          display: 'other.py:1',
+          id: 'other.py:unstaged:h1',
+          path: 'other.py',
+          sectionId: 'other.py:unstaged',
+          status: 'modified',
+        }),
+        hunk({
+          added: 1,
+          deleted: 1,
+          display: 'database_search.py:12',
+          id: 'database_search.py:unstaged:h3',
+          path: 'database_search.py',
+          sectionId: 'database_search.py:unstaged',
+          status: 'modified',
+        }),
+      ],
+      id: 'cross',
+    }),
+  };
+
+  expect(
+    resolveWalkthroughHunkRuns(item, [file, other]).map((run) => run.resolved.file.path),
+  ).toEqual(['database_search.py', 'other.py', 'database_search.py']);
+
+  const grouped = resolveWalkthroughHunkRuns(
+    { ...item, hunks: [item.hunks[0], item.hunks[2], item.hunks[1]] },
+    [file, other],
+  );
+  expect(grouped.map((run) => run.hunks.map((hunk) => hunk.id))).toEqual([
+    ['database_search.py:unstaged:h1', 'database_search.py:unstaged:h3'],
+    ['other.py:unstaged:h1'],
+  ]);
+});
+
+test('getWalkthroughRunNote combines header notes for grouped hunks', () => {
+  const file = multiHunkFile();
+  const section = file.sections[0];
+  const item = {
+    ...group({
+      hunks: [
+        hunk({
+          added: 1,
+          deleted: 1,
+          display: 'database_search.py:2',
+          id: `${section.id}:h1`,
+          path: file.path,
+          sectionId: section.id,
+          status: 'modified',
+        }),
+        hunk({
+          added: 1,
+          deleted: 1,
+          display: 'database_search.py:12',
+          id: `${section.id}:h3`,
+          path: file.path,
+          sectionId: section.id,
+          status: 'modified',
+        }),
+      ],
+      id: 'drag',
+    }),
+    notes: [
+      {
+        body: 'This line turns the widget into a reorderable list.',
+        hunkId: `${section.id}:h1`,
+      },
+      {
+        body: 'This hunk persists the final order.',
+        hunkId: `${section.id}:h3`,
+      },
+    ],
+  };
+  const runs = resolveWalkthroughHunkRuns(item, [file]);
+
+  expect(runs).toHaveLength(1);
+  expect(getWalkthroughRunNote(item, runs[0])).toBe(
+    'This line turns the widget into a reorderable list. • This hunk persists the final order.',
+  );
 });

--- a/src/__tests__/review-command-target.test.ts
+++ b/src/__tests__/review-command-target.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'vite-plus/test';
+import {
+  createReviewCommandTarget,
+  resolveReviewCommandTarget,
+} from '../lib/review-command-target.ts';
+import type { ChangedFile, ReviewSource } from '../types.ts';
+
+const file = (path: string): ChangedFile => ({
+  fingerprint: `${path}:1`,
+  path,
+  sections: [
+    {
+      binary: false,
+      id: `${path}:unstaged`,
+      kind: 'unstaged',
+      patch: '',
+    },
+  ],
+  status: 'modified',
+});
+
+test('review command target prefers active walkthrough target for the same source', () => {
+  const source = { type: 'working-tree' } satisfies ReviewSource;
+  const selectedFile = file('src/first.ts');
+  const activeFile = file('src/current-walkthrough-hunk.ts');
+  const activeTarget = createReviewCommandTarget(source, activeFile, {
+    fingerprint: activeFile.fingerprint,
+    key: 'walkthrough:active',
+  });
+
+  expect(
+    resolveReviewCommandTarget({
+      activeTarget,
+      files: [selectedFile],
+      selectedPath: selectedFile.path,
+      source,
+      useActiveTarget: true,
+    }),
+  ).toEqual(activeTarget);
+});
+
+test('review command target falls back to selected path outside active walkthrough routing', () => {
+  const source = { type: 'working-tree' } satisfies ReviewSource;
+  const selectedFile = file('src/first.ts');
+  const activeFile = file('src/current-walkthrough-hunk.ts');
+
+  const target = resolveReviewCommandTarget({
+    activeTarget: createReviewCommandTarget(source, activeFile),
+    files: [selectedFile],
+    selectedPath: selectedFile.path,
+    source,
+    useActiveTarget: false,
+  });
+
+  expect(target?.file.path).toBe(selectedFile.path);
+  expect(target?.reviewIdentity.key).toBe(selectedFile.path);
+});
+
+test('review command target ignores stale active target from another source', () => {
+  const selectedFile = file('src/first.ts');
+  const currentSource = { ref: 'HEAD', type: 'commit' } satisfies ReviewSource;
+  const staleSource = { type: 'working-tree' } satisfies ReviewSource;
+
+  const target = resolveReviewCommandTarget({
+    activeTarget: createReviewCommandTarget(staleSource, file('src/stale.ts')),
+    files: [selectedFile],
+    selectedPath: selectedFile.path,
+    source: currentSource,
+    useActiveTarget: true,
+  });
+
+  expect(target?.file.path).toBe(selectedFile.path);
+  expect(target?.sourceKey).toBe('commit:HEAD');
+});

--- a/src/__tests__/useNarrativeNavigation.test.tsx
+++ b/src/__tests__/useNarrativeNavigation.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from 'react';
+import { expect, test } from 'vite-plus/test';
+import type { NarrativeNavigation } from '../app/components/walkthrough/useNarrativeNavigation.ts';
+import { useNarrativeNavigation } from '../app/components/walkthrough/useNarrativeNavigation.ts';
+import type { NarrativeWalkthrough, WalkthroughStop } from '../types.ts';
+import { renderReact } from './helpers/react.tsx';
+
+const stop = (id: string): WalkthroughStop => ({
+  added: 1,
+  deleted: 0,
+  hunkIds: [],
+  hunks: [],
+  id,
+  importance: 'normal',
+  prose: id,
+  title: id,
+});
+
+const walkthrough: NarrativeWalkthrough = {
+  agent: 'codex',
+  chapters: [
+    {
+      blurb: 'Main path',
+      icon: 'path',
+      id: 'main',
+      stops: [stop('first'), stop('second'), stop('third')],
+      title: 'Main',
+    },
+  ],
+  focus: 'Focus',
+  generatedAt: '2026-06-08T00:00:00.000Z',
+  kind: 'narrative',
+  repo: { branch: 'main', root: '/repo' },
+  source: { type: 'working-tree' },
+  support: [],
+  title: 'Walkthrough',
+  version: 4,
+};
+
+function NavigationHarness({
+  onNavigation,
+}: {
+  onNavigation: (navigation: NarrativeNavigation) => void;
+}) {
+  const navigation = useNarrativeNavigation(walkthrough, []);
+  onNavigation(navigation);
+  return null;
+}
+
+test('clicked walkthrough stops hold selection until target reached or user scroll input releases it', async () => {
+  const navigationRef: { current: NarrativeNavigation | null } = { current: null };
+  const getNavigation = () => {
+    if (!navigationRef.current) {
+      throw new Error('Navigation did not render.');
+    }
+    return navigationRef.current;
+  };
+
+  const view = await renderReact(
+    <NavigationHarness onNavigation={(next) => (navigationRef.current = next)} />,
+  );
+
+  try {
+    expect(getNavigation().index).toBe(0);
+
+    await act(async () => {
+      getNavigation().goStop(2);
+    });
+    expect(getNavigation().index).toBe(2);
+
+    await act(async () => {
+      getNavigation().syncIndexFromScroll(1);
+    });
+    expect(getNavigation().index).toBe(2);
+
+    await act(async () => {
+      getNavigation().syncIndexFromScroll(2);
+    });
+    expect(getNavigation().index).toBe(2);
+
+    await act(async () => {
+      getNavigation().syncIndexFromScroll(1);
+    });
+    expect(getNavigation().index).toBe(1);
+
+    await act(async () => {
+      getNavigation().goStop(2);
+    });
+    expect(getNavigation().index).toBe(2);
+
+    await act(async () => {
+      getNavigation().releaseStopScrollLock();
+      getNavigation().syncIndexFromScroll(1);
+    });
+    expect(getNavigation().index).toBe(1);
+  } finally {
+    await view.cleanup();
+  }
+});

--- a/src/app/components/ReviewCodeView.tsx
+++ b/src/app/components/ReviewCodeView.tsx
@@ -24,10 +24,12 @@ import {
   useMemo,
   useRef,
   useState,
+  type ChangeEvent,
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
+  type ReactNode,
   type SyntheticEvent,
 } from 'react';
 import claudeIconUrl from '../../assets/claude.svg';
@@ -41,6 +43,7 @@ import type {
   ReviewAnnotationMetadata,
   ReviewComment,
   ReviewCommentAnnotationMetadata,
+  ReviewIdentity,
   ReviewScrollBehavior,
   ReviewScrollTarget,
   WalkthroughNote,
@@ -77,6 +80,7 @@ import {
   shouldDiscardReviewCommentOnEscape,
   updateStickyHeaderState,
 } from '../../lib/review-comments.ts';
+import { getReviewIdentity, isReviewIdentityViewed } from '../../lib/review-identity.ts';
 import { applySearchHighlights } from '../../lib/search-highlights.ts';
 import type {
   ChangedFile,
@@ -147,9 +151,9 @@ function CodeViewHeader({
   meta: CodeViewItemMetadata;
   onLoadSection: (file: ChangedFile, section: DiffSection) => void;
   onOpenFile: (file: ChangedFile) => void;
-  onToggleCollapsed: (file: ChangedFile, isCollapsed: boolean) => void;
+  onToggleCollapsed: (file: ChangedFile, isCollapsed: boolean, reviewKey: string) => void;
   onToggleMarkdownPreview: (section: DiffSection) => void;
-  onToggleViewed: (file: ChangedFile, isViewed: boolean) => void;
+  onToggleViewed: (file: ChangedFile, isViewed: boolean, reviewIdentity: ReviewIdentity) => void;
 }) {
   const {
     canRenderMarkdown,
@@ -159,6 +163,7 @@ function CodeViewHeader({
     isSelected,
     isViewed,
     lineCount,
+    reviewIdentity,
     section,
     sectionCount,
     walkthroughNote,
@@ -176,11 +181,11 @@ function CodeViewHeader({
         aria-expanded={!isCollapsed}
         aria-label={isCollapsed ? 'Expand file' : 'Collapse file'}
         className="codiff-header-toggle"
-        onClick={() => onToggleCollapsed(file, isCollapsed)}
+        onClick={() => onToggleCollapsed(file, isCollapsed, reviewIdentity.key)}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
-            onToggleCollapsed(file, isCollapsed);
+            onToggleCollapsed(file, isCollapsed, reviewIdentity.key);
           }
         }}
         role="button"
@@ -247,7 +252,7 @@ function CodeViewHeader({
       <button
         aria-pressed={isViewed}
         className={`codiff-viewed-button${isViewed ? ' active' : ''}`}
-        onClick={() => onToggleViewed(file, isViewed)}
+        onClick={() => onToggleViewed(file, isViewed, reviewIdentity)}
         type="button"
       >
         <span aria-hidden className="codiff-viewed-checkbox">
@@ -290,6 +295,9 @@ const canSubmitCommentToGitHub = (comment: ReviewComment) =>
   !comment.isReadOnly &&
   comment.body.trim().length > 0 &&
   comment.githubSubmit?.status !== 'submitting';
+
+const withCommentBody = (comment: ReviewComment, body: string): ReviewComment =>
+  comment.body === body ? comment : { ...comment, body };
 
 const getAddedLinesDigest = (lines: ReadonlySet<number>) =>
   lines.size > 0 ? [...lines].join(',') : '';
@@ -591,6 +599,259 @@ function ImageDiffPreview({
   );
 }
 
+function ReviewCommentEditor({
+  agentId,
+  agentLabel,
+  comment,
+  displayName,
+  focusCommentId,
+  focusTextareaRef,
+  identity,
+  isPullRequest,
+  keymap,
+  onAskCodex,
+  onCommentBlur,
+  onCommentFocus,
+  onDeleteComment,
+  onSubmitComment,
+  onUpdateComment,
+}: {
+  agentId: 'codex' | 'claude';
+  agentLabel: string;
+  comment: ReviewComment;
+  displayName: string;
+  focusCommentId: string | null;
+  focusTextareaRef: (node: HTMLTextAreaElement | null) => void;
+  identity: GitIdentity | null;
+  isPullRequest: boolean;
+  keymap: CodiffKeymap;
+  onAskCodex: (commentId: string) => void;
+  onCommentBlur: (comment: ReviewComment, body: string) => void;
+  onCommentFocus: (comment: ReviewComment) => void;
+  onDeleteComment: (commentId: string) => void;
+  onSubmitComment: (commentId: string) => void;
+  onUpdateComment: (commentId: string, body: string) => void;
+}) {
+  const [draftState, setDraftState] = useState(() => ({
+    commentBody: comment.body,
+    commentId: comment.id,
+    dirty: false,
+    draft: comment.body,
+  }));
+  const effectiveDraftState =
+    draftState.commentId === comment.id
+      ? draftState
+      : {
+          commentBody: comment.body,
+          commentId: comment.id,
+          dirty: false,
+          draft: comment.body,
+        };
+  const draft =
+    !effectiveDraftState.dirty && effectiveDraftState.commentBody !== comment.body
+      ? comment.body
+      : effectiveDraftState.draft;
+
+  const draftComment = withCommentBody(comment, draft);
+  const canAskCodex = canAskCodexForComment(draftComment);
+  const canSubmitComment = canSubmitCommentToGitHub(draftComment);
+  const flushDraft = useCallback(() => {
+    setDraftState((current) =>
+      current.commentId === comment.id
+        ? {
+            ...current,
+            commentBody: comment.body,
+            dirty: false,
+            draft,
+          }
+        : {
+            commentBody: comment.body,
+            commentId: comment.id,
+            dirty: false,
+            draft,
+          },
+    );
+    if (!comment.isReadOnly && draft !== comment.body) {
+      onUpdateComment(comment.id, draft);
+    }
+    return withCommentBody(comment, draft);
+  }, [comment, draft, onUpdateComment]);
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      const draft = event.currentTarget.value;
+      setDraftState((current) => ({
+        commentBody: comment.body,
+        commentId: comment.id,
+        dirty: true,
+        draft,
+      }));
+    },
+    [comment.body, comment.id],
+  );
+
+  const handleAskCodex = useCallback(() => {
+    const flushed = flushDraft();
+    if (canAskCodexForComment(flushed)) {
+      onAskCodex(comment.id);
+    }
+  }, [comment.id, flushDraft, onAskCodex]);
+
+  const handleSubmitComment = useCallback(() => {
+    const flushed = flushDraft();
+    if (canSubmitCommentToGitHub(flushed)) {
+      onSubmitComment(comment.id);
+    }
+  }, [comment.id, flushDraft, onSubmitComment]);
+
+  const handleBlur = useCallback(() => {
+    onCommentBlur(flushDraft(), draft);
+  }, [draft, flushDraft, onCommentBlur]);
+
+  const handleFocus = useCallback(() => {
+    onCommentFocus(draftComment);
+  }, [draftComment, onCommentFocus]);
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (matchesShortcut(event, keymap, 'submitComment')) {
+        if (isPullRequest && canSubmitComment) {
+          event.preventDefault();
+          event.stopPropagation();
+          handleSubmitComment();
+          return;
+        }
+
+        if (!isPullRequest && canAskCodex) {
+          event.preventDefault();
+          event.stopPropagation();
+          handleAskCodex();
+        }
+        return;
+      }
+
+      if (!matchesShortcut(event, keymap, 'discardComment')) {
+        return;
+      }
+
+      if (comment.isReadOnly) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (shouldDiscardReviewCommentOnEscape(draft)) {
+        onDeleteComment(comment.id);
+      }
+    },
+    [
+      canAskCodex,
+      canSubmitComment,
+      comment.id,
+      comment.isReadOnly,
+      draft,
+      handleAskCodex,
+      handleSubmitComment,
+      isPullRequest,
+      keymap,
+      onDeleteComment,
+    ],
+  );
+
+  return (
+    <Fragment>
+      <div className="review-comment">
+        <ReviewAvatar author={comment.author} identity={identity} />
+        <div className="review-comment-body">
+          <div
+            className={`review-comment-header${
+              isPullRequest && !comment.isReadOnly ? ' with-comment-action' : ''
+            }${comment.isReadOnly ? ' read-only' : ''}`}
+          >
+            <strong>{displayName}</strong>
+            <span>{getReviewCommentLineLabel(comment)}</span>
+            {!comment.isReadOnly ? (
+              <button
+                className="review-comment-action"
+                disabled={!canAskCodex}
+                onClick={handleAskCodex}
+                title={
+                  canAskCodex ? `Ask ${agentLabel}` : `Write a note before asking ${agentLabel}`
+                }
+                type="button"
+              >
+                Ask
+              </button>
+            ) : null}
+            {isPullRequest && !comment.isReadOnly ? (
+              <button
+                className="review-comment-action"
+                disabled={!canSubmitComment}
+                onClick={handleSubmitComment}
+                title={
+                  canSubmitComment ? 'Submit comment to GitHub' : 'Write a note before commenting'
+                }
+                type="button"
+              >
+                {comment.githubSubmit?.status === 'submitting' ? 'Sending' : 'Comment'}
+              </button>
+            ) : null}
+            {!comment.isReadOnly ? (
+              <button
+                aria-label="Delete comment"
+                className="review-comment-delete"
+                onClick={() => onDeleteComment(comment.id)}
+                title="Delete comment"
+                type="button"
+              >
+                <X aria-hidden className="review-comment-delete-icon" size={14} weight="bold" />
+              </button>
+            ) : null}
+          </div>
+          <textarea
+            aria-label={`Comment on ${comment.filePath} ${getReviewCommentLineLabel(comment)}`}
+            className={`review-comment-input${comment.isReadOnly ? ' read-only' : ''}`}
+            onBlur={handleBlur}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            onKeyDown={handleKeyDown}
+            placeholder="Write a review comment…"
+            readOnly={comment.isReadOnly}
+            ref={comment.id === focusCommentId ? focusTextareaRef : undefined}
+            rows={3}
+            spellCheck
+            value={draft}
+          />
+          {comment.githubSubmit?.status === 'error' ? (
+            <div className="review-comment-error">{comment.githubSubmit.error}</div>
+          ) : null}
+        </div>
+      </div>
+      {comment.codexReply ? (
+        <div className="review-comment codex">
+          <AgentAvatar agentId={agentId} />
+          <div className="review-comment-body codex">
+            <div className="review-comment-header codex">
+              <strong>{agentLabel}</strong>
+            </div>
+            <div
+              className={`review-comment-codex-reply${
+                comment.codexReply.status === 'loading' ? ' is-loading' : ''
+              }${comment.codexReply.status === 'error' ? ' error' : ''}`}
+            >
+              {comment.codexReply.status === 'loading' ? (
+                <span className="review-comment-codex-loading">Waiting for {agentLabel}…</span>
+              ) : (
+                renderMarkdown(comment.codexReply.body ?? comment.codexReply.error ?? '')
+              )}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </Fragment>
+  );
+}
+
 function ReviewAnnotation({
   agentId,
   agentLabel,
@@ -625,6 +886,9 @@ function ReviewAnnotation({
   onUpdateComment: (commentId: string, body: string) => void;
 }) {
   const focusTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const setFocusTextareaRef = useCallback((node: HTMLTextAreaElement | null) => {
+    focusTextareaRef.current = node;
+  }, []);
   const annotationComments = annotation.metadata.commentIds
     .map((commentId) => comments.find((comment) => comment.id === commentId))
     .filter((comment): comment is ReviewComment => comment != null);
@@ -637,42 +901,6 @@ function ReviewAnnotation({
     }
   }, [focusCommentId, focusCommentRequest, hasFocusedComment]);
 
-  const handleCommentKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLTextAreaElement>, comment: ReviewComment) => {
-      if (matchesShortcut(event, keymap, 'submitComment')) {
-        if (isPullRequest && canSubmitCommentToGitHub(comment)) {
-          event.preventDefault();
-          event.stopPropagation();
-          onSubmitComment(comment.id);
-          return;
-        }
-
-        if (!isPullRequest && canAskCodexForComment(comment)) {
-          event.preventDefault();
-          event.stopPropagation();
-          onAskCodex(comment.id);
-        }
-        return;
-      }
-
-      if (!matchesShortcut(event, keymap, 'discardComment')) {
-        return;
-      }
-
-      if (comment.isReadOnly) {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-
-      if (shouldDiscardReviewCommentOnEscape(comment.body)) {
-        onDeleteComment(comment.id);
-      }
-    },
-    [isPullRequest, keymap, onAskCodex, onDeleteComment, onSubmitComment],
-  );
-
   if (annotationComments.length === 0) {
     return null;
   }
@@ -680,113 +908,28 @@ function ReviewAnnotation({
   return (
     <div className="review-comment-thread">
       {annotationComments.map((comment) => {
-        const canAskCodex = canAskCodexForComment(comment);
-        const canSubmitComment = canSubmitCommentToGitHub(comment);
         const displayName =
           comment.author?.login || identity?.name || identity?.email || 'Git user';
 
         return (
-          <Fragment key={comment.id}>
-            <div className="review-comment">
-              <ReviewAvatar author={comment.author} identity={identity} />
-              <div className="review-comment-body">
-                <div
-                  className={`review-comment-header${
-                    isPullRequest && !comment.isReadOnly ? ' with-comment-action' : ''
-                  }${comment.isReadOnly ? ' read-only' : ''}`}
-                >
-                  <strong>{displayName}</strong>
-                  <span>{getReviewCommentLineLabel(comment)}</span>
-                  {!comment.isReadOnly ? (
-                    <button
-                      className="review-comment-action"
-                      disabled={!canAskCodex}
-                      onClick={() => onAskCodex(comment.id)}
-                      title={
-                        canAskCodex
-                          ? `Ask ${agentLabel}`
-                          : `Write a note before asking ${agentLabel}`
-                      }
-                      type="button"
-                    >
-                      Ask
-                    </button>
-                  ) : null}
-                  {isPullRequest && !comment.isReadOnly ? (
-                    <button
-                      className="review-comment-action"
-                      disabled={!canSubmitComment}
-                      onClick={() => onSubmitComment(comment.id)}
-                      title={
-                        canSubmitComment
-                          ? 'Submit comment to GitHub'
-                          : 'Write a note before commenting'
-                      }
-                      type="button"
-                    >
-                      {comment.githubSubmit?.status === 'submitting' ? 'Sending' : 'Comment'}
-                    </button>
-                  ) : null}
-                  {!comment.isReadOnly ? (
-                    <button
-                      aria-label="Delete comment"
-                      className="review-comment-delete"
-                      onClick={() => onDeleteComment(comment.id)}
-                      title="Delete comment"
-                      type="button"
-                    >
-                      <X
-                        aria-hidden
-                        className="review-comment-delete-icon"
-                        size={14}
-                        weight="bold"
-                      />
-                    </button>
-                  ) : null}
-                </div>
-                <textarea
-                  aria-label={`Comment on ${comment.filePath} ${getReviewCommentLineLabel(comment)}`}
-                  className={`review-comment-input${comment.isReadOnly ? ' read-only' : ''}`}
-                  onBlur={(event) => onCommentBlur(comment, event.currentTarget.value)}
-                  onChange={(event) => onUpdateComment(comment.id, event.currentTarget.value)}
-                  onFocus={() => onCommentFocus(comment)}
-                  onKeyDown={(event) => handleCommentKeyDown(event, comment)}
-                  placeholder="Write a review comment…"
-                  readOnly={comment.isReadOnly}
-                  ref={comment.id === focusCommentId ? focusTextareaRef : undefined}
-                  rows={3}
-                  spellCheck
-                  value={comment.body}
-                />
-                {comment.githubSubmit?.status === 'error' ? (
-                  <div className="review-comment-error">{comment.githubSubmit.error}</div>
-                ) : null}
-              </div>
-            </div>
-            {comment.codexReply ? (
-              <div className="review-comment codex">
-                <AgentAvatar agentId={agentId} />
-                <div className="review-comment-body codex">
-                  <div className="review-comment-header codex">
-                    <strong>{agentLabel}</strong>
-                  </div>
-                  <div
-                    className={`review-comment-codex-reply${
-                      comment.codexReply.status === 'loading' ? ' is-loading' : ''
-                    }${comment.codexReply.status === 'error' ? ' error' : ''}`}
-                  >
-                    {comment.codexReply.status === 'loading' ? (
-                      <span className="review-comment-codex-loading">
-                        Waiting for {agentLabel}…
-                      </span>
-                    ) : (
-                      renderMarkdown(comment.codexReply.body ?? comment.codexReply.error ?? '')
-                    )}
-                  </div>
-                </div>
-              </div>
-            ) : null}
-          </Fragment>
+          <ReviewCommentEditor
+            agentId={agentId}
+            agentLabel={agentLabel}
+            comment={comment}
+            displayName={displayName}
+            focusCommentId={focusCommentId}
+            focusTextareaRef={setFocusTextareaRef}
+            identity={identity}
+            isPullRequest={isPullRequest}
+            key={comment.id}
+            keymap={keymap}
+            onAskCodex={onAskCodex}
+            onCommentBlur={onCommentBlur}
+            onCommentFocus={onCommentFocus}
+            onDeleteComment={onDeleteComment}
+            onSubmitComment={onSubmitComment}
+            onUpdateComment={onUpdateComment}
+          />
         );
       })}
     </div>
@@ -816,10 +959,6 @@ const getCommitDetailsVersionKey = (
   navigationKey: string,
 ) => [getCommitDetailsContentKey(metadata), layoutPass, navigationKey].join('\u0001');
 
-function isScrollTargetRendered(viewer: CodeViewInstance, itemId: string) {
-  return viewer.getRenderedItems().some((item) => item.id === itemId);
-}
-
 const getEffectiveScrollBehavior = (behavior: ReviewScrollBehavior) =>
   behavior === 'smooth' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
     ? 'instant'
@@ -841,6 +980,142 @@ type NavAnchor = {
   scrollTarget: CodeViewScrollTarget;
   selection: SelectedLineRange | null;
   top: number;
+};
+
+type FileReviewDiffBlock = {
+  comments?: ReadonlyArray<ReviewComment>;
+  file: ChangedFile;
+  header?: ReactNode;
+  id: string;
+  itemIdPrefix?: string;
+  note?: string;
+  reviewIdentity?: ReviewIdentity;
+  selected?: boolean;
+};
+
+type HeaderReviewDiffBlock = {
+  file?: undefined;
+  header: ReactNode;
+  id: string;
+  selected?: boolean;
+};
+
+export type ReviewDiffBlock = FileReviewDiffBlock | HeaderReviewDiffBlock;
+
+const createFileReviewBlocks = (
+  files: ReadonlyArray<ChangedFile>,
+): ReadonlyArray<ReviewDiffBlock> =>
+  files.map((file) => ({
+    file,
+    id: `file:${file.path}`,
+  }));
+
+const getBlockItemId = (block: FileReviewDiffBlock, section: DiffSection) =>
+  block.itemIdPrefix ? `${block.itemIdPrefix}:${getItemId(section)}` : getItemId(section);
+
+const getBlockHeaderItemId = (block: ReviewDiffBlock) => `${block.id}:walkthrough-header`;
+
+const createInlineWalkthroughNote = (reason: string): WalkthroughNote => ({
+  action: 'review',
+  context: reason,
+  groupReason: 'Walkthrough',
+  groupTitle: 'Walkthrough',
+  impact: 'contained',
+  order: 0,
+  reason,
+});
+
+const getBlockWalkthroughNote = (
+  block: FileReviewDiffBlock,
+  fallbackByPath: ReadonlyMap<string, WalkthroughNote>,
+) => (block.note ? createInlineWalkthroughNote(block.note) : fallbackByPath.get(block.file.path));
+
+const lineIsVisibleInFileDiff = (
+  fileDiff: FileDiffMetadata,
+  side: ReviewComment['side'],
+  lineNumber: number,
+) =>
+  fileDiff.hunks.some((hunk) => {
+    const hunkStart = side === 'deletions' ? hunk.deletionStart : hunk.additionStart;
+    const hunkLineCount = side === 'deletions' ? hunk.deletionCount : hunk.additionCount;
+    return lineNumber >= hunkStart && lineNumber < hunkStart + hunkLineCount;
+  });
+
+const reviewCommentAnchorIsVisibleInFileDiff = (
+  comment: ReviewComment,
+  fileDiff: FileDiffMetadata,
+) => lineIsVisibleInFileDiff(fileDiff, comment.side, comment.lineNumber);
+
+const diffSearchMatchIsVisibleInFileDiff = (match: DiffSearchMatch, fileDiff: FileDiffMetadata) => {
+  if (match.lineNumber == null) {
+    return true;
+  }
+
+  return match.side
+    ? lineIsVisibleInFileDiff(fileDiff, match.side, match.lineNumber)
+    : lineIsVisibleInFileDiff(fileDiff, 'additions', match.lineNumber) ||
+        lineIsVisibleInFileDiff(fileDiff, 'deletions', match.lineNumber);
+};
+
+const dedupeReviewComments = (
+  comments: ReadonlyArray<ReviewComment>,
+): ReadonlyArray<ReviewComment> => {
+  const deduped: Array<ReviewComment> = [];
+  const seen = new Set<string>();
+  for (const comment of comments) {
+    if (seen.has(comment.id)) {
+      continue;
+    }
+    seen.add(comment.id);
+    deduped.push(comment);
+  }
+  return deduped;
+};
+
+const groupReviewCommentsBySection = (comments: ReadonlyArray<ReviewComment>) => {
+  const map = new Map<string, Array<ReviewComment>>();
+  for (const comment of comments) {
+    const list = map.get(comment.sectionId);
+    if (list) {
+      list.push(comment);
+    } else {
+      map.set(comment.sectionId, [comment]);
+    }
+  }
+  return map;
+};
+
+type RenderedSearchTarget = {
+  fileDiff: FileDiffMetadata;
+  itemId: string;
+  path: string;
+};
+
+const resolveRenderedSearchMatch = (
+  match: DiffSearchMatch | null,
+  itemMetadata: ReadonlyMap<string, CodeViewItemMetadata>,
+  searchTargetsByBaseItemId: ReadonlyMap<string, ReadonlyArray<RenderedSearchTarget>>,
+): DiffSearchMatch | null => {
+  if (!match) {
+    return null;
+  }
+
+  if (itemMetadata.has(match.itemId)) {
+    return match;
+  }
+
+  const candidates = searchTargetsByBaseItemId.get(match.itemId) ?? [];
+  const candidate =
+    candidates.find(
+      (candidate) =>
+        candidate.path === match.filePath &&
+        diffSearchMatchIsVisibleInFileDiff(match, candidate.fileDiff),
+    ) ??
+    candidates.find((candidate) => candidate.path === match.filePath) ??
+    candidates.find((candidate) => diffSearchMatchIsVisibleInFileDiff(match, candidate.fileDiff)) ??
+    candidates[0];
+
+  return candidate ? { ...match, itemId: candidate.itemId } : null;
 };
 
 // Estimate the rendered row index of a file line inside a diff item so comment
@@ -975,6 +1250,8 @@ export function ReviewCodeView({
   activeSearchMatch,
   agentId,
   agentLabel,
+  blocks,
+  bottomInset = codeViewLayout.paddingBottom,
   collapsed,
   comments,
   commitMetadata,
@@ -987,9 +1264,10 @@ export function ReviewCodeView({
   gitIdentity,
   hunkNavigation,
   isPullRequest,
-  itemVersionByPath,
+  itemVersionByKey,
   keymap,
   loadingSectionIds,
+  onActiveBlockChange,
   onAskCodex,
   onCreateComment,
   onDeleteComment,
@@ -1000,6 +1278,7 @@ export function ReviewCodeView({
   onToggleCollapsed,
   onToggleViewed,
   onUpdateComment,
+  reviewIdentityByPath,
   scrollTarget,
   searchQuery,
   selectedPath,
@@ -1012,6 +1291,8 @@ export function ReviewCodeView({
   activeSearchMatch: DiffSearchMatch | null;
   agentId: 'codex' | 'claude';
   agentLabel: string;
+  blocks?: ReadonlyArray<ReviewDiffBlock>;
+  bottomInset?: number;
   collapsed: ReadonlySet<string>;
   comments: ReadonlyArray<ReviewComment>;
   commitMetadata: CommitMetadata | null;
@@ -1024,9 +1305,10 @@ export function ReviewCodeView({
   gitIdentity: GitIdentity | null;
   hunkNavigation: HunkNavigationRequest | null;
   isPullRequest: boolean;
-  itemVersionByPath: Readonly<Record<string, number>>;
+  itemVersionByKey: Readonly<Record<string, number>>;
   keymap: CodiffKeymap;
   loadingSectionIds: ReadonlySet<string>;
+  onActiveBlockChange?: (blockId: string) => void;
   onAskCodex: (commentId: string) => void;
   onCreateComment: (comment: Omit<ReviewComment, 'body' | 'id'>) => void;
   onDeleteComment: (commentId: string) => void;
@@ -1034,9 +1316,10 @@ export function ReviewCodeView({
   onOpenFile: (file: ChangedFile) => void;
   onSelectPathFromScroll: (viewer: CodeViewInstance) => void;
   onSubmitComment: (commentId: string) => void;
-  onToggleCollapsed: (file: ChangedFile, isCollapsed: boolean) => void;
-  onToggleViewed: (file: ChangedFile, isViewed: boolean) => void;
+  onToggleCollapsed: (file: ChangedFile, isCollapsed: boolean, reviewKey: string) => void;
+  onToggleViewed: (file: ChangedFile, isViewed: boolean, reviewIdentity: ReviewIdentity) => void;
   onUpdateComment: (commentId: string, body: string) => void;
+  reviewIdentityByPath?: ReadonlyMap<string, ReviewIdentity>;
   scrollTarget: ReviewScrollTarget | null;
   searchQuery: string;
   selectedPath: string | null;
@@ -1083,15 +1366,24 @@ export function ReviewCodeView({
       ? commitDetailsCollapseState.collapsed
       : false;
   const stickyHeaderFrameRef = useRef<number | null>(null);
-  const commentsBySection = useMemo(() => {
-    const map = new Map<string, Array<ReviewComment>>();
+  const reviewBlocks = useMemo(() => blocks ?? createFileReviewBlocks(files), [blocks, files]);
+  const commentLookup = useMemo(() => {
+    const map = new Map<string, ReviewComment>();
     for (const comment of comments) {
-      const list = map.get(comment.sectionId) ?? [];
-      list.push(comment);
-      map.set(comment.sectionId, list);
+      map.set(comment.id, comment);
+    }
+    for (const block of reviewBlocks) {
+      if (!block.file) {
+        continue;
+      }
+      for (const comment of block.comments ?? []) {
+        map.set(comment.id, comment);
+      }
     }
     return map;
-  }, [comments]);
+  }, [comments, reviewBlocks]);
+  const renderComments = useMemo(() => [...commentLookup.values()], [commentLookup]);
+  const commentsBySection = useMemo(() => groupReviewCommentsBySection(comments), [comments]);
 
   const markMarkdownPreviewLayoutReady = useCallback((sectionId: string) => {
     setMarkdownPreviewLayoutPassBySection((current) => ({
@@ -1124,27 +1416,101 @@ export function ReviewCodeView({
     }
   }, [commitDetailsItemId, commitMetadata]);
 
-  const { commitDetailsFiles, firstItemByPath, itemMetadata, items } = useMemo(() => {
+  const {
+    commitDetailsFiles,
+    firstItemByBlockId,
+    firstItemByPath,
+    itemBlockId,
+    itemMetadata,
+    items,
+    searchTargetsByBaseItemId,
+  } = useMemo(() => {
     const nextItems: Array<CodeViewItem<ReviewAnnotationMetadata>> = [];
+    const nextFirstItemByBlockId = new Map<string, string>();
     const nextFirstItemByPath = new Map<string, string>();
+    const nextItemBlockId = new Map<string, string>();
     const nextItemMetadata = new Map<string, CodeViewItemMetadata>();
+    const nextSearchTargetsByBaseItemId = new Map<string, Array<RenderedSearchTarget>>();
     const fontLayoutKey = `line-height:${diffLineHeight}`;
 
-    for (const file of files) {
-      const isViewed = viewed[file.path] === file.fingerprint;
-      const isCollapsed = collapsed.has(file.path) && !forceExpandedPaths.has(file.path);
+    for (const block of reviewBlocks) {
+      if (block.header) {
+        const headerId = getBlockHeaderItemId(block);
+        nextFirstItemByBlockId.set(block.id, nextFirstItemByBlockId.get(block.id) ?? headerId);
+        nextItemBlockId.set(headerId, block.id);
+        nextItems.push({
+          annotations: [
+            {
+              lineNumber: 1,
+              metadata: {
+                header: block.header,
+                type: 'walkthrough-header',
+              },
+            } satisfies LineAnnotation<ReviewAnnotationMetadata>,
+          ],
+          collapsed: false,
+          file: {
+            cacheKey: `walkthrough-header:${block.id}`,
+            contents: ' ',
+            lang: 'text',
+            name: headerId,
+          },
+          id: headerId,
+          type: 'file',
+          version: getItemVersion(
+            `${block.id}:walkthrough-header:${block.selected === true ? 'selected' : 'idle'}`,
+          ),
+        });
+      }
+
+      if (!block.file) {
+        continue;
+      }
+
+      const file = block.file;
+      const reviewIdentity = block.reviewIdentity ?? getReviewIdentity(file, reviewIdentityByPath);
+      const reviewKey = reviewIdentity.key;
+      const isViewed = isReviewIdentityViewed(viewed, reviewIdentity);
+      const isCollapsed = collapsed.has(reviewKey) && !forceExpandedPaths.has(file.path);
       const visibleSections = getVisibleDiffSections(file, showWhitespace);
       const lineCount = getDiffLineCountFromVisibleSections(visibleSections);
       const sections = isCollapsed ? visibleSections.slice(0, 1) : visibleSections;
+      const walkthroughNote = getBlockWalkthroughNote(block, walkthroughNotes);
+      const blockCommentsBySection = groupReviewCommentsBySection(block.comments ?? []);
 
       for (const [index, { fileDiff, section }] of sections.entries()) {
-        const id = getItemId(section);
+        const baseItemId = getItemId(section);
+        const id = getBlockItemId(block, section);
+        nextItemBlockId.set(id, block.id);
+        const searchTargets = nextSearchTargetsByBaseItemId.get(baseItemId) ?? [];
+        searchTargets.push({ fileDiff, itemId: id, path: file.path });
+        nextSearchTargetsByBaseItemId.set(baseItemId, searchTargets);
         const markdownPreview = getMarkdownPreviewContents(file, section, fileDiff);
         const canRenderImage = canRenderImagePreview(file.path, section);
         const canRenderMarkdown = markdownPreview != null;
         const isMarkdownPreview = canRenderMarkdown && markdownPreviewSections.has(section.id);
+        const isSelected = block.selected ?? selectedPath === file.path;
+        const reviewVersionPrefix = `${itemVersionByKey[reviewKey] ?? 0}:${block.id}:${
+          reviewIdentity.fingerprint
+        }:${reviewKey}:${section.id}`;
+        const sectionStateVersionKey = `${isCollapsed ? 'collapsed' : 'open'}:${
+          isViewed ? 'viewed' : 'pending'
+        }:${index}:${isSelected ? 'selected' : 'idle'}:${fontLayoutKey}:${
+          walkthroughNote?.reason ?? ''
+        }`;
         const annotationMap = new Map<string, DiffLineAnnotation<ReviewAnnotationMetadata>>();
-        for (const comment of commentsBySection.get(section.id) ?? []) {
+        const globalSectionComments = commentsBySection.get(section.id) ?? [];
+        const visibleGlobalComments = globalSectionComments.filter(
+          (comment) =>
+            comment.filePath === file.path &&
+            reviewCommentAnchorIsVisibleInFileDiff(comment, fileDiff),
+        );
+        const blockSectionComments = blockCommentsBySection.get(section.id) ?? [];
+        const sectionComments = dedupeReviewComments([
+          ...visibleGlobalComments,
+          ...blockSectionComments,
+        ]);
+        for (const comment of sectionComments) {
           const key = getCommentKey(comment);
           const existing = annotationMap.get(key);
           if (existing && existing.metadata.type === 'review-comment') {
@@ -1168,17 +1534,21 @@ export function ReviewCodeView({
         }
 
         nextItemMetadata.set(id, {
+          blockId: block.id,
           canRenderMarkdown,
+          comments: sectionComments,
           file,
           isCollapsed,
           isMarkdownPreview,
-          isSelected: selectedPath === file.path,
+          isSelected,
           isViewed,
           lineCount,
+          reviewIdentity,
           section,
           sectionCount: file.sections.length,
-          walkthroughNote: walkthroughNotes.get(file.path),
+          walkthroughNote,
         });
+        nextFirstItemByBlockId.set(block.id, nextFirstItemByBlockId.get(block.id) ?? id);
         nextFirstItemByPath.set(file.path, nextFirstItemByPath.get(file.path) ?? id);
         if (canRenderImage) {
           nextItems.push({
@@ -1202,11 +1572,7 @@ export function ReviewCodeView({
             id,
             type: 'file',
             version: getItemVersion(
-              `${itemVersionByPath[file.path] ?? 0}:${file.fingerprint}:${section.id}:image:${
-                isCollapsed ? 'collapsed' : 'open'
-              }:${isViewed ? 'viewed' : 'pending'}:${index}:${
-                selectedPath === file.path ? 'selected' : 'idle'
-              }:${fontLayoutKey}:${walkthroughNotes.get(file.path)?.reason ?? ''}:${
+              `${reviewVersionPrefix}:image:${sectionStateVersionKey}:${
                 imagePreviewLayoutPassBySection[section.id] ?? 0
               }`,
             ),
@@ -1242,11 +1608,7 @@ export function ReviewCodeView({
             id,
             type: 'file',
             version: getItemVersion(
-              `${itemVersionByPath[file.path] ?? 0}:${file.fingerprint}:${section.id}:markdown:${
-                isCollapsed ? 'collapsed' : 'open'
-              }:${isViewed ? 'viewed' : 'pending'}:${index}:${
-                selectedPath === file.path ? 'selected' : 'idle'
-              }:${fontLayoutKey}:${walkthroughNotes.get(file.path)?.reason ?? ''}:${
+              `${reviewVersionPrefix}:markdown:${sectionStateVersionKey}:${
                 markdownPreviewLayoutKey
               }:${markdownPreviewLayoutPassBySection[section.id] ?? 0}`,
             ),
@@ -1260,13 +1622,9 @@ export function ReviewCodeView({
           id,
           type: 'diff',
           version: getItemVersion(
-            `${itemVersionByPath[file.path] ?? 0}:${file.fingerprint}:${section.id}:${
-              isCollapsed ? 'collapsed' : 'open'
-            }:${isViewed ? 'viewed' : 'pending'}:${index}:${
-              selectedPath === file.path ? 'selected' : 'idle'
-            }:${fontLayoutKey}:${walkthroughNotes.get(file.path)?.reason ?? ''}:${
+            `${reviewVersionPrefix}:${sectionStateVersionKey}:${
               showWhitespace ? 'ws' : 'ignore-ws'
-            }:${diffStyle}:${getReviewCommentsDigest(commentsBySection.get(section.id) ?? [])}`,
+            }:${diffStyle}:${getReviewCommentsDigest(sectionComments)}`,
           ),
         });
       }
@@ -1317,9 +1675,12 @@ export function ReviewCodeView({
 
     return {
       commitDetailsFiles: nextCommitDetailsFiles,
+      firstItemByBlockId: nextFirstItemByBlockId,
       firstItemByPath: nextFirstItemByPath,
+      itemBlockId: nextItemBlockId,
       itemMetadata: nextItemMetadata,
       items: nextItems,
+      searchTargetsByBaseItemId: nextSearchTargetsByBaseItemId,
     };
   }, [
     collapsed,
@@ -1330,15 +1691,16 @@ export function ReviewCodeView({
     commentsBySection,
     diffLineHeight,
     diffStyle,
-    files,
     forceExpandedPaths,
     imagePreviewLayoutPassBySection,
-    itemVersionByPath,
+    itemVersionByKey,
     markdownPreviewLayoutPassBySection,
     markdownPreviewSections,
+    reviewBlocks,
     selectedPath,
     showWhitespace,
     viewed,
+    reviewIdentityByPath,
     walkthroughNotes,
   ]);
 
@@ -1347,6 +1709,11 @@ export function ReviewCodeView({
     navigatedSelectionRef.current = null;
     setSelectedLines(null);
   }, []);
+
+  const resolvedActiveSearchMatch = useMemo(
+    () => resolveRenderedSearchMatch(activeSearchMatch, itemMetadata, searchTargetsByBaseItemId),
+    [activeSearchMatch, itemMetadata, searchTargetsByBaseItemId],
+  );
 
   const setCodeViewSelectedLines = useCallback((selection: CodeViewLineSelection | null) => {
     if (
@@ -1429,7 +1796,10 @@ export function ReviewCodeView({
         expansionLineCount: diffContextExpansionLineCount,
         hunkSeparators: 'line-info-basic',
         itemMetrics: codeViewItemMetrics,
-        layout: codeViewLayout,
+        layout: {
+          ...codeViewLayout,
+          paddingBottom: bottomInset,
+        },
         lineHoverHighlight: 'both',
         onGutterUtilityClick: (range, context) => {
           ignoreNextLineSelectionEndRef.current = context.item.type === 'diff';
@@ -1480,10 +1850,12 @@ export function ReviewCodeView({
         },
         onPostRender: (node, _instance, _phase, context) => {
           const metadata = itemMetadata.get(context.item.id);
+          const isWalkthroughHeaderItem = context.item.id.endsWith(':walkthrough-header');
           node.classList.toggle(
             'codiff-commit-details-item',
             context.item.id === commitDetailsItemId,
           );
+          node.classList.toggle('codiff-walkthrough-header-item', isWalkthroughHeaderItem);
           node.classList.toggle('codiff-selected-item', metadata?.isSelected === true);
           node.classList.toggle(
             'codiff-markdown-preview-item',
@@ -1515,6 +1887,7 @@ export function ReviewCodeView({
         unsafeCSS: codeViewUnsafeCSS,
       }) satisfies CodeViewOptions<ReviewAnnotationMetadata>,
     [
+      bottomInset,
       cancelPendingEmptyCommentDeletes,
       commitDetailsItemId,
       createCommentForRange,
@@ -1631,7 +2004,11 @@ export function ReviewCodeView({
     }
 
     const behavior = scrollTarget.behavior ?? 'instant';
-    const itemId = firstItemByPath.get(scrollTarget.path);
+    const itemId = scrollTarget.blockId
+      ? firstItemByBlockId.get(scrollTarget.blockId)
+      : scrollTarget.path
+        ? firstItemByPath.get(scrollTarget.path)
+        : null;
     if (!itemId) {
       return;
     }
@@ -1639,24 +2016,15 @@ export function ReviewCodeView({
     let frame: number | null = null;
     let attempts = 0;
     let canceled = false;
-    let requested = false;
 
     const tryScroll = () => {
       if (canceled || handledScrollRequestRef.current === scrollTarget.request) {
         return;
       }
 
-      const viewer = codeViewRef.current?.getInstance();
-      if (requested && viewer && isScrollTargetRendered(viewer, itemId)) {
+      if (requestScrollItemHeaderIntoView(itemId, behavior)) {
         handledScrollRequestRef.current = scrollTarget.request;
         return;
-      }
-
-      if (
-        (behavior === 'instant' || !requested) &&
-        requestScrollItemHeaderIntoView(itemId, behavior)
-      ) {
-        requested = true;
       }
 
       if (attempts < scrollTargetRetryFrameLimit) {
@@ -1673,7 +2041,7 @@ export function ReviewCodeView({
         window.cancelAnimationFrame(frame);
       }
     };
-  }, [firstItemByPath, requestScrollItemHeaderIntoView, scrollTarget]);
+  }, [firstItemByBlockId, firstItemByPath, requestScrollItemHeaderIntoView, scrollTarget]);
 
   useEffect(() => {
     selectedLinesRef.current = selectedLines;
@@ -1782,7 +2150,7 @@ export function ReviewCodeView({
         );
       }
 
-      for (const comment of commentsBySection.get(meta.section.id) ?? []) {
+      for (const comment of meta.comments) {
         addLineEntry(comment.lineNumber, comment.side, {
           end: comment.lineNumber,
           endSide: comment.side,
@@ -1852,7 +2220,6 @@ export function ReviewCodeView({
     handle.scrollTo(target.scrollTarget);
   }, [
     clearCommentLineHighlight,
-    commentsBySection,
     commitDetailsItemId,
     diffLineHeight,
     diffStyle,
@@ -1913,9 +2280,9 @@ export function ReviewCodeView({
 
     highlightFrameRef.current = window.requestAnimationFrame(() => {
       highlightFrameRef.current = null;
-      applySearchHighlights(viewer.getRenderedItems(), searchQuery, activeSearchMatch);
+      applySearchHighlights(viewer.getRenderedItems(), searchQuery, resolvedActiveSearchMatch);
     });
-  }, [activeSearchMatch, searchQuery]);
+  }, [resolvedActiveSearchMatch, searchQuery]);
 
   const scheduleStickyHeaderStateUpdate = useCallback((viewer?: CodeViewInstance) => {
     const nextViewer = viewer ?? codeViewRef.current?.getInstance();
@@ -1958,31 +2325,31 @@ export function ReviewCodeView({
   useEffect(() => {
     const handle = codeViewRef.current;
     const viewer = handle?.getInstance();
-    if (!handle || !viewer || !activeSearchMatch) {
+    if (!handle || !viewer || !resolvedActiveSearchMatch) {
       return;
     }
 
-    if (activeSearchMatch.lineNumber == null) {
+    if (resolvedActiveSearchMatch.lineNumber == null) {
       handle.scrollTo({
         align: 'center',
         behavior: 'smooth-auto',
-        id: activeSearchMatch.itemId,
+        id: resolvedActiveSearchMatch.itemId,
         type: 'item',
       });
     } else {
       handle.scrollTo({
         align: 'center',
         behavior: 'smooth-auto',
-        id: activeSearchMatch.itemId,
-        lineNumber: activeSearchMatch.lineNumber,
+        id: resolvedActiveSearchMatch.itemId,
+        lineNumber: resolvedActiveSearchMatch.lineNumber,
         offset: DEFAULT_PADDING,
-        side: activeSearchMatch.side,
+        side: resolvedActiveSearchMatch.side,
         type: 'line',
       });
     }
 
     scheduleSearchHighlights();
-  }, [activeSearchMatch, scheduleSearchHighlights]);
+  }, [resolvedActiveSearchMatch, scheduleSearchHighlights]);
 
   const renderCustomHeader = useCallback(
     (item: CodeViewItem<ReviewAnnotationMetadata>) => {
@@ -2071,12 +2438,16 @@ export function ReviewCodeView({
         );
       }
 
+      if (annotation.metadata.type === 'walkthrough-header') {
+        return annotation.metadata.header;
+      }
+
       return item.type === 'diff' ? (
         <ReviewAnnotation
           agentId={agentId}
           agentLabel={agentLabel}
           annotation={annotation as DiffLineAnnotation<ReviewCommentAnnotationMetadata>}
-          comments={comments}
+          comments={renderComments}
           focusCommentId={focusCommentId}
           focusCommentRequest={focusCommentRequest}
           identity={gitIdentity}
@@ -2094,7 +2465,6 @@ export function ReviewCodeView({
     [
       agentId,
       agentLabel,
-      comments,
       blurComment,
       commitDetailsFiles,
       deleteComment,
@@ -2111,6 +2481,7 @@ export function ReviewCodeView({
       onAskCodex,
       onSubmitComment,
       onUpdateComment,
+      renderComments,
       scrollToCommitDetailsDestination,
       source,
     ],
@@ -2119,10 +2490,34 @@ export function ReviewCodeView({
   const handleScroll = useCallback(
     (_scrollTop: number, viewer: CodeViewInstance) => {
       onSelectPathFromScroll(viewer);
+      if (onActiveBlockChange) {
+        const activationTop = viewer.getScrollTop() + DEFAULT_PADDING;
+        let activeBlockId: string | null = null;
+        for (const item of items) {
+          const top = viewer.getTopForItem(item.id);
+          if (top == null) {
+            continue;
+          }
+          if (top > activationTop) {
+            break;
+          }
+          activeBlockId = itemBlockId.get(item.id) ?? activeBlockId;
+        }
+        if (activeBlockId) {
+          onActiveBlockChange(activeBlockId);
+        }
+      }
       scheduleSearchHighlights();
       scheduleStickyHeaderStateUpdate(viewer);
     },
-    [onSelectPathFromScroll, scheduleSearchHighlights, scheduleStickyHeaderStateUpdate],
+    [
+      itemBlockId,
+      items,
+      onActiveBlockChange,
+      onSelectPathFromScroll,
+      scheduleSearchHighlights,
+      scheduleStickyHeaderStateUpdate,
+    ],
   );
 
   return (

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -324,6 +324,7 @@ export function Sidebar({
         <NarrativeSidebar
           files={commitFiles}
           navigation={narrativeNavigation}
+          showWhitespace={showWhitespace}
           walkthrough={narrativeWalkthrough}
         />
       ) : mode === 'walkthrough' ? (

--- a/src/app/components/walkthrough/CommitView.tsx
+++ b/src/app/components/walkthrough/CommitView.tsx
@@ -12,7 +12,7 @@ import type {
   WalkthroughCommitResult,
 } from '../../../types.ts';
 import { ArrowsClockwise, Check, GitBranch } from './icons.tsx';
-import { PhaseIcon, WalkthroughLineCount } from './parts.tsx';
+import { ChapterIcon, WalkthroughLineCount } from './parts.tsx';
 
 export type CommitHandler = (request: WalkthroughCommitRequest) => Promise<WalkthroughCommitResult>;
 export type CommitMessageHandler = (
@@ -113,7 +113,7 @@ function StageGroupRow({
       <button className="wt-stage-group-head" onClick={() => onToggleGroup(paths)} type="button">
         <CommitCheck state={state} />
         <span className="wt-stage-group-icon">
-          <PhaseIcon icon={group.icon} size={14} />
+          <ChapterIcon icon={group.icon} size={14} />
         </span>
         <span className="wt-stage-group-title">{group.title}</span>
         <span className="wt-stage-group-count">

--- a/src/app/components/walkthrough/NarrativeSidebar.tsx
+++ b/src/app/components/walkthrough/NarrativeSidebar.tsx
@@ -19,12 +19,18 @@ const agentLabel = (agentId: 'codex' | 'claude') =>
 function TocFileRows({
   files,
 }: {
-  files: ReadonlyArray<{ added: number; deleted: number; label: string; title: string }>;
+  files: ReadonlyArray<{
+    added: number;
+    deleted: number;
+    label: string;
+    path?: string;
+    title: string;
+  }>;
 }) {
   return (
     <span className="wt-toc-file-list">
-      {files.map((file) => (
-        <span className="wt-toc-file-row" key={file.title}>
+      {files.map((file, index) => (
+        <span className="wt-toc-file-row" key={file.path ?? `${file.title}:${file.label}:${index}`}>
           <span className="wt-toc-file" title={file.title}>
             {file.label}
           </span>

--- a/src/app/components/walkthrough/NarrativeSidebar.tsx
+++ b/src/app/components/walkthrough/NarrativeSidebar.tsx
@@ -1,24 +1,42 @@
 import { renderInlineMarkdown } from '../../../lib/markdown.tsx';
 import {
   buildCommitModel,
-  getStopLineCount,
-  getStopSegments,
+  formatWalkthroughFileLineRows,
+  getUncoveredWalkthroughFileLineItems,
   isWalkthroughCommittable,
-  type WalkthroughOrderView,
+  walkthroughItemTitleFallback,
+  type WalkthroughView,
   type WalkthroughStopView,
 } from '../../../lib/narrative-walkthrough.ts';
 import type { ChangedFile, NarrativeWalkthrough } from '../../../types.ts';
 import { Check, GitBranch, Path } from './icons.tsx';
-import { PhaseIcon } from './parts.tsx';
+import { ChapterIcon } from './parts.tsx';
 import type { NarrativeNavigation } from './useNarrativeNavigation.ts';
 
 const agentLabel = (agentId: 'codex' | 'claude') =>
   agentId === 'claude' ? 'Claude Code' : 'Codex';
 
-const fileName = (path: string) => path.split('/').pop() ?? path;
-
-const countUniqueRestFiles = (orderView: WalkthroughOrderView) =>
-  new Set(orderView.rest.map((item) => item.segment.path)).size;
+function TocFileRows({
+  files,
+}: {
+  files: ReadonlyArray<{ added: number; deleted: number; label: string; title: string }>;
+}) {
+  return (
+    <span className="wt-toc-file-list">
+      {files.map((file) => (
+        <span className="wt-toc-file-row" key={file.title}>
+          <span className="wt-toc-file" title={file.title}>
+            {file.label}
+          </span>
+          <span className="wt-toc-count">
+            <span className="added">+{file.added}</span>
+            {file.deleted > 0 ? <span className="deleted">−{file.deleted}</span> : null}
+          </span>
+        </span>
+      ))}
+    </span>
+  );
+}
 
 function TocStop({
   current,
@@ -32,14 +50,13 @@ function TocStop({
   visited: boolean;
 }) {
   const isDone = visited && !current;
-  const segments = getStopSegments(stop);
-  const fileCount = new Set(segments.map((segment) => segment.path)).size;
-  const lineCount = getStopLineCount(stop);
+  const files = formatWalkthroughFileLineRows(stop.hunks);
+  const title = stop.title ?? walkthroughItemTitleFallback(stop);
   return (
     <button
       className={`wt-toc-stop${current ? ' current' : ''}${isDone ? ' visited' : ''}`}
       onClick={() => onSelect(stop.index)}
-      title={stop.title ?? stop.segment.title ?? stop.segment.path}
+      title={title}
       type="button"
     >
       <span className="wt-toc-rail">
@@ -56,50 +73,52 @@ function TocStop({
       <span className="wt-toc-main">
         <span className="wt-toc-title-row">
           <span className="wt-toc-num">{stop.index + 1}</span>
-          <span className="wt-toc-title">
-            {stop.title ?? stop.segment.title ?? stop.segment.path}
-          </span>
+          <span className="wt-toc-title">{title}</span>
         </span>
-        <span className="wt-toc-meta">
-          <span className="wt-toc-file">
-            {fileCount > 1 ? `${fileCount} files` : fileName(stop.segment.path)}
-          </span>
-          <span className="wt-toc-count">
-            <span className="added">+{lineCount.added}</span>
-            {lineCount.deleted > 0 ? <span className="deleted">−{lineCount.deleted}</span> : null}
-          </span>
-        </span>
+        <TocFileRows files={files} />
       </span>
     </button>
   );
 }
 
 function SupportingFilesStop({
+  files,
   navigation,
-  orderView,
+  showWhitespace,
+  walkthroughView,
 }: {
+  files: ReadonlyArray<ChangedFile>;
   navigation: NarrativeNavigation;
-  orderView: WalkthroughOrderView;
+  showWhitespace: boolean;
+  walkthroughView: WalkthroughView;
 }) {
-  if (orderView.rest.length === 0) {
+  const uncoveredFiles = getUncoveredWalkthroughFileLineItems(
+    files,
+    walkthroughView,
+    showWhitespace,
+  );
+  if (walkthroughView.support.length === 0 && uncoveredFiles.length === 0) {
     return null;
   }
-  const current = navigation.mode === 'rest';
-  const isDone = navigation.restVisited && !current;
-  const fileCount = countUniqueRestFiles(orderView);
+  const current = navigation.mode === 'support';
+  const isDone = navigation.supportVisited && !current;
+  const fileRows = formatWalkthroughFileLineRows([
+    ...walkthroughView.support.flatMap((item) => item.hunks),
+    ...uncoveredFiles,
+  ]);
   return (
     <div className="wt-toc-chapter">
       <div className="wt-toc-chapter-head">
         <span className="wt-toc-chapter-icon">
           <Path size={15} />
         </span>
-        <span className="wt-toc-chapter-title">{orderView.order.restLabel}</span>
+        <span className="wt-toc-chapter-title">Support</span>
       </div>
       <div className="wt-toc-stops">
         <button
           className={`wt-toc-stop${current ? ' current' : ''}${isDone ? ' visited' : ''}`}
-          onClick={navigation.openRest}
-          title={orderView.order.restBlurb}
+          onClick={navigation.openSupport}
+          title="Changed alongside the main walkthrough"
           type="button"
         >
           <span className="wt-toc-rail">
@@ -114,19 +133,7 @@ function SupportingFilesStop({
             )}
           </span>
           <span className="wt-toc-main">
-            <span className="wt-toc-title-row">
-              <span className="wt-toc-title">
-                {fileCount} file{fileCount === 1 ? '' : 's'}
-              </span>
-            </span>
-            <span className="wt-toc-meta">
-              <span className="wt-toc-count">
-                <span className="added">+{orderView.restTotals.added}</span>
-                {orderView.restTotals.deleted > 0 ? (
-                  <span className="deleted">−{orderView.restTotals.deleted}</span>
-                ) : null}
-              </span>
-            </span>
+            <TocFileRows files={fileRows} />
           </span>
         </button>
       </div>
@@ -137,29 +144,28 @@ function SupportingFilesStop({
 export function NarrativeSidebar({
   files,
   navigation,
+  showWhitespace,
   walkthrough,
 }: {
   files: ReadonlyArray<ChangedFile>;
   navigation: NarrativeNavigation;
+  showWhitespace: boolean;
   walkthrough: NarrativeWalkthrough;
 }) {
-  const { orderView } = navigation;
-  if (!orderView) {
-    return <div className="wt-empty">This walkthrough has no readable order.</div>;
+  const { walkthroughView } = navigation;
+  if (!walkthroughView) {
+    return <div className="wt-empty">This walkthrough has no readable sequence.</div>;
   }
 
-  const currentSegmentId =
-    navigation.mode === 'stop' ? orderView.sequence[navigation.index]?.segmentId : null;
+  const currentStopId =
+    navigation.mode === 'stop' ? walkthroughView.sequence[navigation.index]?.id : null;
 
   const committable = isWalkthroughCommittable(walkthrough);
-  const commitModel = committable ? buildCommitModel(orderView, files) : null;
-  const commitTotals = commitModel
-    ? commitModel.files
-        .filter((file) => navigation.commitSelected.has(file.path))
-        .reduce(
-          (sum, file) => ({ added: sum.added + file.added, deleted: sum.deleted + file.deleted }),
-          { added: 0, deleted: 0 },
-        )
+  const commitModel = committable ? buildCommitModel(walkthroughView, files) : null;
+  const commitFiles = commitModel
+    ? formatWalkthroughFileLineRows(
+        commitModel.files.filter((file) => navigation.commitSelected.has(file.path)),
+      )
     : null;
 
   return (
@@ -170,29 +176,34 @@ export function NarrativeSidebar({
       </div>
 
       <div className="wt-toc-scroll">
-        {orderView.phases.map((phase) => (
-          <div className="wt-toc-chapter" key={phase.id}>
+        {walkthroughView.chapters.map((chapter) => (
+          <div className="wt-toc-chapter" key={chapter.id}>
             <div className="wt-toc-chapter-head">
               <span className="wt-toc-chapter-icon">
-                <PhaseIcon icon={phase.icon} size={15} />
+                <ChapterIcon icon={chapter.icon} size={15} />
               </span>
-              <span className="wt-toc-chapter-title">{phase.title}</span>
+              <span className="wt-toc-chapter-title">{chapter.title}</span>
             </div>
             <div className="wt-toc-stops">
-              {phase.stops.map((stop) => (
+              {chapter.stops.map((stop) => (
                 <TocStop
-                  current={navigation.mode === 'stop' && stop.segmentId === currentSegmentId}
-                  key={stop.segmentId}
+                  current={navigation.mode === 'stop' && stop.id === currentStopId}
+                  key={stop.id}
                   onSelect={navigation.goStop}
                   stop={stop}
-                  visited={navigation.visited.has(stop.segmentId)}
+                  visited={navigation.visited.has(stop.id)}
                 />
               ))}
             </div>
           </div>
         ))}
-        <SupportingFilesStop navigation={navigation} orderView={orderView} />
-        {committable && commitTotals ? (
+        <SupportingFilesStop
+          files={files}
+          navigation={navigation}
+          showWhitespace={showWhitespace}
+          walkthroughView={walkthroughView}
+        />
+        {committable && commitFiles ? (
           <div className="wt-toc-chapter">
             <div className="wt-toc-chapter-head">
               <span className="wt-toc-chapter-icon commit">
@@ -214,18 +225,7 @@ export function NarrativeSidebar({
                 <span className="wt-toc-title-row">
                   <span className="wt-toc-title">Write the commit</span>
                 </span>
-                <span className="wt-toc-meta">
-                  <span className="wt-toc-file">
-                    {navigation.commitSelected.size} file
-                    {navigation.commitSelected.size === 1 ? '' : 's'}
-                  </span>
-                  <span className="wt-toc-count">
-                    <span className="added">+{commitTotals.added}</span>
-                    {commitTotals.deleted > 0 ? (
-                      <span className="deleted">−{commitTotals.deleted}</span>
-                    ) : null}
-                  </span>
-                </span>
+                <TocFileRows files={commitFiles} />
               </span>
             </button>
           </div>

--- a/src/app/components/walkthrough/NarrativeWalkthroughView.tsx
+++ b/src/app/components/walkthrough/NarrativeWalkthroughView.tsx
@@ -1,507 +1,291 @@
-import {
-  Activity,
-  Fragment,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import type { ReviewIdentity } from '../../../lib/app-types.ts';
+import type { ReviewScrollBehavior } from '../../../lib/app-types.ts';
 import {
   buildCommitModel,
-  getStopSegments,
+  focusChangedFileForHunks,
+  formatWalkthroughFileList,
+  getUncoveredWalkthroughFiles,
+  getWalkthroughRunNote,
   isWalkthroughCommittable,
-  resolveSegmentFile,
-  type ResolvedSegmentFile,
-  type WalkthroughOrderView,
+  resolveWalkthroughHunkRuns,
+  walkthroughItemPaths,
+  walkthroughItemTitleFallback,
+  walkthroughFileName,
+  type WalkthroughView,
   type WalkthroughStopView,
 } from '../../../lib/narrative-walkthrough.ts';
-import type { ChangedFile, NarrativeWalkthrough } from '../../../types.ts';
+import type { ChangedFile, NarrativeWalkthrough, WalkthroughHunkGroup } from '../../../types.ts';
+import type { ReviewDiffBlock } from '../ReviewCodeView.tsx';
 import { CommitView, type CommitHandler, type CommitMessageHandler } from './CommitView.tsx';
 import { ArrowLeft, ArrowRight, CaretLeft, CaretRight, Check, GitBranch, Path } from './icons.tsx';
-import { ImportancePill, Narration, PhaseIcon } from './parts.tsx';
+import { ChapterIcon, ImportancePill, Narration } from './parts.tsx';
 import type { NarrativeNavigation } from './useNarrativeNavigation.ts';
 
-const fileName = (path: string) => path.split('/').pop() ?? path;
+type FocusedRunDiff = {
+  file: ChangedFile;
+  note?: string;
+  reviewIdentity: ReviewIdentity;
+};
 
-const countUniqueRestFiles = (orderView: WalkthroughOrderView) =>
-  new Set(orderView.rest.map((item) => item.segment.path)).size;
+export type WalkthroughReviewTarget = {
+  file: ChangedFile;
+  reviewIdentity: ReviewIdentity;
+};
 
-const stopEstimateHeight = (stop: WalkthroughStopView) => {
-  const segments = getStopSegments(stop);
-  const files = new Set(segments.map((segment) => segment.path)).size;
-  const changedLines = segments.reduce(
-    (total, segment) => total + segment.added + segment.deleted,
-    0,
+export type WalkthroughBlockScrollTarget = {
+  behavior?: ReviewScrollBehavior;
+  blockId: string;
+  request: number;
+};
+
+const getFocusedRunDiffs = (
+  item: WalkthroughHunkGroup,
+  files: ReadonlyArray<ChangedFile>,
+): ReadonlyArray<FocusedRunDiff> =>
+  resolveWalkthroughHunkRuns(item, files).flatMap((run) => {
+    const focused = focusChangedFileForHunks(run.resolved.file, run.resolved.section, run.hunks);
+    return focused
+      ? [
+          {
+            file: focused,
+            note: getWalkthroughRunNote(item, run),
+            reviewIdentity: {
+              fingerprint: focused.fingerprint,
+              key: `walkthrough:${run.key}`,
+            },
+          },
+        ]
+      : [];
+  });
+
+export type RenderWalkthroughDiffBlocks = (
+  blocks: ReadonlyArray<ReviewDiffBlock>,
+  scrollTarget: WalkthroughBlockScrollTarget | null,
+  onActiveBlockChange: (blockId: string) => void,
+) => ReactNode;
+
+type WalkthroughBlockSet = {
+  blocks: ReadonlyArray<ReviewDiffBlock>;
+  firstBlockIdByStop: ReadonlyArray<string | null>;
+  stopIndexByBlockId: ReadonlyMap<string, number>;
+};
+
+type WalkthroughNavigationKeyEvent = Pick<
+  KeyboardEvent,
+  'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'
+>;
+
+export const getWalkthroughNavigationKeyDirection = (
+  event: WalkthroughNavigationKeyEvent,
+): -1 | 0 | 1 => {
+  const hasAnyModifier = event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
+  if (!hasAnyModifier) {
+    if (event.key === 'j') {
+      return 1;
+    }
+    if (event.key === 'k') {
+      return -1;
+    }
+  }
+
+  const isCtrlOnly = event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey;
+  if (isCtrlOnly && event.key === 'ArrowDown') {
+    return 1;
+  }
+  if (isCtrlOnly && event.key === 'ArrowUp') {
+    return -1;
+  }
+
+  return 0;
+};
+
+const emptyWalkthroughBlockSet: WalkthroughBlockSet = {
+  blocks: [],
+  firstBlockIdByStop: [],
+  stopIndexByBlockId: new Map(),
+};
+
+function StopHeader({ current, stop }: { current: boolean; stop: WalkthroughStopView }) {
+  return (
+    <div className={`wt-stop-block wt-stop-block-header${current ? ' current' : ''}`}>
+      <div className="wt-stage-title-row">
+        <h2 className="wt-stage-title">{stop.title ?? walkthroughItemTitleFallback(stop)}</h2>
+        <ImportancePill importance={stop.importance} />
+      </div>
+      <Narration prose={stop.prose} />
+    </div>
   );
-  return Math.max(520, Math.min(1600, 260 + files * 120 + changedLines * 14));
-};
+}
 
-const createVisibleIndexSet = (length: number, index: number) => {
-  const indexes = [index - 1, index, index + 1].filter((item) => item >= 0 && item < length);
-  return new Set(indexes);
-};
+function SupportHeader() {
+  return (
+    <div className="wt-stop-block wt-stop-block-header current">
+      <div className="wt-stage-title-row">
+        <h2 className="wt-stage-title">Support</h2>
+        <ImportancePill importance="normal" />
+      </div>
+      <Narration prose="Supporting changes grouped outside the main sequence." />
+    </div>
+  );
+}
 
-/** Renders the live diff for one changed file via the real ReviewCodeView. */
-export type RenderStopDiff = (file: ChangedFile, note?: string) => ReactNode;
+const createWalkthroughBlocks = (
+  files: ReadonlyArray<ChangedFile>,
+  walkthroughView: WalkthroughView,
+  currentIndex: number,
+): WalkthroughBlockSet => {
+  const blocks: Array<ReviewDiffBlock> = [];
+  const firstBlockIdByStop: Array<string | null> = [];
+  const stopIndexByBlockId = new Map<string, number>();
 
-/** One stop's narration header above its file diff, as a block in the sequence. */
-function StopBlock({
-  files,
-  isCurrent,
-  renderStopDiff,
-  showWhitespace,
-  stop,
-}: {
-  files: ReadonlyArray<ChangedFile>;
-  isCurrent: boolean;
-  renderStopDiff: RenderStopDiff;
-  showWhitespace: boolean;
-  stop: WalkthroughStopView;
-}) {
-  const renderedPaths = new Set<string>();
-  const resolvedFiles: Array<{ note?: string; resolved: ResolvedSegmentFile }> = [];
-  for (const segment of getStopSegments(stop)) {
-    if (renderedPaths.has(segment.path)) {
+  for (const stop of walkthroughView.sequence) {
+    const focusedRuns = getFocusedRunDiffs(stop, files);
+    if (focusedRuns.length === 0) {
+      const blockId = `walkthrough:${stop.id}:missing`;
+      firstBlockIdByStop[stop.index] = blockId;
+      stopIndexByBlockId.set(blockId, stop.index);
+      blocks.push({
+        header: <StopHeader current={stop.index === currentIndex} stop={stop} />,
+        id: blockId,
+        selected: stop.index === currentIndex,
+      });
       continue;
     }
-    renderedPaths.add(segment.path);
-    const resolved = resolveSegmentFile(segment, files, showWhitespace);
-    if (resolved) {
-      resolvedFiles.push({
-        note: segment === stop.segment ? undefined : (segment.summary ?? segment.title),
-        resolved,
+
+    firstBlockIdByStop[stop.index] = `walkthrough:${stop.id}:0`;
+
+    focusedRuns.forEach(({ file, note, reviewIdentity }, runIndex) => {
+      const blockId = `walkthrough:${stop.id}:${runIndex}`;
+      stopIndexByBlockId.set(blockId, stop.index);
+      blocks.push({
+        file,
+        header:
+          runIndex === 0 ? <StopHeader current={stop.index === currentIndex} stop={stop} /> : null,
+        id: blockId,
+        itemIdPrefix: blockId,
+        note,
+        reviewIdentity,
+        selected: stop.index === currentIndex,
+      });
+    });
+  }
+
+  return { blocks, firstBlockIdByStop, stopIndexByBlockId };
+};
+
+const getBlockReviewTarget = (
+  blocks: ReadonlyArray<ReviewDiffBlock>,
+  blockId: string | null | undefined,
+): WalkthroughReviewTarget | null => {
+  const block = blockId ? blocks.find((candidate) => candidate.id === blockId) : null;
+  return block?.file && block.reviewIdentity
+    ? {
+        file: block.file,
+        reviewIdentity: block.reviewIdentity,
+      }
+    : null;
+};
+
+const createSupportBlocks = (
+  files: ReadonlyArray<ChangedFile>,
+  walkthroughView: WalkthroughView,
+  showWhitespace: boolean,
+): ReadonlyArray<ReviewDiffBlock> => {
+  const blocks: Array<ReviewDiffBlock> = [];
+  for (const group of walkthroughView.supportByReason) {
+    for (const item of group.files) {
+      getFocusedRunDiffs(item, files).forEach(({ file, note, reviewIdentity }, runIndex) => {
+        const blockId = `walkthrough:support:${item.id}:${runIndex}`;
+        const isFirstBlock = blocks.length === 0;
+        blocks.push({
+          file,
+          header: isFirstBlock ? <SupportHeader /> : null,
+          id: blockId,
+          itemIdPrefix: blockId,
+          note: note ?? item.note ?? group.reason,
+          reviewIdentity,
+          selected: true,
+        });
       });
     }
   }
-  return (
-    <section className={`wt-stop-block${isCurrent ? ' current' : ''}`}>
-      <div className="wt-stop-header">
-        <div className="wt-stage-title-row">
-          <h2 className="wt-stage-title">
-            {stop.title ?? stop.segment.title ?? fileName(stop.segment.path)}
-          </h2>
-          <ImportancePill importance={stop.importance} />
-        </div>
-        <Narration prose={stop.body} />
-      </div>
-      <div className="wt-stop-diff-host">
-        {resolvedFiles.length > 0 ? (
-          resolvedFiles.map(({ note, resolved }) => (
-            <Fragment key={resolved.file.path}>{renderStopDiff(resolved.file, note)}</Fragment>
-          ))
-        ) : (
-          <div className="wt-empty">These files are no longer part of the current diff.</div>
-        )}
-      </div>
-    </section>
-  );
-}
 
-function MeasuredStop({
-  children,
-  index,
-  onHeight,
-  onRef,
-}: {
-  children: ReactNode;
-  index: number;
-  onHeight: (index: number, height: number) => void;
-  onRef: (index: number, el: HTMLElement | null) => void;
-}) {
-  const [node, setNode] = useState<HTMLDivElement | null>(null);
-  const setRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      onRef(index, el);
-      setNode(el);
-    },
-    [index, onRef],
-  );
-
-  useLayoutEffect(() => {
-    if (!node) {
-      return;
-    }
-    const measure = () => onHeight(index, node.getBoundingClientRect().height);
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [index, node, onHeight]);
-
-  return <div ref={setRef}>{children}</div>;
-}
-
-function StopPlaceholder({
-  children,
-  height,
-  index,
-  onRef,
-}: {
-  children?: ReactNode;
-  height: number;
-  index: number;
-  onRef: (index: number, el: HTMLElement | null) => void;
-}) {
-  const setRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      onRef(index, el);
-    },
-    [index, onRef],
-  );
-
-  return (
-    <div aria-hidden className="wt-stop-placeholder" ref={setRef} style={{ height }}>
-      {children}
-    </div>
-  );
-}
-
-/**
- * The whole order as one continuous scroll: every stop's narration and diff
- * stacked top-to-bottom, so the reader moves through the change hunk by hunk by
- * scrolling rather than paging file by file. The focused stop is derived from
- * scroll position (which drives the arc and "visited" ticks), and command
- * navigation jumps the requested stop back to the top.
- */
-function SequenceScroll({
-  files,
-  navigation,
-  orderView,
-  renderStopDiff,
-  showWhitespace,
-}: {
-  files: ReadonlyArray<ChangedFile>;
-  navigation: NarrativeNavigation;
-  orderView: WalkthroughOrderView;
-  renderStopDiff: RenderStopDiff;
-  showWhitespace: boolean;
-}) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const blockRefs = useRef<Array<HTMLElement | null>>([]);
-  const commandScrollIgnoreUntilRef = useRef(0);
-  const { scrollTarget, syncIndexFromScroll } = navigation;
-  const [heightBySegment, setHeightBySegment] = useState<Readonly<Record<string, number>>>({});
-  const orderKey = orderView.sequence.map((stop) => stop.segmentId).join('\0');
-  const [visibleIndexState, setVisibleIndexState] = useState<{
-    indexes: ReadonlySet<number>;
-    orderKey: string;
-  }>(() => ({
-    indexes: createVisibleIndexSet(orderView.sequence.length, navigation.index),
-    orderKey,
-  }));
-  const visibleIndexes =
-    visibleIndexState.orderKey === orderKey
-      ? visibleIndexState.indexes
-      : createVisibleIndexSet(orderView.sequence.length, scrollTarget.index);
-
-  const getStopHeight = useCallback(
-    (stop: WalkthroughStopView) => heightBySegment[stop.segmentId] ?? stopEstimateHeight(stop),
-    [heightBySegment],
-  );
-
-  const setBlockRef = useCallback((index: number, el: HTMLElement | null) => {
-    blockRefs.current[index] = el;
-  }, []);
-
-  const updateStopHeight = useCallback(
-    (index: number, height: number) => {
-      const stop = orderView.sequence[index];
-      if (!stop || height <= 0) {
-        return;
-      }
-      setHeightBySegment((current) =>
-        current[stop.segmentId] != null && Math.abs(current[stop.segmentId] - height) < 1
-          ? current
-          : { ...current, [stop.segmentId]: height },
-      );
-    },
-    [orderView],
-  );
-
-  useEffect(() => {
-    blockRefs.current = blockRefs.current.slice(0, orderView.sequence.length);
-  }, [orderView.sequence.length]);
-
-  useEffect(() => {
-    const container = scrollRef.current;
-    if (!container) {
-      return;
-    }
-    if (typeof IntersectionObserver === 'undefined') {
-      return;
-    }
-    const elements: Array<HTMLElement> = [];
-    for (const element of blockRefs.current) {
-      if (element) {
-        elements.push(element);
-      }
-    }
-    if (elements.length === 0) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        setVisibleIndexState((current) => {
-          const currentIndexes =
-            current.orderKey === orderKey
-              ? current.indexes
-              : createVisibleIndexSet(orderView.sequence.length, scrollTarget.index);
-          const next = new Set(currentIndexes);
-          let changed = false;
-          for (const entry of entries) {
-            const index = blockRefs.current.indexOf(entry.target as HTMLElement);
-            if (index === -1) {
-              continue;
-            }
-            if (entry.isIntersecting) {
-              if (!next.has(index)) {
-                next.add(index);
-                changed = true;
-              }
-            } else if (next.delete(index)) {
-              changed = true;
-            }
-          }
-          return changed ? { indexes: next, orderKey } : current;
-        });
+  for (const file of getUncoveredWalkthroughFiles(files, walkthroughView, showWhitespace)) {
+    const blockId = `walkthrough:uncovered:${file.path}`;
+    const isFirstBlock = blocks.length === 0;
+    blocks.push({
+      file,
+      header: isFirstBlock ? <SupportHeader /> : null,
+      id: blockId,
+      itemIdPrefix: blockId,
+      note: 'Not included in the generated walkthrough.',
+      reviewIdentity: {
+        fingerprint: file.fingerprint,
+        key: blockId,
       },
-      {
-        root: container,
-        rootMargin: '640px 0px',
-        threshold: 0,
-      },
-    );
-
-    for (const element of elements) {
-      observer.observe(element);
-    }
-    return () => observer.disconnect();
-  }, [heightBySegment, orderKey, orderView.sequence.length, scrollTarget.index, visibleIndexes]);
-
-  // Derive the focused stop from scroll: it's the last block whose top has
-  // crossed an activation line a little below the top of the viewport.
-  useEffect(() => {
-    const container = scrollRef.current;
-    if (!container) {
-      return;
-    }
-    let frame = 0;
-    const measure = () => {
-      frame = 0;
-      const activation = container.scrollTop + 140;
-      let current = 0;
-      for (let i = 0; i < blockRefs.current.length; i += 1) {
-        const el = blockRefs.current[i];
-        if (!el) {
-          continue;
-        }
-        if (el.offsetTop <= activation) {
-          current = i;
-        } else {
-          break;
-        }
-      }
-      syncIndexFromScroll(current);
-    };
-    const onScroll = () => {
-      if (performance.now() < commandScrollIgnoreUntilRef.current) {
-        return;
-      }
-      if (!frame) {
-        frame = requestAnimationFrame(measure);
-      }
-    };
-    container.addEventListener('scroll', onScroll, { passive: true });
-    return () => {
-      container.removeEventListener('scroll', onScroll);
-      if (frame) {
-        cancelAnimationFrame(frame);
-      }
-    };
-  }, [syncIndexFromScroll]);
-
-  // Command-driven moves bump scrollTarget.nonce; bring that stop to the top
-  // instantly. Smooth scrolling makes the active stop walk through every
-  // intermediate item because scroll position is the source of truth while the
-  // animation is in flight.
-  useEffect(() => {
-    const container = scrollRef.current;
-    const el = blockRefs.current[scrollTarget.index];
-    if (!container || !el) {
-      return;
-    }
-    setVisibleIndexState((current) => {
-      const currentIndexes =
-        current.orderKey === orderKey
-          ? current.indexes
-          : createVisibleIndexSet(orderView.sequence.length, scrollTarget.index);
-      const next = new Set(currentIndexes);
-      for (const index of createVisibleIndexSet(orderView.sequence.length, scrollTarget.index)) {
-        next.add(index);
-      }
-      return { indexes: next, orderKey };
+      selected: true,
     });
-    commandScrollIgnoreUntilRef.current = performance.now() + 80;
-    container.scrollTo({
-      behavior: 'instant',
-      top: el.offsetTop,
-    });
-  }, [orderKey, orderView.sequence.length, scrollTarget]);
+  }
 
-  const currentIndex = navigation.mode === 'stop' ? navigation.index : scrollTarget.index;
-
-  return (
-    <div className="wt-stop wt-sequence" ref={scrollRef}>
-      {orderView.sequence.map((stop, i) => {
-        const isVisible = visibleIndexes.has(i);
-        if (isVisible) {
-          return (
-            <MeasuredStop
-              index={i}
-              key={stop.segmentId}
-              onHeight={updateStopHeight}
-              onRef={setBlockRef}
-            >
-              <Activity mode="visible" name={`walkthrough-stop-${i + 1}`}>
-                <StopBlock
-                  files={files}
-                  isCurrent={i === navigation.index}
-                  renderStopDiff={renderStopDiff}
-                  showWhitespace={showWhitespace}
-                  stop={stop}
-                />
-              </Activity>
-            </MeasuredStop>
-          );
-        }
-
-        const isWarm = Math.abs(i - currentIndex) <= 2;
-        return (
-          <StopPlaceholder
-            height={getStopHeight(stop)}
-            index={i}
-            key={stop.segmentId}
-            onRef={setBlockRef}
-          >
-            {isWarm ? (
-              <Activity mode="hidden" name={`walkthrough-stop-${i + 1}`}>
-                <StopBlock
-                  files={files}
-                  isCurrent={false}
-                  renderStopDiff={renderStopDiff}
-                  showWhitespace={showWhitespace}
-                  stop={stop}
-                />
-              </Activity>
-            ) : null}
-          </StopPlaceholder>
-        );
-      })}
-    </div>
-  );
-}
-
-function RestOverview({
-  files,
-  orderView,
-  renderStopDiff,
-  showWhitespace,
-}: {
-  files: ReadonlyArray<ChangedFile>;
-  orderView: WalkthroughOrderView;
-  renderStopDiff: RenderStopDiff;
-  showWhitespace: boolean;
-}) {
-  return (
-    <div className="wt-stop">
-      <div className="wt-stop-header">
-        <div className="wt-stage-title-row">
-          <h2 className="wt-stage-title">{orderView.order.restLabel || 'Supporting files'}</h2>
-        </div>
-        {orderView.order.restBlurb ? <Narration prose={orderView.order.restBlurb} /> : null}
-      </div>
-      <div className="wt-support-diffs">
-        {orderView.restByReason.map((group) => (
-          <Fragment key={group.reason}>
-            {group.files.map((item) => {
-              const resolved = resolveSegmentFile(item.segment, files, showWhitespace);
-              return (
-                <section className="wt-support-diff" key={item.segmentId}>
-                  <div className="wt-stop-diff-host">
-                    {resolved ? (
-                      renderStopDiff(resolved.file, item.note ?? group.reason)
-                    ) : (
-                      <div className="wt-empty">
-                        This file is no longer part of the current diff.
-                      </div>
-                    )}
-                  </div>
-                </section>
-              );
-            })}
-          </Fragment>
-        ))}
-      </div>
-    </div>
-  );
-}
+  return blocks;
+};
 
 function Arc({
   committable,
   navigation,
-  orderView,
+  supportAvailable,
+  walkthroughView,
 }: {
   committable: boolean;
   navigation: NarrativeNavigation;
-  orderView: WalkthroughOrderView;
+  supportAvailable: boolean;
+  walkthroughView: WalkthroughView;
 }) {
   const currentIndex =
     navigation.mode === 'stop'
       ? navigation.index
-      : navigation.mode === 'rest'
-        ? orderView.sequence.length
+      : navigation.mode === 'support'
+        ? walkthroughView.sequence.length
         : -1;
   const trackRef = useRef<HTMLDivElement>(null);
   const [overflow, setOverflow] = useState({ end: false, start: false });
   const goArcNext = useCallback(() => {
     if (navigation.mode === 'stop') {
-      if (navigation.index < orderView.sequence.length - 1) {
+      if (navigation.index < walkthroughView.sequence.length - 1) {
         navigation.goNext();
-      } else if (orderView.rest.length > 0) {
-        navigation.openRest();
+      } else if (supportAvailable) {
+        navigation.openSupport();
       } else if (committable) {
         navigation.enterCommit();
       }
-    } else if (navigation.mode === 'rest' && committable) {
+    } else if (navigation.mode === 'support' && committable) {
       navigation.enterCommit();
     }
-  }, [committable, navigation, orderView]);
+  }, [committable, navigation, supportAvailable, walkthroughView]);
   const goArcPrev = useCallback(() => {
     if (navigation.mode === 'stop') {
       navigation.goPrev();
-    } else if (navigation.mode === 'rest') {
-      navigation.goStop(orderView.sequence.length - 1);
+    } else if (navigation.mode === 'support') {
+      navigation.goStop(walkthroughView.sequence.length - 1);
     } else if (navigation.mode === 'commit') {
-      if (orderView.rest.length > 0) {
-        navigation.openRest();
+      if (supportAvailable) {
+        navigation.openSupport();
       } else {
-        navigation.goStop(orderView.sequence.length - 1);
+        navigation.goStop(walkthroughView.sequence.length - 1);
       }
     }
-  }, [navigation, orderView]);
+  }, [navigation, supportAvailable, walkthroughView]);
   const canGoPrev =
     navigation.mode === 'stop'
       ? navigation.index > 0
-      : navigation.mode === 'rest'
-        ? orderView.sequence.length > 0
-        : navigation.mode === 'commit' && orderView.sequence.length > 0;
+      : navigation.mode === 'support'
+        ? walkthroughView.sequence.length > 0
+        : navigation.mode === 'commit' && walkthroughView.sequence.length > 0;
   const canGoNext =
     navigation.mode === 'stop'
-      ? navigation.index < orderView.sequence.length - 1 || orderView.rest.length > 0 || committable
-      : navigation.mode === 'rest' && committable;
+      ? navigation.index < walkthroughView.sequence.length - 1 || supportAvailable || committable
+      : navigation.mode === 'support' && committable;
 
   // The arc never shows a scrollbar; instead it fades the side that has more.
   const updateOverflow = useCallback(() => {
@@ -547,7 +331,7 @@ function Arc({
     }
     const timer = window.setTimeout(updateOverflow, 220);
     return () => window.clearTimeout(timer);
-  }, [currentIndex, navigation.mode, orderView.order.id, updateOverflow]);
+  }, [currentIndex, navigation.mode, updateOverflow]);
 
   return (
     <div className="wt-arc">
@@ -560,28 +344,28 @@ function Arc({
         }`}
         ref={trackRef}
       >
-        {orderView.phases.map((phase, phaseIndex) => (
-          <Fragment key={phase.id}>
-            {phaseIndex > 0 ? <span className="wt-arc-join" /> : null}
+        {walkthroughView.chapters.map((chapter, chapterIndex) => (
+          <Fragment key={chapter.id}>
+            {chapterIndex > 0 ? <span className="wt-arc-join" /> : null}
             <div className="wt-arc-chapter">
               <span className="wt-arc-chapter-label">
-                <PhaseIcon icon={phase.icon} size={13} />
-                {phase.title}
+                <ChapterIcon icon={chapter.icon} size={13} />
+                {chapter.title}
               </span>
               <div className="wt-arc-nodes">
-                {phase.stops.map((stop) => {
+                {chapter.stops.map((stop) => {
                   const state =
                     stop.index === currentIndex
                       ? 'current'
-                      : navigation.visited.has(stop.segmentId)
+                      : navigation.visited.has(stop.id)
                         ? 'visited'
                         : 'upcoming';
                   return (
                     <button
                       className={`wt-arc-node ${state}`}
-                      key={stop.segmentId}
+                      key={stop.id}
                       onClick={() => navigation.goStop(stop.index)}
-                      title={stop.title ?? stop.segment.title ?? stop.segment.path}
+                      title={stop.title ?? walkthroughItemTitleFallback(stop)}
                       type="button"
                     >
                       {state === 'visited' ? (
@@ -596,27 +380,27 @@ function Arc({
             </div>
           </Fragment>
         ))}
-        {orderView.rest.length > 0 ? (
+        {supportAvailable ? (
           <>
             <span className="wt-arc-join" />
-            <div className="wt-arc-chapter rest">
+            <div className="wt-arc-chapter support">
               <span className="wt-arc-chapter-label">
                 <Path size={13} />
-                {orderView.order.restLabel}
+                Support
               </span>
               <button
                 className={`wt-arc-bundle ${
-                  navigation.mode === 'rest'
+                  navigation.mode === 'support'
                     ? 'current'
-                    : navigation.restVisited
+                    : navigation.supportVisited
                       ? 'visited'
                       : 'upcoming'
                 }`}
-                onClick={navigation.openRest}
+                onClick={navigation.openSupport}
                 title="Review supporting files"
                 type="button"
               >
-                <span>{orderView.sequence.length + 1}</span>
+                <span>{walkthroughView.sequence.length + 1}</span>
               </button>
             </div>
           </>
@@ -651,22 +435,84 @@ function Arc({
 export function NarrativeWalkthroughView({
   files,
   navigation,
+  onActiveReviewTargetChange,
   onCommit,
   onUpdateCommitMessage,
-  renderStopDiff,
+  renderDiffBlocks,
   showWhitespace,
   walkthrough,
 }: {
   files: ReadonlyArray<ChangedFile>;
   navigation: NarrativeNavigation;
+  onActiveReviewTargetChange: (target: WalkthroughReviewTarget | null) => void;
   onCommit: CommitHandler;
   onUpdateCommitMessage: CommitMessageHandler;
-  renderStopDiff: RenderStopDiff;
+  renderDiffBlocks: RenderWalkthroughDiffBlocks;
   showWhitespace: boolean;
   walkthrough: NarrativeWalkthrough;
 }) {
-  const { orderView } = navigation;
+  const { walkthroughView } = navigation;
   const committable = isWalkthroughCommittable(walkthrough);
+  const walkthroughBlocks = useMemo(
+    () =>
+      walkthroughView
+        ? createWalkthroughBlocks(files, walkthroughView, navigation.index)
+        : emptyWalkthroughBlockSet,
+    [files, navigation.index, walkthroughView],
+  );
+  const supportBlocks = useMemo(
+    () => (walkthroughView ? createSupportBlocks(files, walkthroughView, showWhitespace) : []),
+    [files, showWhitespace, walkthroughView],
+  );
+  const supportAvailable = supportBlocks.length > 0;
+  const activeBlockId = walkthroughBlocks.firstBlockIdByStop[navigation.scrollTarget.index];
+  const activeBlockScrollTarget: WalkthroughBlockScrollTarget | null =
+    navigation.mode === 'stop' && activeBlockId
+      ? {
+          behavior: 'smooth',
+          blockId: activeBlockId,
+          request: navigation.scrollTarget.nonce,
+        }
+      : null;
+  const supportBlockScrollTarget: WalkthroughBlockScrollTarget | null =
+    navigation.mode === 'support' && supportBlocks[0]
+      ? {
+          behavior: 'smooth',
+          blockId: supportBlocks[0].id,
+          request: navigation.supportScrollRequest,
+        }
+      : null;
+  const handleActiveBlockChange = useCallback(
+    (blockId: string) => {
+      onActiveReviewTargetChange(getBlockReviewTarget(walkthroughBlocks.blocks, blockId));
+      const stopIndex = walkthroughBlocks.stopIndexByBlockId.get(blockId);
+      if (stopIndex != null) {
+        navigation.syncIndexFromScroll(stopIndex);
+      }
+    },
+    [navigation, onActiveReviewTargetChange, walkthroughBlocks],
+  );
+  const handleSupportActiveBlockChange = useCallback(
+    (blockId: string) => {
+      onActiveReviewTargetChange(getBlockReviewTarget(supportBlocks, blockId));
+    },
+    [onActiveReviewTargetChange, supportBlocks],
+  );
+  useEffect(() => {
+    if (navigation.mode === 'stop') {
+      onActiveReviewTargetChange(getBlockReviewTarget(walkthroughBlocks.blocks, activeBlockId));
+    } else if (navigation.mode === 'support') {
+      onActiveReviewTargetChange(getBlockReviewTarget(supportBlocks, supportBlocks[0]?.id));
+    } else {
+      onActiveReviewTargetChange(null);
+    }
+  }, [
+    activeBlockId,
+    navigation.mode,
+    onActiveReviewTargetChange,
+    supportBlocks,
+    walkthroughBlocks.blocks,
+  ]);
 
   // j/k and Ctrl+↑/↓ move between stops, matching the prototype and Codiff's
   // hunk navigation. Ignore while typing into a comment or input.
@@ -679,40 +525,39 @@ export function NarrativeWalkthroughView({
       ) {
         return;
       }
-      if (!orderView) {
+      if (!walkthroughView) {
         return;
       }
-      const isNext = event.key === 'j' || (event.ctrlKey && event.key === 'ArrowDown');
-      const isPrev = event.key === 'k' || (event.ctrlKey && event.key === 'ArrowUp');
-      if (isNext) {
+      const direction = getWalkthroughNavigationKeyDirection(event);
+      if (direction === 1) {
         event.preventDefault();
         if (navigation.mode === 'stop') {
-          if (navigation.index < orderView.sequence.length - 1) {
+          if (navigation.index < walkthroughView.sequence.length - 1) {
             navigation.goNext();
-          } else if (orderView.rest.length > 0) {
-            navigation.openRest();
+          } else if (supportAvailable) {
+            navigation.openSupport();
           } else if (committable) {
             navigation.enterCommit();
           }
-        } else if (navigation.mode === 'rest' && committable) {
+        } else if (navigation.mode === 'support' && committable) {
           navigation.enterCommit();
         }
-      } else if (isPrev) {
+      } else if (direction === -1) {
         event.preventDefault();
         if (navigation.mode === 'stop') {
           navigation.goPrev();
-        } else if (navigation.mode === 'rest') {
+        } else if (navigation.mode === 'support') {
           navigation.goStop(navigation.index);
         } else if (navigation.mode === 'commit') {
-          if (orderView.rest.length > 0) {
-            navigation.openRest();
+          if (supportAvailable) {
+            navigation.openSupport();
           } else {
             navigation.goStop(navigation.index);
           }
         }
       }
     },
-    [committable, navigation, orderView],
+    [committable, navigation, supportAvailable, walkthroughView],
   );
 
   useEffect(() => {
@@ -720,17 +565,19 @@ export function NarrativeWalkthroughView({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleKeyDown]);
 
-  if (!orderView) {
-    return <div className="wt-empty">This walkthrough has no readable order.</div>;
+  if (!walkthroughView) {
+    return <div className="wt-empty">This walkthrough has no readable sequence.</div>;
   }
 
-  const next = orderView.sequence[navigation.index + 1];
-  const restFileCount = countUniqueRestFiles(orderView);
+  const next = walkthroughView.sequence[navigation.index + 1];
+  const supportFiles = formatWalkthroughFileList(
+    supportBlocks.flatMap((block) => (block.file ? [block.file.path] : [])),
+  );
   const allStopsVisited =
-    orderView.sequence.length > 0 &&
-    orderView.sequence.every((stop) => navigation.visited.has(stop.segmentId)) &&
-    (orderView.rest.length === 0 || navigation.restVisited);
-  const totalSteps = orderView.sequence.length + (orderView.rest.length > 0 ? 1 : 0);
+    walkthroughView.sequence.length > 0 &&
+    walkthroughView.sequence.every((stop) => navigation.visited.has(stop.id)) &&
+    (!supportAvailable || navigation.supportVisited);
+  const totalSteps = walkthroughView.sequence.length + (supportAvailable ? 1 : 0);
   const completionAction = allStopsVisited
     ? committable
       ? {
@@ -738,39 +585,38 @@ export function NarrativeWalkthroughView({
           title: 'Commit the change',
         }
       : {
-          file: `${totalSteps} chapters`,
+          file: `${totalSteps} steps`,
           onClick: null,
           title: 'All chapters reviewed',
         }
     : null;
 
   return (
-    <div className="wt-hybrid">
-      <Arc committable={committable} navigation={navigation} orderView={orderView} />
+    <div
+      className="wt-hybrid"
+      onPointerDownCapture={navigation.releaseStopScrollLock}
+      onTouchStartCapture={navigation.releaseStopScrollLock}
+      onWheelCapture={navigation.releaseStopScrollLock}
+    >
+      <Arc
+        committable={committable}
+        navigation={navigation}
+        supportAvailable={supportAvailable}
+        walkthroughView={walkthroughView}
+      />
 
       {navigation.mode === 'commit' ? (
         <CommitView
           branch={walkthrough.repo.branch}
           draft={navigation}
-          model={buildCommitModel(orderView, files)}
+          model={buildCommitModel(walkthroughView, files)}
           onCommit={onCommit}
           onUpdateMessage={onUpdateCommitMessage}
         />
-      ) : navigation.mode === 'stop' && orderView.sequence.length > 0 ? (
-        <SequenceScroll
-          files={files}
-          navigation={navigation}
-          orderView={orderView}
-          renderStopDiff={renderStopDiff}
-          showWhitespace={showWhitespace}
-        />
+      ) : navigation.mode === 'stop' && walkthroughView.sequence.length > 0 ? (
+        renderDiffBlocks(walkthroughBlocks.blocks, activeBlockScrollTarget, handleActiveBlockChange)
       ) : (
-        <RestOverview
-          files={files}
-          orderView={orderView}
-          renderStopDiff={renderStopDiff}
-          showWhitespace={showWhitespace}
-        />
+        renderDiffBlocks(supportBlocks, supportBlockScrollTarget, handleSupportActiveBlockChange)
       )}
 
       {navigation.mode === 'commit' ? null : completionAction ? (
@@ -799,22 +645,24 @@ export function NarrativeWalkthroughView({
             <span className="wt-upnext-main">
               <span className="wt-upnext-label">Next:</span>{' '}
               <span className="wt-upnext-title">
-                {next.title ?? next.segment.title ?? fileName(next.segment.path)}
+                {next.title ?? walkthroughItemTitleFallback(next)}
               </span>
             </span>
-            <span className="wt-upnext-file">{fileName(next.segment.path)}</span>
+            <span className="wt-upnext-file">
+              {walkthroughFileName(walkthroughItemPaths(next)[0] ?? '')}
+            </span>
             <ArrowRight size={17} />
           </span>
         </button>
-      ) : navigation.mode === 'stop' && orderView.rest.length > 0 ? (
-        <button className="wt-upnext" onClick={navigation.openRest} type="button">
+      ) : navigation.mode === 'stop' && supportAvailable ? (
+        <button className="wt-upnext" onClick={navigation.openSupport} type="button">
           <span className="wt-upnext-action">
             <span className="wt-upnext-main">
               <span className="wt-upnext-label">Next:</span>{' '}
-              <span className="wt-upnext-title">{orderView.order.restLabel}</span>
+              <span className="wt-upnext-title">Support</span>
             </span>
-            <span className="wt-upnext-file">
-              {restFileCount} file{restFileCount === 1 ? '' : 's'}
+            <span className="wt-upnext-file" title={supportFiles.title}>
+              {supportFiles.label}
             </span>
             <ArrowRight size={17} />
           </span>
@@ -829,7 +677,7 @@ export function NarrativeWalkthroughView({
             <ArrowRight size={17} />
           </span>
         </button>
-      ) : navigation.mode === 'rest' && committable ? (
+      ) : navigation.mode === 'support' && committable ? (
         <button className="wt-upnext commit" onClick={navigation.enterCommit} type="button">
           <span className="wt-upnext-action">
             <span className="wt-upnext-main">
@@ -839,7 +687,7 @@ export function NarrativeWalkthroughView({
             <ArrowRight size={17} />
           </span>
         </button>
-      ) : navigation.mode === 'rest' ? (
+      ) : navigation.mode === 'support' ? (
         <button
           className="wt-upnext"
           onClick={() => navigation.goStop(navigation.index)}
@@ -850,9 +698,10 @@ export function NarrativeWalkthroughView({
             <span className="wt-upnext-main">
               <span className="wt-upnext-label">Previous:</span>{' '}
               <span className="wt-upnext-title">
-                {orderView.sequence[navigation.index]?.title ??
-                  orderView.sequence[navigation.index]?.segment.title ??
-                  fileName(orderView.sequence[navigation.index]?.segment.path ?? '')}
+                {walkthroughView.sequence[navigation.index]?.title ??
+                  (walkthroughView.sequence[navigation.index]
+                    ? walkthroughItemTitleFallback(walkthroughView.sequence[navigation.index])
+                    : '')}
               </span>
             </span>
             <span className="wt-upnext-file">Chapter {navigation.index + 1}</span>

--- a/src/app/components/walkthrough/icons.tsx
+++ b/src/app/components/walkthrough/icons.tsx
@@ -21,8 +21,8 @@ type IconProps = {
   weight?: 'thin' | 'light' | 'regular' | 'bold' | 'fill' | 'duotone';
 };
 
-/** Phosphor components for the icon names a walkthrough phase may use. */
-export const phaseIcons: Record<WalkthroughIcon, ComponentType<IconProps>> = {
+/** Phosphor components for the icon names a walkthrough chapter may use. */
+export const chapterIcons: Record<WalkthroughIcon, ComponentType<IconProps>> = {
   beaker: Flask,
   bug: Bug,
   doc: Doc,

--- a/src/app/components/walkthrough/parts.tsx
+++ b/src/app/components/walkthrough/parts.tsx
@@ -2,19 +2,19 @@ import claudeIconUrl from '../../../assets/claude.svg';
 import codexIconUrl from '../../../assets/codex.svg';
 import { renderInlineMarkdown } from '../../../lib/markdown.tsx';
 import { importanceLabel } from '../../../lib/narrative-walkthrough.ts';
-import type { WalkthroughIcon, WalkthroughOrderStop } from '../../../types.ts';
-import { phaseIcons } from './icons.tsx';
+import type { WalkthroughIcon, WalkthroughStop } from '../../../types.ts';
+import { chapterIcons } from './icons.tsx';
 
 export function AgentLogo({ agentId }: { agentId: 'codex' | 'claude' }) {
   return <img alt="" draggable={false} src={agentId === 'claude' ? claudeIconUrl : codexIconUrl} />;
 }
 
-export function PhaseIcon({ icon, size = 13 }: { icon: WalkthroughIcon; size?: number }) {
-  const Icon = phaseIcons[icon] ?? phaseIcons.path;
+export function ChapterIcon({ icon, size = 13 }: { icon: WalkthroughIcon; size?: number }) {
+  const Icon = chapterIcons[icon] ?? chapterIcons.path;
   return <Icon size={size} />;
 }
 
-export function ImportancePill({ importance }: { importance: WalkthroughOrderStop['importance'] }) {
+export function ImportancePill({ importance }: { importance: WalkthroughStop['importance'] }) {
   return <span className={`wt-importance ${importance}`}>{importanceLabel[importance]}</span>;
 }
 

--- a/src/app/components/walkthrough/useNarrativeNavigation.ts
+++ b/src/app/components/walkthrough/useNarrativeNavigation.ts
@@ -37,9 +37,10 @@ export const useNarrativeNavigation = (
   });
   const [supportScrollRequest, setSupportScrollRequest] = useState(0);
   const [supportVisited, setSupportVisited] = useState(false);
-  const [visited, setVisited] = useState<ReadonlySet<string>>(
-    () => new Set(firstStopId(walkthrough) ? [firstStopId(walkthrough)!] : []),
-  );
+  const [visited, setVisited] = useState<ReadonlySet<string>>(() => {
+    const stopId = firstStopId(walkthrough);
+    return new Set(stopId ? [stopId] : []);
+  });
 
   const [commitSelected, setCommitSelected] = useState<ReadonlySet<string>>(
     () => new Set(commitPaths),

--- a/src/app/components/walkthrough/useNarrativeNavigation.ts
+++ b/src/app/components/walkthrough/useNarrativeNavigation.ts
@@ -1,85 +1,58 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  buildOrderView,
-  collectWalkthroughSegments,
-  resolveOrder,
+  buildWalkthroughView,
+  getCommitSelectionPaths,
 } from '../../../lib/narrative-walkthrough.ts';
 import type { ChangedFile, NarrativeWalkthrough } from '../../../types.ts';
 
-export type NarrativeViewMode = 'stop' | 'rest' | 'commit';
+export type NarrativeViewMode = 'stop' | 'support' | 'commit';
 
 export type NarrativeNavigation = ReturnType<typeof useNarrativeNavigation>;
 
-/** Every unique path in the live tree, with walkthrough-only paths as a fallback. */
-const collectCommitPaths = (
-  walkthrough: NarrativeWalkthrough | null,
-  files: ReadonlyArray<ChangedFile>,
-): ReadonlyArray<string> => {
-  const seen = new Set<string>();
-  const paths: Array<string> = [];
-  for (const file of files) {
-    seen.add(file.path);
-    paths.push(file.path);
-  }
-  if (!walkthrough) {
-    return paths;
-  }
-  for (const segment of collectWalkthroughSegments(walkthrough)) {
-    if (!seen.has(segment.path)) {
-      seen.add(segment.path);
-      paths.push(segment.path);
-    }
-  }
-  return paths;
-};
+const firstStopId = (walkthrough: NarrativeWalkthrough | null): string | undefined =>
+  walkthrough?.chapters[0]?.stops[0]?.id;
 
 /**
  * Shared navigation state for the narrative walkthrough, owned by App and passed
- * to both the sidebar table-of-contents and the main hybrid view so a click in
- * either moves both. State: the active order, the focused stop index, whether
- * we're on a stop, supporting files, or commit, and which segments have been
- * visited (ticked), keyed by segment id so progress survives an order switch.
+ * to both the sidebar table-of-contents and the main hybrid view.
  */
 export const useNarrativeNavigation = (
   walkthrough: NarrativeWalkthrough | null,
   files: ReadonlyArray<ChangedFile>,
-  preferredOrderId = 'keys',
   resetKey = '',
 ) => {
-  const [orderId, setOrderId] = useState<string>(() =>
-    walkthrough ? (resolveOrder(walkthrough, preferredOrderId)?.id ?? 'walkthrough') : '',
+  const walkthroughView = useMemo(
+    () => (walkthrough ? buildWalkthroughView(walkthrough) : null),
+    [walkthrough],
+  );
+  const commitPaths = useMemo(
+    () => getCommitSelectionPaths(walkthroughView, files),
+    [files, walkthroughView],
   );
   const [mode, setMode] = useState<NarrativeViewMode>('stop');
   const [index, setIndex] = useState(0);
-  // A nonce-tagged scroll request. The continuous sequence view watches this and
-  // jumps to `index` whenever `nonce` bumps — i.e. for command-driven moves
-  // (Next/Prev, the arc, j/k), but NOT for the scroll-driven index updates the
-  // view feeds back in, which would otherwise fight the user's scrolling.
   const [scrollTarget, setScrollTarget] = useState<{ index: number; nonce: number }>({
     index: 0,
     nonce: 0,
   });
-  const [restVisited, setRestVisited] = useState(false);
-  const [visited, setVisited] = useState<ReadonlySet<string>>(() => {
-    const firstSegment = walkthrough
-      ? resolveOrder(walkthrough, preferredOrderId)?.sequence[0]?.segmentIds[0]
-      : undefined;
-    return new Set(firstSegment ? [firstSegment] : []);
-  });
+  const [supportScrollRequest, setSupportScrollRequest] = useState(0);
+  const [supportVisited, setSupportVisited] = useState(false);
+  const [visited, setVisited] = useState<ReadonlySet<string>>(
+    () => new Set(firstStopId(walkthrough) ? [firstStopId(walkthrough)!] : []),
+  );
 
-  // Commit composer state, only meaningful for working-tree walkthroughs. All
-  // changed files start selected; the title/body may seed from the document.
   const [commitSelected, setCommitSelected] = useState<ReadonlySet<string>>(
-    () => new Set(collectCommitPaths(walkthrough, files)),
+    () => new Set(commitPaths),
   );
   const [commitSubject, setCommitSubjectState] = useState<string>(
     () => walkthrough?.commit?.title ?? '',
   );
   const [commitBody, setCommitBodyState] = useState<string>(() => walkthrough?.commit?.body ?? '');
   const commitBodyDirtyRef = useRef(false);
-  const commitPathSetRef = useRef(new Set(collectCommitPaths(walkthrough, files)));
+  const commitPathSetRef = useRef(new Set(commitPaths));
   const commitResetKeyRef = useRef(resetKey);
   const commitSubjectDirtyRef = useRef(false);
+  const pendingStopScrollIndexRef = useRef<number | null>(null);
 
   const setCommitSubject = useCallback((value: string) => {
     commitSubjectDirtyRef.current = true;
@@ -91,30 +64,24 @@ export const useNarrativeNavigation = (
     setCommitBodyState(value);
   }, []);
 
-  // The useState initializers above run once, on the first render — which happens
-  // before the walkthrough has loaded (App passes `null`, then sets it). Re-seed the
-  // walkthrough-derived state the first time a walkthrough (or a fresh one, after a
-  // source switch) arrives, so the order is active, the first stop is ticked, and the
-  // commit composer opens with every file selected and the subject seeded.
   const seededFor = useRef<NarrativeWalkthrough | null>(null);
   useEffect(() => {
     if (!walkthrough || seededFor.current === walkthrough) {
       return;
     }
     seededFor.current = walkthrough;
-    const order = resolveOrder(walkthrough, preferredOrderId);
-    setOrderId(order?.id ?? 'walkthrough');
     setMode('stop');
     setIndex(0);
     setScrollTarget({ index: 0, nonce: 0 });
-    setRestVisited(false);
-    const firstSegment = order?.sequence[0]?.segmentIds[0];
-    setVisited(new Set(firstSegment ? [firstSegment] : []));
-  }, [files, preferredOrderId, walkthrough]);
+    pendingStopScrollIndexRef.current = null;
+    setSupportScrollRequest(0);
+    setSupportVisited(false);
+    const stopId = firstStopId(walkthrough);
+    setVisited(new Set(stopId ? [stopId] : []));
+  }, [walkthrough]);
 
   useEffect(() => {
-    const paths = collectCommitPaths(walkthrough, files);
-    const pathSet = new Set(paths);
+    const pathSet = new Set(commitPaths);
 
     if (commitResetKeyRef.current !== resetKey) {
       commitResetKeyRef.current = resetKey;
@@ -139,7 +106,7 @@ export const useNarrativeNavigation = (
           changed = true;
         }
       }
-      for (const path of paths) {
+      for (const path of commitPaths) {
         if (!previousPathSet.has(path)) {
           next.add(path);
           changed = true;
@@ -156,71 +123,81 @@ export const useNarrativeNavigation = (
         setCommitBodyState(walkthrough.commit.body ?? '');
       }
     }
-  }, [files, resetKey, walkthrough]);
+  }, [commitPaths, resetKey, walkthrough]);
 
-  const orderView = useMemo(
-    () => (walkthrough ? buildOrderView(walkthrough, orderId) : null),
-    [walkthrough, orderId],
-  );
-
-  const markVisited = useCallback((segmentId: string | undefined) => {
-    if (!segmentId) {
+  const markVisited = useCallback((stopId: string | undefined) => {
+    if (!stopId) {
       return;
     }
     setVisited((current) => {
-      if (current.has(segmentId)) {
+      if (current.has(stopId)) {
         return current;
       }
       const next = new Set(current);
-      next.add(segmentId);
+      next.add(stopId);
       return next;
     });
   }, []);
 
   const goStop = useCallback(
     (target: number) => {
-      if (!orderView) {
+      if (!walkthroughView) {
         return;
       }
-      const clamped = Math.max(0, Math.min(orderView.sequence.length - 1, target));
+      const clamped = Math.max(0, Math.min(walkthroughView.sequence.length - 1, target));
       setMode('stop');
       setIndex(clamped);
-      markVisited(orderView.sequence[clamped]?.segmentId);
-      // Ask the sequence view to scroll this stop into view.
+      markVisited(walkthroughView.sequence[clamped]?.id);
+      pendingStopScrollIndexRef.current = clamped;
       setScrollTarget((current) => ({ index: clamped, nonce: current.nonce + 1 }));
     },
-    [orderView, markVisited],
+    [walkthroughView, markVisited],
   );
 
   const goNext = useCallback(() => goStop(index + 1), [goStop, index]);
   const goPrev = useCallback(() => goStop(index - 1), [goStop, index]);
 
-  // The continuous sequence view calls this as the reader scrolls, to keep the
-  // arc, count and "visited" ticks in step with what's on screen. It updates the
-  // focused stop WITHOUT issuing a scroll request, so it never fights the scroll.
   const syncIndexFromScroll = useCallback(
     (target: number) => {
-      if (!orderView) {
+      if (!walkthroughView) {
         return;
       }
-      const clamped = Math.max(0, Math.min(orderView.sequence.length - 1, target));
+      const clamped = Math.max(0, Math.min(walkthroughView.sequence.length - 1, target));
+      const pendingStopScrollIndex = pendingStopScrollIndexRef.current;
+      if (pendingStopScrollIndex != null && pendingStopScrollIndex !== clamped) {
+        return;
+      }
+      if (pendingStopScrollIndex === clamped) {
+        pendingStopScrollIndexRef.current = null;
+      }
       setIndex((current) => (current === clamped ? current : clamped));
-      markVisited(orderView.sequence[clamped]?.segmentId);
+      markVisited(walkthroughView.sequence[clamped]?.id);
     },
-    [orderView, markVisited],
+    [walkthroughView, markVisited],
   );
 
-  const openRest = useCallback(() => {
-    if (orderView?.sequence.length) {
-      setIndex(orderView.sequence.length - 1);
+  const releaseStopScrollLock = useCallback(() => {
+    pendingStopScrollIndexRef.current = null;
+  }, []);
+
+  const leaveStopMode = useCallback(() => {
+    pendingStopScrollIndexRef.current = null;
+  }, []);
+
+  const openSupport = useCallback(() => {
+    leaveStopMode();
+    if (walkthroughView?.sequence.length) {
+      setIndex(walkthroughView.sequence.length - 1);
     }
-    setMode('rest');
-    setRestVisited(true);
-  }, [orderView]);
+    setMode('support');
+    setSupportScrollRequest((current) => current + 1);
+    setSupportVisited(true);
+  }, [walkthroughView, leaveStopMode]);
 
   const enterCommit = useCallback(() => {
+    leaveStopMode();
     setMode('commit');
-  }, []);
+  }, [leaveStopMode]);
 
   const toggleCommitFile = useCallback((path: string) => {
     setCommitSelected((current) => {
@@ -249,39 +226,6 @@ export const useNarrativeNavigation = (
     });
   }, []);
 
-  const switchOrder = useCallback(
-    (nextOrderId: string) => {
-      const nextOrder = walkthrough ? resolveOrder(walkthrough, nextOrderId) : null;
-      const resolvedOrderId = nextOrder?.id ?? nextOrderId;
-      if (resolvedOrderId === orderId) {
-        return;
-      }
-      setOrderId(resolvedOrderId);
-      setMode('stop');
-      setIndex(0);
-      setScrollTarget((current) => ({ index: 0, nonce: current.nonce + 1 }));
-      setRestVisited(false);
-      markVisited(
-        walkthrough
-          ? buildOrderView(walkthrough, resolvedOrderId)?.sequence[0]?.segmentId
-          : undefined,
-      );
-    },
-    [orderId, walkthrough, markVisited],
-  );
-
-  useEffect(() => {
-    if (!walkthrough) {
-      return;
-    }
-    const resolvedOrderId = resolveOrder(walkthrough, preferredOrderId)?.id ?? preferredOrderId;
-    if (resolvedOrderId === orderId) {
-      return;
-    }
-    const frame = requestAnimationFrame(() => switchOrder(resolvedOrderId));
-    return () => cancelAnimationFrame(frame);
-  }, [orderId, preferredOrderId, switchOrder, walkthrough]);
-
   return {
     commitBody,
     commitSelected,
@@ -292,17 +236,17 @@ export const useNarrativeNavigation = (
     goStop,
     index,
     mode,
-    openRest,
-    orderId,
-    orderView,
-    restVisited,
+    openSupport,
+    releaseStopScrollLock,
     scrollTarget,
     setCommitBody,
     setCommitSubject,
-    switchOrder,
+    supportScrollRequest,
+    supportVisited,
     syncIndexFromScroll,
     toggleCommitFile,
     toggleCommitGroup,
     visited,
+    walkthroughView,
   };
 };

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -79,11 +79,6 @@
           "default": "system",
           "description": "Application color theme. 'system' follows OS preference."
         },
-        "walkthroughOrder": {
-          "type": "string",
-          "default": "keys",
-          "description": "Preferred narrative walkthrough order. 'keys' opens key changes first; 'results' opens results first when that order exists."
-        },
         "wordWrap": {
           "type": "boolean",
           "default": false,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -15,7 +15,6 @@ export type CodiffSettings = {
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
-  walkthroughOrder: string;
   wordWrap: boolean;
 };
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -55,7 +55,6 @@ declare global {
       resetCodeFontSize: () => Promise<void>;
       setDiffStyle: (value: CodiffPreferences['diffStyle']) => Promise<void>;
       setShowOutdated: (value: boolean) => Promise<void>;
-      setWalkthroughOrder: (value: string) => Promise<void>;
       setWordWrap: (value: boolean) => Promise<void>;
       showInFolder: (path: string) => Promise<void>;
       submitPullRequestComment: (

--- a/src/lib/app-types.ts
+++ b/src/lib/app-types.ts
@@ -1,4 +1,5 @@
 import type { CodeViewHandle } from '@pierre/diffs/react';
+import type { ReactNode } from 'react';
 import type {
   ChangedFile,
   CommitMetadata,
@@ -36,11 +37,17 @@ type CommitDetailsAnnotationMetadata = {
   type: 'commit-details';
 };
 
+type WalkthroughHeaderAnnotationMetadata = {
+  header: ReactNode;
+  type: 'walkthrough-header';
+};
+
 export type ReviewAnnotationMetadata =
   | CommitDetailsAnnotationMetadata
   | ImagePreviewAnnotationMetadata
   | MarkdownPreviewAnnotationMetadata
-  | ReviewCommentAnnotationMetadata;
+  | ReviewCommentAnnotationMetadata
+  | WalkthroughHeaderAnnotationMetadata;
 
 export type CodeViewInstance = NonNullable<
   ReturnType<CodeViewHandle<ReviewAnnotationMetadata>['getInstance']>
@@ -63,8 +70,14 @@ export type ReviewScrollBehavior = 'instant' | 'smooth';
 
 export type ReviewScrollTarget = {
   behavior?: ReviewScrollBehavior;
-  path: string;
+  blockId?: string;
+  path?: string;
   request: number;
+};
+
+export type ReviewIdentity = {
+  fingerprint: string;
+  key: string;
 };
 
 export type DiffLineCount = {
@@ -128,13 +141,16 @@ export type RepositoryLoadError = {
 };
 
 export type CodeViewItemMetadata = {
+  blockId: string;
   canRenderMarkdown: boolean;
+  comments: ReadonlyArray<ReviewComment>;
   file: ChangedFile;
   isCollapsed: boolean;
   isMarkdownPreview: boolean;
   isSelected: boolean;
   isViewed: boolean;
   lineCount: DiffLineCount;
+  reviewIdentity: ReviewIdentity;
   section: DiffSection;
   sectionCount: number;
   walkthroughNote?: WalkthroughNote;

--- a/src/lib/code-view-options.ts
+++ b/src/lib/code-view-options.ts
@@ -145,6 +145,8 @@ export const maxWorkerThreads = 3;
 
 export const codeViewUnsafeCSS = `
   :host {
+    border-radius: var(--codiff-diff-radius, 28px);
+    corner-shape: squircle;
     --diffs-font-family: var(--font-diff-mono, var(--font-mono));
     --diffs-header-font-family: var(--font-sans);
     --diffs-font-size: var(--font-diff-size, 13px);
@@ -169,7 +171,34 @@ export const codeViewUnsafeCSS = `
 
   [data-diffs-header="custom"][data-sticky] {
     background-color: transparent;
-    border-radius: 28px 28px 0 0;
+    border-radius: 0;
+  }
+
+  :host(.codiff-walkthrough-header-item) {
+    background: var(--app-bg);
+    border-radius: 0;
+    box-shadow: none;
+    corner-shape: initial;
+    overflow: visible;
+  }
+
+  :host(.codiff-walkthrough-header-item) [data-file],
+  :host(.codiff-walkthrough-header-item) pre,
+  :host(.codiff-walkthrough-header-item) code,
+  :host(.codiff-walkthrough-header-item) [data-code],
+  :host(.codiff-walkthrough-header-item) [data-line-annotation] {
+    background: var(--app-bg);
+    border-radius: 0;
+    box-shadow: none;
+    overflow: visible;
+  }
+
+  :host(.codiff-walkthrough-header-item) [data-column-number],
+  :host(.codiff-walkthrough-header-item) [data-line-number],
+  :host(.codiff-walkthrough-header-item) [data-gutter],
+  :host(.codiff-walkthrough-header-item) [data-gutter-buffer],
+  :host(.codiff-walkthrough-header-item) [data-content] > [data-line] {
+    display: none;
   }
 
   /* Commit details render through CodeView's file layout; hide the file UI around the panel. */

--- a/src/lib/narrative-walkthrough.ts
+++ b/src/lib/narrative-walkthrough.ts
@@ -155,14 +155,19 @@ const walkthroughCoveredSectionIds = (view: WalkthroughView): ReadonlySet<string
 const getSectionHunkIds = (section: DiffSection): ReadonlyArray<string> =>
   extractPatchHunks(section.patch).map((_, index) => `${section.id}:h${index + 1}`);
 
+type UncoveredWalkthroughSection = {
+  identity: string;
+  section: DiffSection;
+};
+
 const getUncoveredWalkthroughSection = (
   section: DiffSection,
   coveredHunkIds: ReadonlySet<string>,
   coveredSectionIds: ReadonlySet<string>,
-): DiffSection | null => {
+): UncoveredWalkthroughSection | null => {
   const hunkIds = getSectionHunkIds(section);
   if (hunkIds.length === 0) {
-    return coveredSectionIds.has(section.id) ? null : section;
+    return coveredSectionIds.has(section.id) ? null : { identity: section.id, section };
   }
 
   const uncoveredHunkIds = hunkIds.filter((hunkId) => !coveredHunkIds.has(hunkId));
@@ -170,12 +175,13 @@ const getUncoveredWalkthroughSection = (
     return null;
   }
 
+  const identity = `${section.id}:${uncoveredHunkIds.join(',')}`;
   if (uncoveredHunkIds.length === hunkIds.length) {
-    return section;
+    return { identity, section };
   }
 
   const patch = filterPatchToHunkIds(section.patch, section.id, uncoveredHunkIds);
-  return patch ? { ...section, patch } : null;
+  return patch ? { identity, section: { ...section, patch } } : null;
 };
 
 export const getUncoveredWalkthroughFiles = (
@@ -186,18 +192,19 @@ export const getUncoveredWalkthroughFiles = (
   const coveredHunkIds = walkthroughCoveredHunkIds(view);
   const coveredSectionIds = walkthroughCoveredSectionIds(view);
   return files.flatMap((file) => {
-    const sections = getVisibleDiffSections(file, showWhitespace)
+    const uncoveredSections = getVisibleDiffSections(file, showWhitespace)
       .map(({ section }) => section)
       .map((section) => getUncoveredWalkthroughSection(section, coveredHunkIds, coveredSectionIds))
-      .filter((section): section is DiffSection => section != null);
+      .filter((entry): entry is UncoveredWalkthroughSection => entry != null);
+    const sections = uncoveredSections.map(({ section }) => section);
     if (sections.length === 0) {
       return [];
     }
     return [
       {
         ...file,
-        fingerprint: `${file.fingerprint}:walkthrough-uncovered:${sections
-          .map((section) => section.id)
+        fingerprint: `${file.fingerprint}:walkthrough-uncovered:${uncoveredSections
+          .map(({ identity }) => identity)
           .join(',')}`,
         sections,
       },
@@ -347,11 +354,8 @@ export const getWalkthroughRunNote = (
   return notes.length > 0 ? notes.join(' • ') : undefined;
 };
 
-const focusSignature = (
-  section: DiffSection,
-  hunkIds: ReadonlyArray<string>,
-  contentIdentity: string,
-) => `walkthrough:${section.id}:${hunkIds.join(',')}:${contentIdentity.length}`;
+const focusSignature = (section: DiffSection, hunkIds: ReadonlyArray<string>) =>
+  `walkthrough:${section.id}:${hunkIds.join(',')}`;
 
 /**
  * Return the changed-file view a walkthrough stop should render for one live diff
@@ -371,13 +375,7 @@ export const focusChangedFileForHunks = (
 
   const hunkIds = sectionHunks.map((hunk) => hunk.id);
   if (section.binary || (section.loadState != null && section.loadState !== 'ready')) {
-    const signature = focusSignature(
-      section,
-      hunkIds,
-      `${section.loadState ?? 'binary'}:${section.summary?.fingerprint ?? ''}:${
-        section.summary?.reason ?? ''
-      }:${section.patch.length}`,
-    );
+    const signature = focusSignature(section, hunkIds);
     return {
       ...file,
       fingerprint: `${file.fingerprint}:${signature}`,
@@ -404,7 +402,7 @@ export const focusChangedFileForHunks = (
     return null;
   }
 
-  const signature = focusSignature(section, hunkIds, focusedPatch);
+  const signature = focusSignature(section, hunkIds);
 
   return {
     ...file,

--- a/src/lib/narrative-walkthrough.ts
+++ b/src/lib/narrative-walkthrough.ts
@@ -1,6 +1,7 @@
 import {
-  extractPatchHunks,
   filterPatchToHunkIds,
+  getSectionWalkthroughHunks,
+  isSyntheticWalkthroughHunk,
 } from '../../shared/narrative-walkthrough-diff.cjs';
 import type {
   ChangedFile,
@@ -152,8 +153,18 @@ const walkthroughCoveredSectionIds = (view: WalkthroughView): ReadonlySet<string
     ),
   );
 
-const getSectionHunkIds = (section: DiffSection): ReadonlyArray<string> =>
-  extractPatchHunks(section.patch).map((_, index) => `${section.id}:h${index + 1}`);
+const walkthroughCoveredSyntheticSectionIds = (view: WalkthroughView): ReadonlySet<string> =>
+  new Set(
+    [...view.sequence, ...view.support].flatMap((item) =>
+      item.hunks
+        .filter(isSyntheticWalkthroughHunk)
+        .map((hunk) => hunk.anchor.sectionId)
+        .filter((sectionId): sectionId is string => typeof sectionId === 'string'),
+    ),
+  );
+
+const getSectionHunkIds = (file: ChangedFile, section: DiffSection): ReadonlyArray<string> =>
+  getSectionWalkthroughHunks(file, section).map((hunk: { id: string }) => hunk.id);
 
 type UncoveredWalkthroughSection = {
   identity: string;
@@ -161,11 +172,17 @@ type UncoveredWalkthroughSection = {
 };
 
 const getUncoveredWalkthroughSection = (
+  file: ChangedFile,
   section: DiffSection,
   coveredHunkIds: ReadonlySet<string>,
   coveredSectionIds: ReadonlySet<string>,
+  coveredSyntheticSectionIds: ReadonlySet<string>,
 ): UncoveredWalkthroughSection | null => {
-  const hunkIds = getSectionHunkIds(section);
+  if (coveredSyntheticSectionIds.has(section.id)) {
+    return null;
+  }
+
+  const hunkIds = getSectionHunkIds(file, section);
   if (hunkIds.length === 0) {
     return coveredSectionIds.has(section.id) ? null : { identity: section.id, section };
   }
@@ -191,10 +208,19 @@ export const getUncoveredWalkthroughFiles = (
 ): ReadonlyArray<ChangedFile> => {
   const coveredHunkIds = walkthroughCoveredHunkIds(view);
   const coveredSectionIds = walkthroughCoveredSectionIds(view);
+  const coveredSyntheticSectionIds = walkthroughCoveredSyntheticSectionIds(view);
   return files.flatMap((file) => {
     const uncoveredSections = getVisibleDiffSections(file, showWhitespace)
       .map(({ section }) => section)
-      .map((section) => getUncoveredWalkthroughSection(section, coveredHunkIds, coveredSectionIds))
+      .map((section) =>
+        getUncoveredWalkthroughSection(
+          file,
+          section,
+          coveredHunkIds,
+          coveredSectionIds,
+          coveredSyntheticSectionIds,
+        ),
+      )
       .filter((entry): entry is UncoveredWalkthroughSection => entry != null);
     const sections = uncoveredSections.map(({ section }) => section);
     if (sections.length === 0) {
@@ -351,7 +377,7 @@ export const getWalkthroughRunNote = (
   const notes = (item.notes ?? [])
     .filter((note) => hunkIds.has(note.hunkId))
     .map((note) => note.body);
-  return notes.length > 0 ? notes.join(' • ') : undefined;
+  return notes.length > 0 ? notes.join(' ') : undefined;
 };
 
 const focusSignature = (section: DiffSection, hunkIds: ReadonlyArray<string>) =>
@@ -374,7 +400,11 @@ export const focusChangedFileForHunks = (
   }
 
   const hunkIds = sectionHunks.map((hunk) => hunk.id);
-  if (section.binary || (section.loadState != null && section.loadState !== 'ready')) {
+  if (
+    sectionHunks.some(isSyntheticWalkthroughHunk) ||
+    section.binary ||
+    (section.loadState != null && section.loadState !== 'ready')
+  ) {
     const signature = focusSignature(section, hunkIds);
     return {
       ...file,

--- a/src/lib/narrative-walkthrough.ts
+++ b/src/lib/narrative-walkthrough.ts
@@ -1,102 +1,233 @@
+import {
+  extractPatchHunks,
+  filterPatchToHunkIds,
+} from '../../shared/narrative-walkthrough-diff.cjs';
 import type {
   ChangedFile,
   DiffSection,
   NarrativeWalkthrough,
   WalkthroughChangeType,
+  WalkthroughChapter,
+  WalkthroughHunk,
+  WalkthroughHunkGroup,
   WalkthroughIcon,
-  WalkthroughOrder,
-  WalkthroughOrderStop,
-  WalkthroughPhase,
-  WalkthroughRestItem,
-  WalkthroughSegment,
+  WalkthroughSupportGroup,
+  WalkthroughStop,
 } from '../types.ts';
-import { getFirstVisibleSection } from './diff.ts';
+import { getDiffLineCount, getVisibleDiffSections } from './diff.ts';
 
 export type NarrativeLineCount = {
   added: number;
   deleted: number;
 };
 
-/** A stop resolved to its segment and given a global position in the order. */
-export type WalkthroughStopView = WalkthroughOrderStop & {
+/** A stop with a global position in the walkthrough. */
+export type WalkthroughStopView = WalkthroughStop & {
+  chapterId: string;
   index: number;
-  relatedSegments: ReadonlyArray<WalkthroughSegment>;
-  segment: WalkthroughSegment;
-  segmentId: string;
 };
 
-/** A phase with the stops that belong to it, in order. */
-export type WalkthroughPhaseView = WalkthroughPhase & {
+/** A chapter with indexed stops. */
+export type WalkthroughChapterView = Omit<WalkthroughChapter, 'stops'> & {
   stops: ReadonlyArray<WalkthroughStopView>;
 };
 
-/** A "rest" item resolved to its segment. */
-export type WalkthroughRestView = WalkthroughRestItem & {
-  segment: WalkthroughSegment;
-};
-
-/** The "rest" grouped by reason, preserving first-seen order. */
-export type WalkthroughRestReason = {
-  files: ReadonlyArray<WalkthroughRestView>;
+/** Support grouped by reason, preserving first-seen order. */
+export type WalkthroughSupportReason = {
+  files: ReadonlyArray<WalkthroughSupportGroup>;
   reason: string;
 };
 
-/** Everything a narrative order needs to render, derived from the document. */
-export type WalkthroughOrderView = {
-  order: WalkthroughOrder;
-  phases: ReadonlyArray<WalkthroughPhaseView>;
-  rest: ReadonlyArray<WalkthroughRestView>;
-  restByReason: ReadonlyArray<WalkthroughRestReason>;
-  restTotals: NarrativeLineCount;
+/** Everything a narrative walkthrough needs to render. */
+export type WalkthroughView = {
+  chapters: ReadonlyArray<WalkthroughChapterView>;
   sequence: ReadonlyArray<WalkthroughStopView>;
-  totals: NarrativeLineCount;
+  support: ReadonlyArray<WalkthroughSupportGroup>;
+  supportByReason: ReadonlyArray<WalkthroughSupportReason>;
 };
 
-export const getStopSegments = (stop: WalkthroughStopView): ReadonlyArray<WalkthroughSegment> => [
-  stop.segment,
-  ...stop.relatedSegments,
-];
+export type WalkthroughFileList = {
+  label: string;
+  title: string;
+};
 
-const sumSegments = (segments: ReadonlyArray<WalkthroughSegment>): NarrativeLineCount =>
-  segments.reduce(
-    (totals, segment) => ({
-      added: totals.added + segment.added,
-      deleted: totals.deleted + segment.deleted,
-    }),
-    { added: 0, deleted: 0 },
+export type WalkthroughFileLineRow = {
+  added: number;
+  deleted: number;
+  label: string;
+  path?: string;
+  title: string;
+};
+
+export const walkthroughFileName = (path: string): string => path.split('/').pop() ?? path;
+
+const uniquePaths = (paths: ReadonlyArray<string>): ReadonlyArray<string> => {
+  const seen = new Set<string>();
+  const unique: Array<string> = [];
+  for (const path of paths) {
+    if (!seen.has(path)) {
+      seen.add(path);
+      unique.push(path);
+    }
+  }
+  return unique;
+};
+
+export const walkthroughItemPaths = (item: WalkthroughHunkGroup): ReadonlyArray<string> =>
+  uniquePaths(item.hunks.map((hunk) => hunk.path));
+
+export const walkthroughItemTitleFallback = (item: WalkthroughHunkGroup): string =>
+  item.title ?? walkthroughFileName(item.hunks[0]?.path ?? item.id);
+
+export const formatWalkthroughFileList = (
+  paths: ReadonlyArray<string>,
+  maxVisibleFiles = 5,
+): WalkthroughFileList => {
+  const unique = uniquePaths(paths);
+  const count = unique.length;
+  return {
+    label:
+      count === 0
+        ? '0 files'
+        : count > maxVisibleFiles
+          ? `${count} files`
+          : unique.map(walkthroughFileName).join(', '),
+    title: unique.join('\n'),
+  };
+};
+
+export const formatWalkthroughFileLineRows = (
+  items: ReadonlyArray<{ added: number; deleted: number; path: string }>,
+  maxVisibleFiles = 5,
+): ReadonlyArray<WalkthroughFileLineRow> => {
+  const order: Array<string> = [];
+  const totalsByPath = new Map<string, NarrativeLineCount>();
+  for (const item of items) {
+    if (!totalsByPath.has(item.path)) {
+      order.push(item.path);
+      totalsByPath.set(item.path, { added: 0, deleted: 0 });
+    }
+    const current = totalsByPath.get(item.path)!;
+    totalsByPath.set(item.path, {
+      added: current.added + item.added,
+      deleted: current.deleted + item.deleted,
+    });
+  }
+
+  if (order.length === 0) {
+    return [{ added: 0, deleted: 0, label: '0 files', title: '' }];
+  }
+
+  if (order.length > maxVisibleFiles) {
+    const totals = [...totalsByPath.values()].reduce(
+      (sum, item) => ({ added: sum.added + item.added, deleted: sum.deleted + item.deleted }),
+      { added: 0, deleted: 0 },
+    );
+    return [
+      {
+        ...totals,
+        label: `${order.length} files`,
+        title: order.join('\n'),
+      },
+    ];
+  }
+
+  return order.map((path) => ({
+    ...totalsByPath.get(path)!,
+    label: walkthroughFileName(path),
+    path,
+    title: path,
+  }));
+};
+
+const walkthroughCoveredHunkIds = (view: WalkthroughView): ReadonlySet<string> =>
+  new Set([...view.sequence, ...view.support].flatMap((item) => item.hunkIds));
+
+const walkthroughCoveredSectionIds = (view: WalkthroughView): ReadonlySet<string> =>
+  new Set(
+    [...view.sequence, ...view.support].flatMap((item) =>
+      item.hunks
+        .map((hunk) => hunk.anchor.sectionId)
+        .filter((sectionId): sectionId is string => typeof sectionId === 'string'),
+    ),
   );
 
-const sumLineCount = (items: ReadonlyArray<{ segment: WalkthroughSegment }>): NarrativeLineCount =>
-  items.reduce(
-    (totals, { segment }) => ({
-      added: totals.added + segment.added,
-      deleted: totals.deleted + segment.deleted,
-    }),
-    { added: 0, deleted: 0 },
-  );
+const getSectionHunkIds = (section: DiffSection): ReadonlyArray<string> =>
+  extractPatchHunks(section.patch).map((_, index) => `${section.id}:h${index + 1}`);
 
-const sumStopLineCount = (stops: ReadonlyArray<WalkthroughStopView>): NarrativeLineCount =>
-  sumSegments(stops.flatMap((stop) => getStopSegments(stop)));
+const getUncoveredWalkthroughSection = (
+  section: DiffSection,
+  coveredHunkIds: ReadonlySet<string>,
+  coveredSectionIds: ReadonlySet<string>,
+): DiffSection | null => {
+  const hunkIds = getSectionHunkIds(section);
+  if (hunkIds.length === 0) {
+    return coveredSectionIds.has(section.id) ? null : section;
+  }
 
-export const getStopLineCount = (stop: WalkthroughStopView): NarrativeLineCount =>
-  sumSegments(getStopSegments(stop));
+  const uncoveredHunkIds = hunkIds.filter((hunkId) => !coveredHunkIds.has(hunkId));
+  if (uncoveredHunkIds.length === 0) {
+    return null;
+  }
+
+  if (uncoveredHunkIds.length === hunkIds.length) {
+    return section;
+  }
+
+  const patch = filterPatchToHunkIds(section.patch, section.id, uncoveredHunkIds);
+  return patch ? { ...section, patch } : null;
+};
+
+export const getUncoveredWalkthroughFiles = (
+  files: ReadonlyArray<ChangedFile>,
+  view: WalkthroughView,
+  showWhitespace: boolean,
+): ReadonlyArray<ChangedFile> => {
+  const coveredHunkIds = walkthroughCoveredHunkIds(view);
+  const coveredSectionIds = walkthroughCoveredSectionIds(view);
+  return files.flatMap((file) => {
+    const sections = getVisibleDiffSections(file, showWhitespace)
+      .map(({ section }) => section)
+      .map((section) => getUncoveredWalkthroughSection(section, coveredHunkIds, coveredSectionIds))
+      .filter((section): section is DiffSection => section != null);
+    if (sections.length === 0) {
+      return [];
+    }
+    return [
+      {
+        ...file,
+        fingerprint: `${file.fingerprint}:walkthrough-uncovered:${sections
+          .map((section) => section.id)
+          .join(',')}`,
+        sections,
+      },
+    ];
+  });
+};
+
+export const getUncoveredWalkthroughFileLineItems = (
+  files: ReadonlyArray<ChangedFile>,
+  view: WalkthroughView,
+  showWhitespace: boolean,
+): ReadonlyArray<{ added: number; deleted: number; path: string }> =>
+  getUncoveredWalkthroughFiles(files, view, showWhitespace).map((file) => {
+    const lineCount = getDiffLineCount(file, showWhitespace);
+    return {
+      added: lineCount.countable ? lineCount.additions : 0,
+      deleted: lineCount.countable ? lineCount.deletions : 0,
+      path: file.path,
+    };
+  });
 
 export const isWalkthroughCommittable = (walkthrough: NarrativeWalkthrough): boolean =>
   walkthrough.source.type === 'working-tree';
 
-export const collectWalkthroughSegments = (
-  walkthrough: NarrativeWalkthrough,
-): ReadonlyArray<WalkthroughSegment> => [
-  ...walkthrough.chapters.flatMap((chapter) => chapter.stops.flatMap((stop) => stop.anchors)),
-  ...walkthrough.support.flatMap((group) => group.files),
-];
-
-const groupRestByReason = (
-  rest: ReadonlyArray<WalkthroughRestView>,
-): ReadonlyArray<WalkthroughRestReason> => {
-  const groups: Array<{ files: Array<WalkthroughRestView>; reason: string }> = [];
-  const byReason = new Map<string, { files: Array<WalkthroughRestView>; reason: string }>();
-  for (const item of rest) {
+const groupSupportByReason = (
+  support: ReadonlyArray<WalkthroughSupportGroup>,
+): ReadonlyArray<WalkthroughSupportReason> => {
+  const groups: Array<{ files: Array<WalkthroughSupportGroup>; reason: string }> = [];
+  const byReason = new Map<string, { files: Array<WalkthroughSupportGroup>; reason: string }>();
+  for (const item of support) {
     let group = byReason.get(item.reason);
     if (!group) {
       group = { files: [], reason: item.reason };
@@ -108,163 +239,59 @@ const groupRestByReason = (
   return groups;
 };
 
-/** Build the UI adapter order from the direct v3 document shape. */
-export const resolveOrder = (
-  walkthrough: NarrativeWalkthrough,
-  _orderId?: string | null,
-): WalkthroughOrder | null => {
-  const phases: Array<WalkthroughPhase> = [];
-  const sequence: Array<WalkthroughOrderStop> = [];
-  const rest: Array<WalkthroughRestItem> = [];
-
-  for (const [chapterIndex, chapter] of walkthrough.chapters.entries()) {
-    phases.push({
-      blurb: chapter.blurb,
-      icon: chapter.icon,
-      id: chapter.id,
-      n: chapterIndex + 1,
-      title: chapter.title,
-    });
-    for (const stop of chapter.stops) {
-      const segmentIds = stop.anchors.map((segment) => segment.id);
-      if (segmentIds.length === 0) {
-        continue;
-      }
-      sequence.push({
-        body: stop.body,
-        id: stop.id,
-        importance: stop.importance,
-        phaseId: chapter.id,
-        segmentIds,
-        summary: stop.summary,
-        title: stop.title,
-      });
-    }
-  }
-
-  for (const group of walkthrough.support) {
-    for (const file of group.files) {
-      rest.push({
-        note: group.note ?? file.summary,
-        reason: group.title,
-        segmentId: file.id,
-      });
-    }
-  }
-
-  if (sequence.length === 0 && rest.length === 0) {
+/** Build the walkthrough view-model with globally indexed stops. */
+export const buildWalkthroughView = (walkthrough: NarrativeWalkthrough): WalkthroughView | null => {
+  if (walkthrough.chapters.length === 0) {
     return null;
   }
-
-  return {
-    id: 'walkthrough',
-    label: 'Walkthrough',
-    phases,
-    rest,
-    restBlurb: 'Changed alongside the main review path.',
-    restLabel: 'Support',
-    sequence,
-    tagline: '',
-  };
-};
-
-/**
- * Build the full view-model for one reading order: stops resolved to their
- * segments and indexed, phases populated with their stops, and "the rest"
- * resolved and grouped by reason. Stops/rest whose segment can't be found are
- * dropped (the normalizer should prevent this, but the UI stays defensive).
- */
-export const buildOrderView = (
-  walkthrough: NarrativeWalkthrough,
-  orderId?: string | null,
-): WalkthroughOrderView | null => {
-  const order = resolveOrder(walkthrough, orderId);
-  if (!order) {
-    return null;
-  }
-
-  const segmentsById = new Map(
-    collectWalkthroughSegments(walkthrough).map((segment) => [segment.id, segment]),
-  );
 
   const sequence: Array<WalkthroughStopView> = [];
-  for (const stop of order.sequence) {
-    const [segmentId, ...relatedSegmentIds] = stop.segmentIds;
-    const segment = segmentsById.get(segmentId);
-    if (segment) {
-      const relatedSegments: Array<WalkthroughSegment> = [];
-      for (const relatedSegmentId of relatedSegmentIds) {
-        const relatedSegment = segmentsById.get(relatedSegmentId);
-        if (relatedSegment) {
-          relatedSegments.push(relatedSegment);
-        }
-      }
-      sequence.push({
-        ...stop,
-        index: sequence.length,
-        relatedSegments,
-        segment,
-        segmentId,
-      });
-    }
-  }
+  const chapters = walkthrough.chapters.map((chapter) => {
+    const stops = chapter.stops.map((stop) => {
+      const view = { ...stop, chapterId: chapter.id, index: sequence.length };
+      sequence.push(view);
+      return view;
+    });
+    return { ...chapter, stops };
+  });
 
-  const phases: Array<WalkthroughPhaseView> = order.phases
-    .map((phase, phaseIndex) => ({
-      ...phase,
-      phaseIndex,
-      stops: sequence.filter((stop) => stop.phaseId === phase.id),
-    }))
-    .sort((a, b) => {
-      const aIndex = a.stops[0]?.index ?? Number.MAX_SAFE_INTEGER;
-      const bIndex = b.stops[0]?.index ?? Number.MAX_SAFE_INTEGER;
-      return aIndex === bIndex ? a.phaseIndex - b.phaseIndex : aIndex - bIndex;
-    })
-    .map(({ phaseIndex, ...phase }) => phase);
-
-  const rest: Array<WalkthroughRestView> = [];
-  for (const item of order.rest) {
-    const segment = segmentsById.get(item.segmentId);
-    if (segment) {
-      rest.push({ ...item, segment });
-    }
+  if (sequence.length === 0) {
+    return null;
   }
 
   return {
-    order,
-    phases,
-    rest,
-    restByReason: groupRestByReason(rest),
-    restTotals: sumLineCount(rest),
+    chapters,
     sequence,
-    totals: sumStopLineCount(sequence),
+    support: walkthrough.support,
+    supportByReason: groupSupportByReason(walkthrough.support),
   };
 };
 
-/** The changed file + diff section a segment anchors into, if present in the diff. */
-export type ResolvedSegmentFile = {
+/** The changed file + diff section a resolved hunk anchors into, if present in the diff. */
+export type ResolvedWalkthroughHunkFile = {
   file: ChangedFile;
   section: DiffSection;
 };
 
-/**
- * Resolve a segment to its live `ChangedFile` and `DiffSection`. Prefers the
- * anchor's `sectionId`, then falls back to the file's first visible section.
- */
-export const resolveSegmentFile = (
-  segment: WalkthroughSegment,
+export type WalkthroughHunkRun = {
+  hunks: ReadonlyArray<WalkthroughHunk>;
+  key: string;
+  resolved: ResolvedWalkthroughHunkFile;
+};
+
+/** Resolve one normalized hunk to its exact live `ChangedFile` and `DiffSection`. */
+export const resolveWalkthroughHunkFile = (
+  hunk: WalkthroughHunk,
   files: ReadonlyArray<ChangedFile>,
-  showWhitespace: boolean,
-): ResolvedSegmentFile | null => {
-  const file = files.find((candidate) => candidate.path === segment.path);
+): ResolvedWalkthroughHunkFile | null => {
+  const file = files.find((candidate) => candidate.path === hunk.path);
   if (!file) {
     return null;
   }
 
-  const section =
-    (segment.anchor.sectionId
-      ? file.sections.find((candidate) => candidate.id === segment.anchor.sectionId)
-      : undefined) ?? getFirstVisibleSection(file, showWhitespace);
+  const section = hunk.anchor.sectionId
+    ? file.sections.find((candidate) => candidate.id === hunk.anchor.sectionId)
+    : undefined;
   if (!section) {
     return null;
   }
@@ -272,15 +299,139 @@ export const resolveSegmentFile = (
   return { file, section };
 };
 
+const walkthroughHunkRunKey = (item: WalkthroughHunkGroup, hunks: ReadonlyArray<WalkthroughHunk>) =>
+  `${item.id}:${hunks.map((hunk) => hunk.id).join(',')}`;
+
+/** Resolve item hunks in authored order, coalescing adjacent hunks from the same file section. */
+export const resolveWalkthroughHunkRuns = (
+  item: WalkthroughHunkGroup,
+  files: ReadonlyArray<ChangedFile>,
+): ReadonlyArray<WalkthroughHunkRun> => {
+  const runs: Array<WalkthroughHunkRun> = [];
+  for (const hunk of item.hunks) {
+    const resolved = resolveWalkthroughHunkFile(hunk, files);
+    if (!resolved) {
+      continue;
+    }
+    const previous = runs.at(-1);
+    if (
+      previous &&
+      previous.resolved.file.path === resolved.file.path &&
+      previous.resolved.section.id === resolved.section.id
+    ) {
+      const hunks = [...previous.hunks, hunk];
+      runs[runs.length - 1] = {
+        ...previous,
+        hunks,
+        key: walkthroughHunkRunKey(item, hunks),
+      };
+    } else {
+      runs.push({
+        hunks: [hunk],
+        key: walkthroughHunkRunKey(item, [hunk]),
+        resolved,
+      });
+    }
+  }
+  return runs;
+};
+
+export const getWalkthroughRunNote = (
+  item: WalkthroughHunkGroup,
+  run: WalkthroughHunkRun,
+): string | undefined => {
+  const hunkIds = new Set(run.hunks.map((hunk) => hunk.id));
+  const notes = (item.notes ?? [])
+    .filter((note) => hunkIds.has(note.hunkId))
+    .map((note) => note.body);
+  return notes.length > 0 ? notes.join(' • ') : undefined;
+};
+
+const focusSignature = (
+  section: DiffSection,
+  hunkIds: ReadonlyArray<string>,
+  contentIdentity: string,
+) => `walkthrough:${section.id}:${hunkIds.join(',')}:${contentIdentity.length}`;
+
+/**
+ * Return the changed-file view a walkthrough stop should render for one live diff
+ * section. The patch contains exactly the provided hunk ids, in that order.
+ */
+export const focusChangedFileForHunks = (
+  file: ChangedFile,
+  section: DiffSection,
+  hunks: ReadonlyArray<WalkthroughHunk>,
+): ChangedFile | null => {
+  const sectionHunks = hunks.filter(
+    (hunk) => hunk.path === file.path && hunk.anchor.sectionId === section.id,
+  );
+  if (sectionHunks.length === 0) {
+    return null;
+  }
+
+  const hunkIds = sectionHunks.map((hunk) => hunk.id);
+  if (section.binary || (section.loadState != null && section.loadState !== 'ready')) {
+    const signature = focusSignature(
+      section,
+      hunkIds,
+      `${section.loadState ?? 'binary'}:${section.summary?.fingerprint ?? ''}:${
+        section.summary?.reason ?? ''
+      }:${section.patch.length}`,
+    );
+    return {
+      ...file,
+      fingerprint: `${file.fingerprint}:${signature}`,
+      sections: [
+        {
+          ...section,
+          summary: section.summary
+            ? {
+                ...section.summary,
+                fingerprint: section.summary.fingerprint ?? signature,
+              }
+            : undefined,
+        },
+      ],
+    };
+  }
+
+  if (section.patch.trim().length === 0) {
+    return null;
+  }
+
+  const focusedPatch = filterPatchToHunkIds(section.patch, section.id, hunkIds);
+  if (!focusedPatch) {
+    return null;
+  }
+
+  const signature = focusSignature(section, hunkIds, focusedPatch);
+
+  return {
+    ...file,
+    fingerprint: `${file.fingerprint}:${signature}`,
+    sections: [
+      {
+        ...section,
+        newFile: undefined,
+        oldFile: undefined,
+        patch: focusedPatch,
+        summary: {
+          ...section.summary,
+          fingerprint: signature,
+          reason: section.summary?.reason ?? 'Focused walkthrough hunk.',
+        },
+      },
+    ],
+  };
+};
+
 /* ------------------------------------------------------------------------- *
- * Commit composer model
+ * Commit composer model.
  *
- * The walkthrough's stops + "the rest" ARE the staged changeset. When the
- * document is committable, these helpers collapse that into one list of unique
- * changed files that reuses the narrative context two ways: files keep their
- * walkthrough section (the order's phases, plus "the rest" as a final group),
- * and each carries an optional change-type tag. The body generator reads the
- * current file selection and rewrites the machine-drafted commit body live.
+ * The walkthrough's stops + support items are the staged changeset. When the
+ * document is committable, these helpers collapse them into one list of unique
+ * changed files, grouped by the authored chapters plus a final support group.
+ * Each file can carry an optional change-type tag and commit note.
  * ------------------------------------------------------------------------- */
 
 /** One unique changed file in the commit composer, with summed line counts. */
@@ -288,19 +439,19 @@ export type CommitFile = {
   added: number;
   changeType?: WalkthroughChangeType;
   deleted: number;
+  itemId: string;
   name: string;
   /** The note the generated body uses for this file. */
   note?: string;
   path: string;
-  segmentId: string;
 };
 
-/** A group of files in the composer — one per phase, plus a final "rest" group. */
+/** A group of files in the composer — one per chapter, plus a final support group. */
 export type CommitGroup = {
   files: ReadonlyArray<CommitFile>;
   icon: WalkthroughIcon;
   id: string;
-  isRest: boolean;
+  isSupport: boolean;
   title: string;
 };
 
@@ -359,9 +510,9 @@ export const buildGenericCommitModel = (changedFiles: ReadonlyArray<ChangedFile>
     return {
       added: totals.added,
       deleted: totals.deleted,
+      itemId: `__file:${changedFile.path}`,
       name: fileBaseName(changedFile.path),
       path: changedFile.path,
-      segmentId: `__file:${changedFile.path}`,
     };
   });
 
@@ -374,7 +525,7 @@ export const buildGenericCommitModel = (changedFiles: ReadonlyArray<ChangedFile>
               files,
               icon: 'path',
               id: '__changed',
-              isRest: false,
+              isSupport: false,
               title: 'Changed files',
             },
           ]
@@ -383,92 +534,91 @@ export const buildGenericCommitModel = (changedFiles: ReadonlyArray<ChangedFile>
 };
 
 /**
- * Collapse one order's view into the unique changed files, grouped by phase with
- * "the rest" as a final group. Line counts are summed across every segment that
- * shares a path, and a path is placed in the first group that mentions it.
+ * Collapse the walkthrough view into unique changed files. Line counts are
+ * summed across every item that shares a path, and a path is placed in the first
+ * group that mentions it.
  */
 export const buildCommitModel = (
-  orderView: WalkthroughOrderView,
+  view: WalkthroughView,
   changedFiles: ReadonlyArray<ChangedFile> = [],
 ): CommitModel => {
   const totalsByPath = new Map<string, NarrativeLineCount>();
-  const addTotals = (segment: WalkthroughSegment) => {
-    const current = totalsByPath.get(segment.path) ?? { added: 0, deleted: 0 };
-    totalsByPath.set(segment.path, {
-      added: current.added + segment.added,
-      deleted: current.deleted + segment.deleted,
-    });
-  };
-  for (const stop of orderView.sequence) {
-    for (const segment of getStopSegments(stop)) {
-      addTotals(segment);
+  const addTotals = (item: WalkthroughHunkGroup) => {
+    for (const hunk of item.hunks) {
+      const current = totalsByPath.get(hunk.path) ?? { added: 0, deleted: 0 };
+      totalsByPath.set(hunk.path, {
+        added: current.added + hunk.added,
+        deleted: current.deleted + hunk.deleted,
+      });
     }
+  };
+  for (const stop of view.sequence) {
+    addTotals(stop);
   }
-  for (const item of orderView.rest) {
-    addTotals(item.segment);
+  for (const item of view.support) {
+    addTotals(item);
   }
 
   const seen = new Set<string>();
-  const toFile = (segment: WalkthroughSegment): CommitFile => {
-    const totals = totalsByPath.get(segment.path) ?? {
-      added: segment.added,
-      deleted: segment.deleted,
-    };
+  const toFile = (item: WalkthroughHunkGroup, path: string): CommitFile => {
+    const totals = totalsByPath.get(path) ?? { added: 0, deleted: 0 };
     return {
       added: totals.added,
-      changeType: segment.changeType,
+      changeType: item.changeType,
       deleted: totals.deleted,
-      name: fileBaseName(segment.path),
-      note: segment.commitNote ?? segment.summary,
-      path: segment.path,
-      segmentId: segment.id,
+      itemId: item.id,
+      name: walkthroughFileName(path),
+      note: item.commitNote ?? item.summary,
+      path,
     };
   };
 
   const files: Array<CommitFile> = [];
   const groups: Array<CommitGroup> = [];
 
-  for (const phase of orderView.phases) {
-    const phaseFiles: Array<CommitFile> = [];
-    for (const stop of phase.stops) {
-      for (const segment of getStopSegments(stop)) {
-        if (seen.has(segment.path)) {
+  for (const chapter of view.chapters) {
+    const chapterFiles: Array<CommitFile> = [];
+    for (const stop of chapter.stops) {
+      for (const path of walkthroughItemPaths(stop)) {
+        if (seen.has(path)) {
           continue;
         }
-        seen.add(segment.path);
-        const file = toFile(segment);
-        phaseFiles.push(file);
+        seen.add(path);
+        const file = toFile(stop, path);
+        chapterFiles.push(file);
         files.push(file);
       }
     }
-    if (phaseFiles.length > 0) {
+    if (chapterFiles.length > 0) {
       groups.push({
-        files: phaseFiles,
-        icon: phase.icon,
-        id: phase.id,
-        isRest: false,
-        title: phase.title,
+        files: chapterFiles,
+        icon: chapter.icon,
+        id: chapter.id,
+        isSupport: false,
+        title: chapter.title,
       });
     }
   }
 
-  const restFiles: Array<CommitFile> = [];
-  for (const item of orderView.rest) {
-    if (seen.has(item.segment.path)) {
-      continue;
+  const supportFiles: Array<CommitFile> = [];
+  for (const item of view.support) {
+    for (const path of walkthroughItemPaths(item)) {
+      if (seen.has(path)) {
+        continue;
+      }
+      seen.add(path);
+      const file = toFile(item, path);
+      supportFiles.push(file);
+      files.push(file);
     }
-    seen.add(item.segment.path);
-    const file = toFile(item.segment);
-    restFiles.push(file);
-    files.push(file);
   }
-  if (restFiles.length > 0) {
+  if (supportFiles.length > 0) {
     groups.push({
-      files: restFiles,
+      files: supportFiles,
       icon: 'path',
-      id: '__rest',
-      isRest: true,
-      title: orderView.order.restLabel,
+      id: '__support',
+      isSupport: true,
+      title: 'Support',
     });
   }
 
@@ -482,10 +632,10 @@ export const buildCommitModel = (
     const file = {
       added: totals.added,
       deleted: totals.deleted,
+      itemId: `__file:${changedFile.path}`,
       name: fileBaseName(changedFile.path),
       note: 'Not included in the generated walkthrough.',
       path: changedFile.path,
-      segmentId: `__file:${changedFile.path}`,
     };
     missingFiles.push(file);
     files.push(file);
@@ -495,7 +645,7 @@ export const buildCommitModel = (
       files: missingFiles,
       icon: 'path',
       id: '__missing',
-      isRest: true,
+      isSupport: true,
       title: 'Other changes',
     });
   }
@@ -503,13 +653,15 @@ export const buildCommitModel = (
   return { files, groups };
 };
 
-export const granularityLabel: Record<WalkthroughSegment['granularity'], string> = {
-  file: 'whole file',
-  hunk: 'hunk',
-  line: 'line',
-};
+export const getCommitSelectionPaths = (
+  view: WalkthroughView | null,
+  changedFiles: ReadonlyArray<ChangedFile>,
+): ReadonlyArray<string> =>
+  (view ? buildCommitModel(view, changedFiles) : buildGenericCommitModel(changedFiles)).files.map(
+    (file) => file.path,
+  );
 
-export const importanceLabel: Record<WalkthroughOrderStop['importance'], string> = {
+export const importanceLabel: Record<WalkthroughStop['importance'], string> = {
   context: 'Context',
   critical: 'Critical',
   normal: 'Review',

--- a/src/lib/review-command-target.ts
+++ b/src/lib/review-command-target.ts
@@ -1,0 +1,42 @@
+import type { ChangedFile, ReviewSource } from '../types.ts';
+import type { ReviewIdentity } from './app-types.ts';
+import { getFileReviewIdentity } from './review-identity.ts';
+import { getSourceKey } from './source.ts';
+
+export type ReviewCommandTarget = {
+  file: ChangedFile;
+  reviewIdentity: ReviewIdentity;
+  sourceKey: string;
+};
+
+export const createReviewCommandTarget = (
+  source: ReviewSource,
+  file: ChangedFile,
+  reviewIdentity: ReviewIdentity = getFileReviewIdentity(file),
+): ReviewCommandTarget => ({
+  file,
+  reviewIdentity,
+  sourceKey: getSourceKey(source),
+});
+
+export const resolveReviewCommandTarget = ({
+  activeTarget,
+  files,
+  selectedPath,
+  source,
+  useActiveTarget,
+}: {
+  activeTarget: ReviewCommandTarget | null;
+  files: ReadonlyArray<ChangedFile>;
+  selectedPath: string | null;
+  source: ReviewSource;
+  useActiveTarget: boolean;
+}): ReviewCommandTarget | null => {
+  const sourceKey = getSourceKey(source);
+  if (useActiveTarget && activeTarget?.sourceKey === sourceKey) {
+    return activeTarget;
+  }
+
+  const file = selectedPath ? files.find((candidate) => candidate.path === selectedPath) : null;
+  return file ? createReviewCommandTarget(source, file) : null;
+};

--- a/src/lib/review-identity.ts
+++ b/src/lib/review-identity.ts
@@ -1,0 +1,48 @@
+import type { ChangedFile } from '../types.ts';
+import type { ReviewIdentity } from './app-types.ts';
+
+export const getFileReviewIdentity = (file: ChangedFile): ReviewIdentity => ({
+  fingerprint: file.fingerprint,
+  key: file.path,
+});
+
+export const getReviewIdentity = (
+  file: ChangedFile,
+  identityByPath?: ReadonlyMap<string, ReviewIdentity>,
+): ReviewIdentity => identityByPath?.get(file.path) ?? getFileReviewIdentity(file);
+
+export const isReviewIdentityViewed = (
+  viewed: Readonly<Record<string, string>>,
+  identity: ReviewIdentity,
+): boolean => viewed[identity.key] === identity.fingerprint;
+
+export const updateReviewIdentityViewed = (
+  viewed: Readonly<Record<string, string>>,
+  identity: ReviewIdentity,
+  isViewed: boolean,
+): Record<string, string> => {
+  if (isViewed) {
+    const next = { ...viewed };
+    delete next[identity.key];
+    return next;
+  }
+
+  return {
+    ...viewed,
+    [identity.key]: identity.fingerprint,
+  };
+};
+
+export const updateReviewIdentityCollapsed = (
+  collapsed: ReadonlySet<string>,
+  identity: ReviewIdentity,
+  isCollapsed: boolean,
+): Set<string> => {
+  const next = new Set(collapsed);
+  if (isCollapsed) {
+    next.delete(identity.key);
+  } else {
+    next.add(identity.key);
+  }
+  return next;
+};

--- a/src/lib/review-identity.ts
+++ b/src/lib/review-identity.ts
@@ -19,9 +19,9 @@ export const isReviewIdentityViewed = (
 export const updateReviewIdentityViewed = (
   viewed: Readonly<Record<string, string>>,
   identity: ReviewIdentity,
-  isViewed: boolean,
+  currentlyViewed: boolean,
 ): Record<string, string> => {
-  if (isViewed) {
+  if (currentlyViewed) {
     const next = { ...viewed };
     delete next[identity.key];
     return next;
@@ -36,10 +36,10 @@ export const updateReviewIdentityViewed = (
 export const updateReviewIdentityCollapsed = (
   collapsed: ReadonlySet<string>,
   identity: ReviewIdentity,
-  isCollapsed: boolean,
+  currentlyCollapsed: boolean,
 ): Set<string> => {
   const next = new Set(collapsed);
-  if (isCollapsed) {
+  if (currentlyCollapsed) {
     next.delete(identity.key);
   } else {
     next.add(identity.key);

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,6 +248,8 @@ export type WalkthroughHunk = {
   deletionEnd?: number;
   deletionStart?: number;
   id: string;
+  /** `synthetic` hunks represent binary, deferred, or metadata-only review units. */
+  kind?: 'patch' | 'synthetic';
   oldPath?: string;
   path: string;
   status: GitFileStatus;

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,37 +197,30 @@ export type TerminalHelperStatus = {
 };
 
 /**
- * Narrative Walkthrough. The authored shape is deliberately direct: chapters
- * contain stops, and stops point at one or more slices of the live diff. The
- * diff content itself is never embedded: an anchor target points into the live
- * diff Codiff computes from the repository.
+ * Narrative Walkthrough. The agent authors chapters, stops, and support groups
+ * around deterministic hunk ids. Codiff resolves those ids against the live diff
+ * and computes file paths, anchors, and line counts.
  */
 export type WalkthroughIcon = 'bug' | 'wrench' | 'path' | 'flask' | 'beaker' | 'doc' | 'gear';
 
-/** Where a segment points into the live diff. Mirrors the comment-anchor fields. */
+/** Where a walkthrough hunk points into the live diff. */
 export type WalkthroughAnchor = {
   /** Human-readable location, e.g. 'src/App.tsx:311' or 'src/hooks/useHunkOrder.ts (new)'. */
   display: string;
-  /** End line on the {@link side} (inclusive). Omitted for 'file' granularity. */
+  /** End line on the {@link side} (inclusive). */
   endLine?: number;
   /** Matches {@link DiffSection.id}, e.g. 'src/App.tsx:staged'. */
   sectionId?: string;
   sectionKind?: DiffSection['kind'];
   side?: 'additions' | 'deletions' | 'both';
-  /** Start line on the {@link side}. Omitted for 'file' granularity. */
+  /** Start line on the {@link side}. */
   startLine?: number;
 };
 
-/** A review comment seeded by the walkthrough, anchored like a live comment. */
-export type WalkthroughSeedComment = {
-  author?: string;
-  /** May be '' to seed an empty composer at this anchor. */
+/** A short header note rendered above one focused walkthrough hunk diff. */
+export type WalkthroughHunkNote = {
   body: string;
-  id: string;
-  lineNumber: number;
-  side: 'additions' | 'deletions';
-  startLineNumber?: number;
-  startSide?: 'additions' | 'deletions';
+  hunkId: string;
 };
 
 /**
@@ -245,29 +238,55 @@ export type WalkthroughChangeType =
   | 'i18n'
   | 'docs';
 
-/** One addressable slice of the live diff with its line counts. */
-export type WalkthroughAnchorTarget = {
+/** One resolved hunk selected by a walkthrough item, in agent-requested order. */
+export type WalkthroughHunk = {
   added: number;
+  additionEnd?: number;
+  additionStart?: number;
   anchor: WalkthroughAnchor;
-  /** Change-type tag for the commit composer's file row. */
-  changeType?: WalkthroughChangeType;
-  comments?: ReadonlyArray<WalkthroughSeedComment>;
-  /** One-line note the generated commit body uses for this file (falls back to {@link summary}). */
-  commitNote?: string;
   deleted: number;
-  granularity: 'line' | 'hunk' | 'file';
-  /** Stable within the document, e.g. 's1'. */
+  deletionEnd?: number;
+  deletionStart?: number;
   id: string;
   oldPath?: string;
   path: string;
   status: GitFileStatus;
+};
+
+/** Shared hunk-backed fields for a stop or support group. */
+export type WalkthroughHunkGroup = {
+  added: number;
+  /** Change-type tag for the commit composer's file row. */
+  changeType?: WalkthroughChangeType;
+  /** One-line note the generated commit body uses for this file (falls back to {@link summary}). */
+  commitNote?: string;
+  deleted: number;
+  /** Deterministic hunk ids selected by the authoring agent, in display order. */
+  hunkIds: ReadonlyArray<string>;
+  /** Resolved hunks with Codiff-computed anchors, file paths, status, and line counts. */
+  hunks: ReadonlyArray<WalkthroughHunk>;
+  /** Stable within the document, e.g. 's1'. */
+  id: string;
+  /** Optional header notes for individual hunk ids in this item. */
+  notes?: ReadonlyArray<WalkthroughHunkNote>;
   /** Short, plain-text gist of the slice. */
   summary?: string;
-  /** Default framing; an order's stop may override it. */
   title?: string;
 };
 
-export type WalkthroughSegment = WalkthroughAnchorTarget;
+/** One stop in the main walkthrough path. */
+export type WalkthroughStop = WalkthroughHunkGroup & {
+  importance: 'critical' | 'normal' | 'context';
+  /** Agent narration (markdown / inline code). */
+  prose: string;
+};
+
+/** A changed hunk group kept off the main path. */
+export type WalkthroughSupportGroup = WalkthroughHunkGroup & {
+  note?: string;
+  /** Why it is off the path, e.g. 'Generated' | 'Lockfile' | 'Snapshot' | 'Mechanical'. */
+  reason: string;
+};
 
 /** A named chapter in the walkthrough. */
 export type WalkthroughChapter = {
@@ -276,66 +295,6 @@ export type WalkthroughChapter = {
   id: string;
   stops: ReadonlyArray<WalkthroughStop>;
   title: string;
-};
-
-/** One stop in the walkthrough: prose plus the live diff anchors it covers. */
-export type WalkthroughStop = {
-  anchors: ReadonlyArray<WalkthroughAnchorTarget>;
-  /** Short narration shown above the live diff. */
-  body: string;
-  id: string;
-  importance: 'critical' | 'normal' | 'context';
-  /** One-line scan label shown in the sidebar and above the diff. */
-  summary: string;
-  title: string;
-};
-
-/** A file changed alongside the work but kept off the narrative path. */
-export type WalkthroughSupportGroup = {
-  files: ReadonlyArray<WalkthroughAnchorTarget>;
-  id: string;
-  note?: string;
-  title: string;
-};
-
-/** Adapter type used by the current walkthrough UI. */
-export type WalkthroughPhase = {
-  blurb: string;
-  icon: WalkthroughIcon;
-  id: string;
-  /** 1-based position. */
-  n: number;
-  title: string;
-};
-
-/** Adapter type used by the current walkthrough UI. */
-export type WalkthroughOrderStop = {
-  body: string;
-  id: string;
-  importance: 'critical' | 'normal' | 'context';
-  phaseId: string;
-  segmentIds: ReadonlyArray<string>;
-  summary: string;
-  title: string;
-};
-
-/** Adapter type used by the current walkthrough UI. */
-export type WalkthroughRestItem = {
-  note?: string;
-  reason: string;
-  segmentId: string;
-};
-
-/** Adapter type used by the current walkthrough UI. */
-export type WalkthroughOrder = {
-  id: string;
-  label: string;
-  phases: ReadonlyArray<WalkthroughPhase>;
-  rest: ReadonlyArray<WalkthroughRestItem>;
-  restBlurb: string;
-  restLabel: string;
-  sequence: ReadonlyArray<WalkthroughOrderStop>;
-  tagline: string;
 };
 
 /**
@@ -379,7 +338,7 @@ export type NarrativeWalkthrough = {
   source: ReviewSource;
   support: ReadonlyArray<WalkthroughSupportGroup>;
   title: string;
-  version: 3;
+  version: 4;
 };
 
 export type NarrativeWalkthroughResult =
@@ -525,7 +484,6 @@ export type CodiffPreferences = {
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
-  walkthroughOrder: string;
   wordWrap: boolean;
 };
 

--- a/src/walkthrough.css
+++ b/src/walkthrough.css
@@ -27,7 +27,8 @@
   gap: 12px;
   min-height: 0;
   overflow: auto;
-  padding: 12px 8px 0;
+  padding: 12px 8px 16px;
+  scroll-padding-block-end: 16px;
 }
 .wt-toc-chapter {
   display: flex;
@@ -159,16 +160,22 @@
 .wt-toc-stop.visited .wt-toc-num {
   color: var(--muted);
 }
-.wt-toc-meta {
-  align-items: center;
-  display: flex;
-  gap: 6px;
+.wt-toc-file-list {
+  display: grid;
+  gap: 3px;
   margin-top: 4px;
+  min-width: 0;
+  width: 100%;
+}
+.wt-toc-file-row {
+  align-items: center;
+  display: grid;
+  gap: 6px;
+  grid-template-columns: minmax(0, 1fr) auto;
   min-width: 0;
 }
 .wt-toc-file {
   color: var(--muted);
-  flex: 1;
   font: 11px/1 var(--font-mono);
   min-width: 0;
   overflow: hidden;
@@ -178,10 +185,9 @@
 .wt-toc-count {
   color: var(--muted);
   display: inline-flex;
-  flex: none;
   font: 700 10px/1 var(--font-mono);
   gap: 4px;
-  margin-left: auto;
+  justify-self: end;
 }
 .wt-toc-count .added {
   color: var(--diff-addition);
@@ -258,16 +264,6 @@
   gap: 12px;
   margin: 0 0 12px;
 }
-/* ---- The focused stop's diff (the real ReviewCodeView, scoped) ------------ */
-.wt-stop-diff {
-  border: 1px solid var(--file-border);
-  border-radius: 14px;
-  overflow: clip;
-}
-.wt-stop-diff .review {
-  height: auto;
-}
-
 /* ---- Variation C — hybrid arc timeline ------------------------------------ */
 .wt-hybrid {
   display: flex;
@@ -297,7 +293,7 @@
   height: 32px;
   justify-content: center;
   position: relative;
-  top: 11px;
+  top: 16px;
   transition:
     background 120ms ease,
     color 120ms ease;
@@ -354,7 +350,7 @@
 .wt-arc-join {
   align-self: flex-start;
   border-top: 2px solid var(--file-border);
-  margin-top: 33px;
+  margin-top: 44px;
   width: 26px;
 }
 .wt-arc-join.dashed {
@@ -367,21 +363,23 @@
   flex-direction: column;
   gap: 8px;
 }
-.wt-arc-chapter.rest {
+.wt-arc-chapter.support {
   align-items: center;
 }
 .wt-arc-chapter-label {
   align-items: center;
   color: var(--muted);
   display: flex;
+  flex-wrap: nowrap;
   font: 700 10px/1 var(--font-sans);
   gap: 4px;
   justify-content: center;
   letter-spacing: 0.03em;
-  max-width: 92px;
+  line-height: 1;
+  max-width: none;
   min-height: 13px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow: visible;
+  text-align: center;
   text-transform: uppercase;
   white-space: nowrap;
 }
@@ -455,37 +453,30 @@
   overflow: auto;
 }
 
-/* The focused stop / full-context reader: the header and the real diff share a
-   single scroll, so the header scrolls away as you move down into the diff. The
-   stop is the scroll container; the CodeView renders at its natural height
-   instead of scrolling inside its own bounded box. */
 .wt-stop {
   display: flex;
   flex: 1;
   flex-direction: column;
   min-height: 0;
-  overflow-y: auto;
-  /* Anchor offsetTop for the sequence blocks to this scroll container so the
-     scroll-driven focus maths stay relative to it. */
+  overflow: hidden;
   position: relative;
 }
-.wt-stop-header {
+.wt-diff-surface .code-view {
+  contain: layout paint;
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+}
+.wt-stop-block-header {
   flex: none;
   margin: 16px auto;
   max-width: 820px;
   padding: 0 24px;
   width: 100%;
 }
-.wt-stop-diff-host {
-  flex: none;
-  position: relative;
-}
-/* Let the diff grow to its content height so the outer .wt-stop does the
-   scrolling, rather than the CodeView scrolling within a fixed-height box. */
-.wt-stop .code-view {
-  contain: none;
-  height: auto;
-  overflow: visible;
+.wt-stop-block-header.current {
+  box-shadow: inset 3px 0 0 var(--tree-selection-focus);
 }
 
 /* The whole order as one continuous scroll: each stop is a block (narration +
@@ -496,26 +487,6 @@
 }
 .wt-stop-block:first-child {
   border-top: 0;
-}
-.wt-stop-placeholder {
-  border-top: 1px solid var(--file-border);
-  contain: layout paint;
-  flex: none;
-  pointer-events: none;
-}
-.wt-stop-placeholder:first-child {
-  border-top: 0;
-}
-.wt-stop-block.current > .wt-stop-header {
-  box-shadow: inset 3px 0 0 var(--tree-selection-focus);
-}
-/* Leave room below the last diff so the final stop can scroll up to the top and
-   become the focused stop, rather than being stuck at the bottom of the page. */
-.wt-sequence::after {
-  content: '';
-  display: block;
-  flex: none;
-  height: 55vh;
 }
 
 .wt-upnext {
@@ -586,11 +557,6 @@
 }
 .wt-upnext-action > .wt-upnext-back-icon {
   margin-left: 0;
-}
-
-/* ---- "The rest" — overview (bundle landing) ------------------------------- */
-.wt-support-diffs {
-  flex: none;
 }
 
 /* ---- Arc bundle node ("supporting files") --------------------------------- */

--- a/src/walkthrough/narrative-walkthrough.schema.json
+++ b/src/walkthrough/narrative-walkthrough.schema.json
@@ -53,7 +53,7 @@
                   "items": {
                     "type": "string"
                   },
-                  "maxItems": 3,
+                  "maxItems": 14,
                   "minItems": 1,
                   "type": "array"
                 },
@@ -141,7 +141,7 @@
             "items": {
               "type": "string"
             },
-            "maxItems": 3,
+            "maxItems": 14,
             "minItems": 1,
             "type": "array"
           },

--- a/src/walkthrough/narrative-walkthrough.schema.json
+++ b/src/walkthrough/narrative-walkthrough.schema.json
@@ -1,9 +1,17 @@
 {
   "additionalProperties": false,
   "properties": {
-    "agent": {
-      "enum": ["codex", "claude"],
-      "type": "string"
+    "commit": {
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     },
     "chapters": {
       "items": {
@@ -23,149 +31,67 @@
             "items": {
               "additionalProperties": false,
               "properties": {
-                "anchors": {
-                  "items": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "added": {
-                        "type": "number"
-                      },
-                      "anchor": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "display": {
-                            "type": "string"
-                          },
-                          "endLine": {
-                            "type": "number"
-                          },
-                          "sectionId": {
-                            "type": "string"
-                          },
-                          "sectionKind": {
-                            "enum": ["commit", "pull-request", "staged", "unstaged"],
-                            "type": "string"
-                          },
-                          "side": {
-                            "enum": ["additions", "deletions", "both"],
-                            "type": "string"
-                          },
-                          "startLine": {
-                            "type": "number"
-                          }
-                        },
-                        "required": ["display"],
-                        "type": "object"
-                      },
-                      "changeType": {
-                        "enum": [
-                          "fix",
-                          "feature",
-                          "refactor",
-                          "test",
-                          "generated",
-                          "lockfile",
-                          "snapshot",
-                          "i18n",
-                          "docs"
-                        ],
-                        "type": "string"
-                      },
-                      "comments": {
-                        "items": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "author": {
-                              "type": "string"
-                            },
-                            "body": {
-                              "type": "string"
-                            },
-                            "id": {
-                              "type": "string"
-                            },
-                            "lineNumber": {
-                              "type": "number"
-                            },
-                            "side": {
-                              "enum": ["additions", "deletions"],
-                              "type": "string"
-                            },
-                            "startLineNumber": {
-                              "type": "number"
-                            },
-                            "startSide": {
-                              "enum": ["additions", "deletions"],
-                              "type": "string"
-                            }
-                          },
-                          "required": ["id", "body", "side", "lineNumber"],
-                          "type": "object"
-                        },
-                        "type": "array"
-                      },
-                      "commitNote": {
-                        "type": "string"
-                      },
-                      "deleted": {
-                        "type": "number"
-                      },
-                      "granularity": {
-                        "enum": ["line", "hunk", "file"],
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "string"
-                      },
-                      "oldPath": {
-                        "type": "string"
-                      },
-                      "path": {
-                        "type": "string"
-                      },
-                      "status": {
-                        "enum": ["added", "deleted", "modified", "renamed", "untracked"],
-                        "type": "string"
-                      },
-                      "summary": {
-                        "type": "string"
-                      },
-                      "title": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "path",
-                      "status",
-                      "granularity",
-                      "anchor",
-                      "added",
-                      "deleted"
-                    ],
-                    "type": "object"
-                  },
-                  "maxItems": 8,
-                  "type": "array"
-                },
-                "body": {
+                "changeType": {
+                  "enum": [
+                    "fix",
+                    "feature",
+                    "refactor",
+                    "test",
+                    "generated",
+                    "lockfile",
+                    "snapshot",
+                    "i18n",
+                    "docs"
+                  ],
                   "type": "string"
+                },
+                "commitNote": {
+                  "type": "string"
+                },
+                "hunkIds": {
+                  "description": "Deterministic hunk ids from the repository digest, in the display order Codiff should render them.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 3,
+                  "minItems": 1,
+                  "type": "array"
                 },
                 "id": {
                   "type": "string"
                 },
-                "importance": {
-                  "enum": ["critical", "normal", "context"],
-                  "type": "string"
+                "notes": {
+                  "description": "Optional short header notes for selected hunk ids. Codiff renders each note under that focused diff header.",
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "body": {
+                        "type": "string"
+                      },
+                      "hunkId": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["hunkId", "body"],
+                    "type": "object"
+                  },
+                  "type": "array"
                 },
                 "summary": {
                   "type": "string"
                 },
                 "title": {
                   "type": "string"
+                },
+                "importance": {
+                  "enum": ["critical", "normal", "context"],
+                  "type": "string"
+                },
+                "prose": {
+                  "type": "string"
                 }
               },
-              "required": ["id", "title", "summary", "body", "importance", "anchors"],
+              "required": ["id", "hunkIds", "importance", "prose"],
               "type": "object"
             },
             "maxItems": 14,
@@ -182,181 +108,77 @@
       "maxItems": 6,
       "type": "array"
     },
-    "commit": {
-      "additionalProperties": false,
-      "properties": {
-        "body": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "context": {
-      "type": "object"
-    },
     "focus": {
-      "type": "string"
-    },
-    "generatedAt": {
       "type": "string"
     },
     "kind": {
       "const": "narrative",
       "type": "string"
     },
-    "meta": {
-      "type": "string"
-    },
-    "repo": {
-      "additionalProperties": false,
-      "properties": {
-        "branch": {
-          "type": ["string", "null"]
-        },
-        "root": {
-          "type": "string"
-        }
-      },
-      "required": ["root", "branch"],
-      "type": "object"
-    },
-    "source": {
-      "type": "object"
-    },
     "support": {
       "items": {
         "additionalProperties": false,
         "properties": {
+          "changeType": {
+            "enum": [
+              "fix",
+              "feature",
+              "refactor",
+              "test",
+              "generated",
+              "lockfile",
+              "snapshot",
+              "i18n",
+              "docs"
+            ],
+            "type": "string"
+          },
+          "commitNote": {
+            "type": "string"
+          },
+          "hunkIds": {
+            "description": "Deterministic hunk ids from the repository digest, in the display order Codiff should render them.",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 3,
+            "minItems": 1,
+            "type": "array"
+          },
           "id": {
             "type": "string"
           },
-          "files": {
+          "notes": {
+            "description": "Optional short header notes for selected hunk ids. Codiff renders each note under that focused diff header.",
             "items": {
               "additionalProperties": false,
               "properties": {
-                "added": {
-                  "type": "number"
-                },
-                "anchor": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "display": {
-                      "type": "string"
-                    },
-                    "endLine": {
-                      "type": "number"
-                    },
-                    "sectionId": {
-                      "type": "string"
-                    },
-                    "sectionKind": {
-                      "enum": ["commit", "pull-request", "staged", "unstaged"],
-                      "type": "string"
-                    },
-                    "side": {
-                      "enum": ["additions", "deletions", "both"],
-                      "type": "string"
-                    },
-                    "startLine": {
-                      "type": "number"
-                    }
-                  },
-                  "required": ["display"],
-                  "type": "object"
-                },
-                "changeType": {
-                  "enum": [
-                    "fix",
-                    "feature",
-                    "refactor",
-                    "test",
-                    "generated",
-                    "lockfile",
-                    "snapshot",
-                    "i18n",
-                    "docs"
-                  ],
+                "body": {
                   "type": "string"
                 },
-                "comments": {
-                  "items": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "author": {
-                        "type": "string"
-                      },
-                      "body": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "string"
-                      },
-                      "lineNumber": {
-                        "type": "number"
-                      },
-                      "side": {
-                        "enum": ["additions", "deletions"],
-                        "type": "string"
-                      },
-                      "startLineNumber": {
-                        "type": "number"
-                      },
-                      "startSide": {
-                        "enum": ["additions", "deletions"],
-                        "type": "string"
-                      }
-                    },
-                    "required": ["id", "body", "side", "lineNumber"],
-                    "type": "object"
-                  },
-                  "type": "array"
-                },
-                "commitNote": {
-                  "type": "string"
-                },
-                "deleted": {
-                  "type": "number"
-                },
-                "granularity": {
-                  "enum": ["line", "hunk", "file"],
-                  "type": "string"
-                },
-                "id": {
-                  "type": "string"
-                },
-                "oldPath": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "string"
-                },
-                "status": {
-                  "enum": ["added", "deleted", "modified", "renamed", "untracked"],
-                  "type": "string"
-                },
-                "summary": {
-                  "type": "string"
-                },
-                "title": {
+                "hunkId": {
                   "type": "string"
                 }
               },
-              "required": ["id", "path", "status", "granularity", "anchor", "added", "deleted"],
+              "required": ["hunkId", "body"],
               "type": "object"
             },
             "type": "array"
           },
-          "note": {
+          "summary": {
             "type": "string"
           },
           "title": {
             "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
           }
         },
-        "required": ["id", "title", "files"],
+        "required": ["id", "hunkIds", "reason"],
         "type": "object"
       },
       "type": "array"
@@ -365,20 +187,10 @@
       "type": "string"
     },
     "version": {
-      "const": 3,
+      "const": 4,
       "type": "number"
     }
   },
-  "required": [
-    "version",
-    "kind",
-    "agent",
-    "title",
-    "focus",
-    "repo",
-    "source",
-    "chapters",
-    "support"
-  ],
+  "required": ["version", "kind", "title", "focus", "chapters"],
   "type": "object"
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,14 @@ export default defineConfig({
     extends: [nkzw],
     ignorePatterns: ['bin/', 'dist/', 'electron/', 'vite.config.ts.timestamp-*'],
     options: { typeAware: true, typeCheck: true },
+    overrides: [
+      {
+        env: {
+          node: true,
+        },
+        files: ['shared/narrative-walkthrough-diff.cjs'],
+      },
+    ],
   },
   plugins: [
     babel({


### PR DESCRIPTION
## Summary

This moves narrative walkthroughs from agent-authored file anchors to deterministic diff hunk IDs.
My experience has been getting mostly full file diffs or near full file diffs with no explicit order for information flow in the code; just order for reviewing files. When information flow within/across files matters, this makes reviewing slow.  Switching to a hunk-based approach gives much better granularity and review order in my tests. When full file diffs are needed, they happen naturally.

The agent now provides review judgment: which hunks matter, how they should be grouped, what order to read them in, and the prose for each step.

Another problem I noticed is that information the agent provides can mismatch what is displayed, especially lines added/removed and other computed metadata. This changes so anything that can be computed deterministically is not asked of the agent. Codiff computes the diff facts from the live diff: paths, statuses, anchors, line counts, labels, focused patches, and uncovered Support items (rest -> Support; any hunks that were not assigned to be explicitly reviewed are shown there).

Another change is making walkthrough renders through a single review surface, avoiding many separate diff views. For large diffs I was getting a lot of perf problems and slow scrolling/typing because each diff item was an independently rendered unit.

I'm still testing and will do some cleaning up, but the core of the change is there and seems to be working well. I have a few more things to clean up and test, but wanted to get this out for early feedback. Also happy to just close this or separate out just the single renderer change since that's still useful perf improvement.

<img width="1491" height="1167" alt="image" src="https://github.com/user-attachments/assets/5beb5dc2-93a0-4309-a8fb-afd45c784e1a" />

<img width="1509" height="1167" alt="image" src="https://github.com/user-attachments/assets/49db683f-2139-46c2-bea0-8b13dc1b49a2" />

<img width="1509" height="1167" alt="image" src="https://github.com/user-attachments/assets/185172e6-c527-4db0-bcb8-fd8e997b3594" />


## What changed

- Added v4 walkthrough JSON based on `hunkIds`
- Render walkthrough stops as focused hunk blocks in one review surface
- Preserve authored review order while grouping adjacent hunks from the same file
- Add Support mode for generated, mechanical, omitted, and uncovered hunks
- Remove agent-authored inline comments from the walkthrough schema
- Key viewed/collapsed state by review identity so repeated file views work correctly

## Refactored

- Removed walkthrough order preference, menu, IPC, and config schema; walkthroughs now use one authored order
- Extracted shared hunk diff utilities into `shared/narrative-walkthrough-diff.cjs`
- Extracted Electron walkthrough schema and constants into `electron/narrative-walkthrough-schema.cjs`
- Extracted review identity and review command target helpers
- Extracted test helpers for fixtures, React rendering, CLI fake commands, and the CodeView mock
- Removed unused walkthrough totals and block note override plumbing

## Validation

- `vp check --fix`
- `vp test`
- `vp build`
