### PR TITLE
Mute viewed files in the tree sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -388,6 +388,42 @@ export default function App() {
     }, 1200);
   }, []);
 
+  const setFileViewedState = useCallback(
+    (repositoryState: RepositoryState, file: ChangedFile, nextViewed: boolean) => {
+      setViewed((current) => {
+        if (!nextViewed) {
+          const next = { ...current };
+          delete next[file.path];
+          if (repositoryState.source.type === 'working-tree') {
+            writeViewed(repositoryState.root, next);
+          }
+          return next;
+        }
+
+        const next = {
+          ...current,
+          [file.path]: file.fingerprint,
+        };
+        if (repositoryState.source.type === 'working-tree') {
+          writeViewed(repositoryState.root, next);
+        }
+        return next;
+      });
+
+      setCollapsed((current) => {
+        const next = new Set(current);
+        if (nextViewed) {
+          next.add(file.path);
+        } else {
+          next.delete(file.path);
+        }
+        return next;
+      });
+      bumpItemVersion(file.path);
+    },
+    [bumpItemVersion],
+  );
+
   const saveCurrentSourceSession = useCallback(() => {
     const currentState = stateRef.current;
     if (!currentState) {
@@ -1464,36 +1500,7 @@ export default function App() {
           }
 
           const isViewed = viewedRef.current[file.path] === file.fingerprint;
-          setViewed((current) => {
-            if (isViewed) {
-              const next = { ...current };
-              delete next[file.path];
-              if (currentState.source.type === 'working-tree') {
-                writeViewed(currentState.root, next);
-              }
-              return next;
-            }
-
-            const next = {
-              ...current,
-              [file.path]: file.fingerprint,
-            };
-            if (currentState.source.type === 'working-tree') {
-              writeViewed(currentState.root, next);
-            }
-            return next;
-          });
-
-          setCollapsed((current) => {
-            const next = new Set(current);
-            if (isViewed) {
-              next.delete(file.path);
-            } else {
-              next.add(file.path);
-            }
-            return next;
-          });
-          bumpItemVersion(file.path);
+          setFileViewedState(currentState, file, !isViewed);
         },
         id: 'toggle-viewed',
         title: 'Toggle Viewed',
@@ -1584,6 +1591,7 @@ export default function App() {
     openDiffSearch,
     openSelectedFile,
     reloadWindow,
+    setFileViewedState,
     toggleSidebar,
     toggleWordWrap,
   ]);
@@ -1656,40 +1664,9 @@ export default function App() {
         return;
       }
 
-      setViewed((current) => {
-        if (isViewed) {
-          const next = { ...current };
-          delete next[file.path];
-          if (state.source.type === 'working-tree') {
-            writeViewed(state.root, next);
-          }
-          return next;
-        }
-
-        const next = {
-          ...current,
-          [file.path]: file.fingerprint,
-        };
-        if (state.source.type === 'working-tree') {
-          writeViewed(state.root, next);
-        }
-        return next;
-      });
-
-      setCollapsed((current) => {
-        if (isViewed) {
-          const next = new Set(current);
-          next.delete(file.path);
-          return next;
-        }
-
-        const next = new Set(current);
-        next.add(file.path);
-        return next;
-      });
-      bumpItemVersion(file.path);
+      setFileViewedState(state, file, !isViewed);
     },
-    [bumpItemVersion, state],
+    [setFileViewedState, state],
   );
 
   const createComment = useCallback(
@@ -2235,6 +2212,7 @@ export default function App() {
           searchQuery={sidebarMode === 'history' ? historySearchQuery : fileSearchQuery}
           selectedPath={visibleSelectedPath}
           showWhitespace={showWhitespace}
+          viewed={viewed}
           walkthroughError={walkthroughError}
           walkthroughLoading={walkthroughLoading}
           walkthroughUnread={walkthroughUnread}

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -713,6 +713,56 @@ test('repository reload colors only git status glyphs for files changed after re
   }
 });
 
+test('tree sidebar subtly mutes files currently marked viewed', async () => {
+  const viewedFile = createChangedFile('src/viewed.ts', 'viewed-current');
+  const staleViewedFile = createChangedFile('src/stale.ts', 'stale-current');
+  const nextState = {
+    ...repositoryState,
+    files: [viewedFile, staleViewedFile],
+  } satisfies RepositoryState;
+
+  window.localStorage.setItem(
+    'codiff:viewed:/repo',
+    JSON.stringify({
+      [staleViewedFile.path]: 'stale-previous',
+      [viewedFile.path]: viewedFile.fingerprint,
+    }),
+  );
+  window.codiff = createCodiffMock({
+    getRepositoryState: vi.fn(async () => nextState),
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      const shadowRoot = container.querySelector('file-tree-container')?.shadowRoot;
+      const styleText =
+        shadowRoot?.querySelector('style[data-codiff-viewed-rows]')?.textContent ?? '';
+      expect(styleText).toContain('[data-item-path="src/viewed.ts"]');
+      expect(styleText).not.toContain('[data-item-path="src/stale.ts"]');
+      expect(styleText).not.toContain('color-mix(in srgb, var(--viewed)');
+      expect(styleText).toContain(
+        "[data-item-path=\"src/viewed.ts\"] > [data-item-section='icon'] > :where(:not([data-icon-name='file-tree-icon-chevron']))",
+      );
+      expect(styleText).toContain("> [data-item-section='content']");
+      expect(styleText).toContain('color: var(--muted)');
+    });
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
 test('before unload saves the current source and selected file for any reload trigger', async () => {
   const changedFile = createChangedFile('src/app.ts');
   const source = { ref: 'abc1234', type: 'commit' } satisfies ReviewSource;

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import type { FileTreeRowDecorationRenderer } from '@pierre/trees';
 import { FileTree, useFileTree } from '@pierre/trees/react';
-import { useCallback, useEffect, useMemo, useRef, type MouseEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type MouseEvent, type RefObject } from 'react';
 import { matchesShortcut } from '../../config/keymap.ts';
 import type { CodiffKeymap } from '../../config/types.ts';
 import type {
@@ -49,6 +49,7 @@ export function Sidebar({
   searchQuery,
   selectedPath,
   showWhitespace,
+  viewed,
   walkthroughError,
   walkthroughLoading,
   walkthroughUnread,
@@ -77,6 +78,7 @@ export function Sidebar({
   searchQuery: string;
   selectedPath: string | null;
   showWhitespace: boolean;
+  viewed: Record<string, string>;
   walkthroughError: WalkthroughError | null;
   walkthroughLoading: boolean;
   walkthroughUnread: boolean;
@@ -105,6 +107,7 @@ export function Sidebar({
     () => getReloadDeltaGitStatusCSS(reloadDeltaPaths),
     [reloadDeltaPaths],
   );
+  const viewedRowCSS = useMemo(() => getViewedRowCSS(files, viewed), [files, viewed]);
   const renderTreeRowDecoration = useCallback<FileTreeRowDecorationRenderer>(({ item }) => {
     const lineCount = lineCountsByPathRef.current.get(item.path);
     return lineCount?.countable
@@ -170,17 +173,8 @@ export function Sidebar({
     `,
   });
 
-  useEffect(() => {
-    // Tree unsafeCSS is constructor-time; keep reload delta styling dynamic without remounting.
-    if (syncReloadDeltaGitStatusCSS(treeHostRef.current, reloadDeltaGitStatusCSS)) {
-      return;
-    }
-
-    const frame = window.requestAnimationFrame(() => {
-      syncReloadDeltaGitStatusCSS(treeHostRef.current, reloadDeltaGitStatusCSS);
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [reloadDeltaGitStatusCSS]);
+  useTreeShadowStyle(treeHostRef, reloadDeltaGitStatusStyleAttribute, reloadDeltaGitStatusCSS);
+  useTreeShadowStyle(treeHostRef, viewedRowStyleAttribute, viewedRowCSS);
 
   useEffect(() => {
     model.resetPaths(paths);
@@ -401,24 +395,70 @@ const getReloadDeltaGitStatusCSS = (paths: ReadonlySet<string>) =>
     )
     .join('\n');
 
-const reloadDeltaGitStatusStyleAttribute = 'data-codiff-reload-delta-git-status';
+const getViewedRowCSS = (files: ReadonlyArray<ChangedFile>, viewed: Record<string, string>) =>
+  getViewedRowCSSFromSelectors(
+    files
+      .filter((file) => viewed[file.path] === file.fingerprint)
+      .map((file) => `[data-item-path="${escapeCSSString(file.path)}"]`),
+  );
 
-const syncReloadDeltaGitStatusCSS = (treeHost: HTMLElement | null, css: string) => {
+const getViewedRowCSSFromSelectors = (selectors: ReadonlyArray<string>) => {
+  if (selectors.length === 0) {
+    return '';
+  }
+
+  const rowContent = selectors
+    .flatMap((selector) => [
+      `${selector} > [data-item-section='icon']`,
+      `${selector} > [data-item-section='icon'] > :where(:not([data-icon-name='file-tree-icon-chevron']))`,
+      `${selector} > [data-item-section='content']`,
+      `${selector} > [data-item-section='decoration']`,
+      `${selector} > [data-item-section='git']`,
+    ])
+    .join(',\n');
+
+  return `
+    ${rowContent} {
+      color: var(--muted);
+    }
+  `;
+};
+
+const reloadDeltaGitStatusStyleAttribute = 'data-codiff-reload-delta-git-status';
+const viewedRowStyleAttribute = 'data-codiff-viewed-rows';
+
+const useTreeShadowStyle = (
+  treeHostRef: RefObject<HTMLElement | null>,
+  styleAttribute: string,
+  css: string,
+) => {
+  useEffect(() => {
+    // Tree unsafeCSS is constructor-time; keep dynamic row styling in a shadow style tag.
+    if (syncTreeShadowStyle(treeHostRef.current, styleAttribute, css)) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      syncTreeShadowStyle(treeHostRef.current, styleAttribute, css);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [css, styleAttribute, treeHostRef]);
+};
+
+const syncTreeShadowStyle = (treeHost: HTMLElement | null, styleAttribute: string, css: string) => {
   const shadowRoot = treeHost?.querySelector('file-tree-container')?.shadowRoot;
   if (!shadowRoot) {
     return false;
   }
 
-  const existingStyle = shadowRoot.querySelector<HTMLStyleElement>(
-    `style[${reloadDeltaGitStatusStyleAttribute}]`,
-  );
+  const existingStyle = shadowRoot.querySelector<HTMLStyleElement>(`style[${styleAttribute}]`);
   if (css.length === 0) {
     existingStyle?.remove();
     return true;
   }
 
   const style = existingStyle ?? document.createElement('style');
-  style.setAttribute(reloadDeltaGitStatusStyleAttribute, '');
+  style.setAttribute(styleAttribute, '');
   style.textContent = css;
   if (!existingStyle) {
     shadowRoot.append(style);


### PR DESCRIPTION
This updates the Tree tab so files marked as `Viewed` are easier to distinguish. Viewed files now mute their row content, including the file icon, path, line count, and git status.

If the fingerprint for a file changes, Viewed gets reset. Also made the viewed toggle logic shared between the keyboard command and Viewed button so they don't drift.

Tests cover current viewed files, stale viewed entries, and the muted tree row selectors.

<img width="334" height="399" alt="image" src="https://github.com/user-attachments/assets/c29fc8d3-f2b1-41e3-8759-83a840c6aef2" />

<img width="330" height="396" alt="image" src="https://github.com/user-attachments/assets/e23b550e-d5ec-45e5-ae3c-3f3ce0bc34e1" />
