### PR TITLE
Forward walkthrough file in app launcher

### DIFF
--- a/bin/codiff-app
+++ b/bin/codiff-app
@@ -40,6 +40,7 @@ show_help() {
   printf '  %-22s%s%s%s\n' "--version, -v" "$gray" "Show version number and exit." "$reset"
   printf '  %-22s%s%s%s\n' "--walkthrough, -w" "$gray" "Start with an LLM-generated narrative walkthrough." "$reset"
   printf '  %-22s%s%s%s\n' "--walkthrough-context <file>" "$gray" "Seed a walkthrough with Codex conversation context JSON." "$reset"
+  printf '  %-22s%s%s%s\n' "--walkthrough-file <file>" "$gray" "Open a pre-authored narrative walkthrough JSON file." "$reset"
   printf '  %-22s%s%s%s\n' "--walkthrough-guide" "$gray" "Print the narrative walkthrough authoring guide and schema, then exit." "$reset"
   printf '\n'
   printf '%s\n' "${blue_bold}Examples:${reset}"
@@ -62,6 +63,7 @@ commit_ref=""
 pull_request_source=""
 source_ref=""
 walkthrough_context_path=""
+walkthrough_file_path=""
 expect_codex_session=0
 expect_claude_session=0
 expect_agent=0
@@ -69,6 +71,7 @@ expect_branch_ref=0
 expect_commit_ref=0
 expect_pull_request_number=0
 expect_walkthrough_context=0
+expect_walkthrough_file=0
 walkthrough=0
 
 is_commit_ref_arg() {
@@ -147,6 +150,12 @@ for arg in "$@"; do
     continue
   fi
 
+  if [ "$expect_walkthrough_file" -eq 1 ]; then
+    walkthrough_file_path="$arg"
+    expect_walkthrough_file=0
+    continue
+  fi
+
   if [ "$expect_pull_request_number" -eq 1 ]; then
     if printf '%s' "$arg" | grep -Eq '^[1-9][0-9]*$'; then
       pull_request_source="#$arg"
@@ -216,6 +225,12 @@ for arg in "$@"; do
     --walkthrough-context=*)
       walkthrough_context_path="${arg#--walkthrough-context=}"
       ;;
+    --walkthrough-file)
+      expect_walkthrough_file=1
+      ;;
+    --walkthrough-file=*)
+      walkthrough_file_path="${arg#--walkthrough-file=}"
+      ;;
     -*)
       ;;
     *)
@@ -266,9 +281,19 @@ if [ -n "$walkthrough_context_path" ]; then
   esac
 fi
 
+if [ -n "$walkthrough_file_path" ]; then
+  case "$walkthrough_file_path" in
+    /*) ;;
+    *) walkthrough_file_path="$PWD/$walkthrough_file_path" ;;
+  esac
+fi
+
 open_codiff() {
   # Prepend optional flags in reverse of their final order so the resulting
-  # argument list reads: --codex-session --claude-session --agent --walkthrough-context <trailing>.
+  # argument list reads: --codex-session --claude-session --agent --walkthrough-context --walkthrough-file <trailing>.
+  if [ -n "$walkthrough_file_path" ]; then
+    set -- --walkthrough-file "$walkthrough_file_path" "$@"
+  fi
   if [ -n "$walkthrough_context_path" ]; then
     set -- --walkthrough-context "$walkthrough_context_path" "$@"
   fi

--- a/src/__tests__/codiff-cli.test.ts
+++ b/src/__tests__/codiff-cli.test.ts
@@ -431,6 +431,50 @@ test('packaged terminal helper forwards Codex walkthrough seed options', async (
   }
 });
 
+test('packaged terminal helper forwards pre-authored walkthrough files', async () => {
+  const logger = await createFakeOpenLogger();
+  const repositoryPath = join(logger.directory, 'repo');
+  const walkthroughFile = join(logger.directory, 'walkthrough.json');
+
+  try {
+    await mkdir(repositoryPath);
+    await writeFile(walkthroughFile, '{}');
+
+    await execFileAsync(
+      resolve('bin/codiff-app'),
+      [
+        '-w',
+        '--agent',
+        'claude',
+        '--walkthrough-file',
+        walkthroughFile,
+        '--claude-session',
+        '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
+        repositoryPath,
+      ],
+      {
+        env: logger.env,
+      },
+    );
+
+    expect(await logger.readArgs()).toEqual([
+      '-n',
+      resolve('bin/../../../..'),
+      '--args',
+      '--claude-session',
+      '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
+      '--agent',
+      'claude',
+      '--walkthrough-file',
+      walkthroughFile,
+      '--walkthrough',
+      repositoryPath,
+    ]);
+  } finally {
+    await logger.cleanup();
+  }
+});
+
 test('Codex skill launcher uses the session cwd as the repository target', async () => {
   const logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
   const home = join(logger.directory, 'home');


### PR DESCRIPTION
## Summary

Fix the packaged macOS launcher so it accepts and forwards `--walkthrough-file` to Electron.

The Node/Electron parser already supported the flag, and the installed Codex/Claude skill invokes Codiff with it. The Homebrew cask links `codiff` to `bin/codiff-app`, though, and that shell launcher only forwarded `--walkthrough-context`, so `--walkthrough-file` was dropped before Electron could see it.

This PR adds launcher help text, parses both `--walkthrough-file <file>` and `--walkthrough-file=<file>`, resolves relative file paths, and covers the packaged terminal helper path with a regression test.

## Validation

```bash
./node_modules/.bin/vp test src/__tests__/codiff-cli.test.ts
./node_modules/.bin/vp check --fix
./node_modules/.bin/vp build
./bin/codiff-app --help | rg walkthrough
```

## Repro

```
➜  ~ brew install --cask nkzw-tech/tap/codiff
==> Auto-updating Homebrew...
Adjust how often this is run with `$HOMEBREW_AUTO_UPDATE_SECS` or disable with
`$HOMEBREW_NO_AUTO_UPDATE=1`. Hide these hints with `$HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> New Formulae
kimi-code: AI coding agent for your terminal
kubectl-explore: Better kubectl explain with the fuzzy finder

You have 3 outdated formulae installed.

==> Tapping nkzw-tech/tap
Cloning into '/opt/homebrew/Library/Taps/nkzw-tech/homebrew-tap'...
remote: Enumerating objects: 90, done.
remote: Counting objects: 100% (90/90), done.
remote: Compressing objects: 100% (45/45), done.
remote: Total 90 (delta 21), reused 90 (delta 21), pack-reused 0 (from 0)
Receiving objects: 100% (90/90), 20.86 KiB | 6.95 MiB/s, done.
Resolving deltas: 100% (21/21), done.
Tapped 1 cask (15 files, 30.4KB).
Warning: The following taps are not trusted:
  alexanderwillner/tap

Homebrew will ignore formulae, casks and commands from these taps when `HOMEBREW_REQUIRE_TAP_TRUST` is set.
This will become the default in Homebrew 6.0.0 or 5.2.0, whichever comes first.
Enable trust checks now with:
  export HOMEBREW_REQUIRE_TAP_TRUST=1
Trust specific formulae, casks or commands with:
  brew trust --formula <user>/<tap>/<formula>
  brew trust --cask <user>/<tap>/<cask>
  brew trust --command <user>/<tap>/<command>
or trust installed formulae from these taps with:
  brew trust --formula alexanderwillner/tap/things.sh
You can trust all formulae, casks and commands from these taps with:
  brew trust alexanderwillner/tap
Prefer trusting only the specific formulae, casks or commands you need.
Untap them with:
  brew untap alexanderwillner/tap
To keep allowing them by default during the transition:
  export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
This is not recommended and will be removed in a later release.
==> Fetching downloads for: nkzw-tech/tap/codiff
✔︎ Cask codiff (1.2.0)                                                                                                          Verified    131.1MB/131.1MB
==> Installing Cask codiff
==> Moving App 'Codiff.app' to '/Applications/Codiff.app'
==> Linking Binary 'codiff-app' to '/opt/homebrew/bin/codiff'
🍺  codiff was successfully installed!
➜  ~ codiff --version
codiff v1.2.0
➜  ~ codiff --help | grep walkthrough
  --codex-session <id>  Attach Codex session metadata to a walkthrough.
  --claude-session <id> Attach Claude Code session metadata to a walkthrough.
  --walkthrough, -w     Start with an LLM-generated narrative walkthrough.
  --walkthrough-context <file>Seed a walkthrough with Codex conversation context JSON.
  --walkthrough-guide   Print the narrative walkthrough authoring guide and schema, then exit.
  codiff -w             Start with an LLM narrative walkthrough.
```