### PR TITLE
Match author names in the history filter

### DIFF
--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -1320,3 +1320,78 @@ test('walkthrough launch errors stay on the walkthrough tab without automatic re
     container.remove();
   }
 });
+
+test('history filter matches commits by author name', async () => {
+  window.codiff = createCodiffMock({
+    getRepositoryHistory: vi.fn(async () => ({
+      entries: [
+        {
+          author: 'Ada Lovelace',
+          committedAt: Date.now(),
+          parents: [],
+          ref: 'aaa1111',
+          subject: 'Fix parser',
+        },
+        {
+          author: 'Grace Hopper',
+          committedAt: Date.now(),
+          parents: [],
+          ref: 'bbb2222',
+          subject: 'Update docs',
+        },
+      ],
+      root: '/repo',
+    })),
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  const findButton = (label: string) =>
+    Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes(label),
+    );
+  const historySubjects = () =>
+    Array.from(container.querySelectorAll('.history-entry-subject')).map(
+      (element) => element.textContent,
+    );
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+    });
+
+    await act(async () => {
+      findButton('History')?.click();
+    });
+
+    await waitFor(() => {
+      expect(historySubjects()).toContain('Fix parser');
+      expect(historySubjects()).toContain('Update docs');
+    });
+
+    const searchInput = container.querySelector<HTMLInputElement>('.sidebar-search');
+    expect(searchInput).toBeTruthy();
+    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+    await act(async () => {
+      setInputValue?.call(searchInput, 'grace');
+      searchInput?.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    await waitFor(() => {
+      expect(historySubjects()).toContain('Update docs');
+      expect(historySubjects()).not.toContain('Fix parser');
+    });
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -530,7 +530,8 @@ function HistorySidebar({
     const matchesQuery = (row: (typeof commitRows)[number]) =>
       !normalizedQuery ||
       row.subject.toLowerCase().includes(normalizedQuery) ||
-      row.ref.toLowerCase().includes(normalizedQuery);
+      row.ref.toLowerCase().includes(normalizedQuery) ||
+      row.author.toLowerCase().includes(normalizedQuery);
 
     if (pullRequestSource) {
       const hasScopedRows = commitRows.some((row) => row.scope != null);


### PR DESCRIPTION
## Summary

The "Filter history" field in the sidebar only matched commit subjects and refs, even though each history entry already carries the author name. This PR includes the author in the match, so typing a name (or part of one) filters the history to that person's commits.

## Test plan

- Added a new test
- Verified manually in the app: typing an author name in **Filter history** narrows the list to their commits; subject and hash filtering behave as before
<details><summary>Recording</summary>
<p>



https://github.com/user-attachments/assets/29a66edc-1f44-4edd-8333-03e8143f2f73

</p>
</details> 


*Disclaimer: Claude Fable was used to help here.*





