### PR TITLE
Do not open the review comment box when clicking line content

### DIFF
--- a/src/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/src/__tests__/ReviewCodeView-scroll.test.tsx
@@ -730,3 +730,89 @@ test('Enter on a focused review control is not converted into a hunk comment', a
     container.remove();
   }
 });
+
+type ReviewLineClickHandler = (
+  line: { annotationSide: 'additions' | 'deletions'; event: unknown; lineNumber: number },
+  context: { item: unknown },
+) => void;
+
+type ReviewLineRangeHandler = (
+  range: { end: number; side: 'additions' | 'deletions'; start: number },
+  context: { item: unknown },
+) => void;
+
+const getReviewCodeViewHandlers = () => {
+  const options = codeViewMock.lastOptions;
+  const item = codeViewMock.lastItems.find((candidate) => candidate.type === 'diff');
+  if (!options || !item) {
+    throw new Error('Expected CodeView options and a diff item.');
+  }
+
+  return {
+    item,
+    onGutterUtilityClick: options.onGutterUtilityClick as unknown as ReviewLineRangeHandler,
+    onLineClick: options.onLineClick as unknown as ReviewLineClickHandler,
+    onLineSelectionEnd: options.onLineSelectionEnd as unknown as ReviewLineRangeHandler,
+  };
+};
+
+const nonInteractivePointerEvent = { composedPath: () => [] };
+
+test('line content clicks do not create review comments', async () => {
+  const onCreateComment = vi.fn();
+  const file = createChangedFileWithPatch(
+    'src/click.ts',
+    'diff --git a/src/click.ts b/src/click.ts\n@@ -1 +1 @@\n-old\n+new\n',
+  );
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<ReviewCodeViewHarness files={[file]} onCreateComment={onCreateComment} />);
+    });
+
+    const { item, onGutterUtilityClick, onLineClick, onLineSelectionEnd } =
+      getReviewCodeViewHandlers();
+    const range = { end: 1, side: 'additions' as const, start: 1 };
+
+    await act(async () => {
+      onLineClick(
+        { annotationSide: 'additions', event: nonInteractivePointerEvent, lineNumber: 1 },
+        { item },
+      );
+    });
+
+    expect(onCreateComment).not.toHaveBeenCalled();
+
+    await act(async () => {
+      onLineSelectionEnd(range, { item });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(onCreateComment).toHaveBeenCalledTimes(1);
+    expect(onCreateComment).toHaveBeenCalledWith({
+      filePath: 'src/click.ts',
+      lineNumber: 1,
+      sectionId: 'src/click.ts:unstaged',
+      side: 'additions',
+    });
+
+    await act(async () => {
+      onGutterUtilityClick(range, { item });
+      // The pointer-up after a gutter drag also ends a line selection; only
+      // the gutter callback may create the comment.
+      onLineSelectionEnd(range, { item });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(onCreateComment).toHaveBeenCalledTimes(2);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});

--- a/src/__tests__/helpers/review-code-view.tsx
+++ b/src/__tests__/helpers/review-code-view.tsx
@@ -8,12 +8,16 @@ import type { ChangedFile, CommitMetadata, ReviewSource } from '../../types.ts';
 export type { ReviewDiffBlock } from '../../app/components/ReviewCodeView.tsx';
 
 const codeViewMockState = vi.hoisted(() => ({
+  lastItems: [] as ReadonlyArray<{ id: string; type: string }>,
+  lastOptions: null as Record<string, unknown> | null,
   postRenderNodes: [] as Array<HTMLElement>,
   scrollTo: vi.fn(),
 }));
 export const codeViewMock = codeViewMockState;
 
 export const resetCodeViewMock = () => {
+  codeViewMock.lastItems = [];
+  codeViewMock.lastOptions = null;
   codeViewMock.postRenderNodes = [];
   codeViewMock.scrollTo.mockClear();
 };
@@ -50,6 +54,8 @@ vi.mock('@pierre/diffs/react', async () => {
 
       React.useLayoutEffect(() => {
         itemsRef.current = props.items;
+        codeViewMock.lastItems = props.items;
+        codeViewMock.lastOptions = props.options ?? null;
         codeViewMock.postRenderNodes.length = props.items.length;
         props.items.forEach((item, index) => {
           const node = codeViewMock.postRenderNodes[index] ?? document.createElement('div');

--- a/src/app/components/ReviewCodeView.tsx
+++ b/src/app/components/ReviewCodeView.tsx
@@ -1826,21 +1826,7 @@ export function ReviewCodeView({
             shouldLoadDiffSectionContents(meta.section)
           ) {
             onLoadSection(meta.file, meta.section);
-            return;
           }
-
-          const side = 'annotationSide' in line ? line.annotationSide : null;
-          if (!side) {
-            return;
-          }
-
-          cancelPendingEmptyCommentDeletes();
-          onCreateComment({
-            filePath: meta.file.path,
-            lineNumber: line.lineNumber,
-            sectionId: meta.section.id,
-            side,
-          });
         },
         onLineSelectionEnd: (range, context) => {
           if (ignoreNextLineSelectionEndRef.current) {
@@ -1894,13 +1880,11 @@ export function ReviewCodeView({
       }) satisfies CodeViewOptions<ReviewAnnotationMetadata>,
     [
       bottomInset,
-      cancelPendingEmptyCommentDeletes,
       commitDetailsItemId,
       createCommentForRange,
       diffStyle,
       itemMetadata,
       loadingSectionIds,
-      onCreateComment,
       onLoadSection,
       wordWrap,
     ],


### PR DESCRIPTION
### Problem
Clicking anywhere on a line's content opens a comment box, even dragging to select text within a line triggers it on pointer-up, so focusing the window or copying code accidentally opens one.

### Summary
This PR removes the comment-on-content-click behavior for everyone, no setting. Clicking or dragging on line content no longer opens the comment box. The deliberate gestures are unchanged: clicking or dragging line numbers still opens it, and so does the gutter "+" (including dragging it for multi-line comments).

### Changes
- `ReviewCodeView`: `onLineClick` no longer creates a comment; it still loads deferred diff sections on click. `onLineSelectionEnd` (line-number selection) and `onGutterUtilityClick` are unchanged.
- Tests: line content clicks don't create comments, line-number selection and the gutter "+" still do, and a gutter drag doesn't double-create through the selection-end callback. The CodeView test mock now captures `options`/`items` to drive these.

### Test plan
- `vp check`, `vp test` (314 passing), `vp build` — all green
- Manually tested every trigger path in the built app with the setting on and off: line clicks, text-selection drags, line-number clicks/drags, gutter "+" clicks and "+" drag for multi-line comments. All behave as described above.
