### PR TITLE
Add configurable `reviewCommentsPrefix` setting

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -10,6 +10,7 @@
     "lastRepositoryPath": "",
     "openAIModel": "gpt-5.3-codex-spark",
     "piModel": "pi-default",
+    "reviewCommentsPrefix": "# Address these Review Comments",
     "showOutdated": false,
     "showWhitespace": false,
     "theme": "system",

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -947,6 +947,7 @@ export default function App() {
         currentState.files,
         reviewCommentsRef.current,
         preferencesRef.current.showWhitespace,
+        preferencesRef.current.reviewCommentsPrefix,
       );
     });
     return removeListener;
@@ -1611,6 +1612,7 @@ export default function App() {
             currentState.files,
             reviewCommentsRef.current,
             preferencesRef.current.showWhitespace,
+            preferencesRef.current.reviewCommentsPrefix,
           );
           if (markdown) {
             void navigator.clipboard.writeText(markdown);
@@ -1630,6 +1632,7 @@ export default function App() {
             currentState.files,
             reviewCommentsRef.current,
             preferencesRef.current.showWhitespace,
+            preferencesRef.current.reviewCommentsPrefix,
           );
           if (markdown) {
             void navigator.clipboard.writeText(markdown).then(() => {
@@ -2351,6 +2354,7 @@ export default function App() {
           <CopyCommentsButton
             comments={reviewComments}
             files={orderedFiles}
+            reviewCommentsPrefix={preferences.reviewCommentsPrefix}
             showWhitespace={showWhitespace}
           />
           {isPullRequest ? (

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -132,6 +132,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
     lastRepositoryPath: '/repo',
     openAIModel: defaultSettings.openAIModel,
     piModel: defaultSettings.piModel,
+    reviewCommentsPrefix: defaultSettings.reviewCommentsPrefix,
     showOutdated: false,
     showWhitespace: false,
     theme: 'system' as const,

--- a/core/__tests__/App.test.tsx
+++ b/core/__tests__/App.test.tsx
@@ -568,6 +568,92 @@ test('review comment markdown includes file and patch context', () => {
   );
 });
 
+test('review comment markdown uses custom prefix', () => {
+  const file = {
+    fingerprint: 'comment-export',
+    path: 'src/comment.ts',
+    sections: [
+      {
+        binary: false,
+        id: 'src/comment.ts:unstaged',
+        kind: 'unstaged',
+        newFile: {
+          contents: 'const label = "alpha";\nconst value = "needle";\n',
+          name: 'src/comment.ts',
+        },
+        oldFile: {
+          contents: 'const label = "alpha";\nconst value = "hay";\n',
+          name: 'src/comment.ts',
+        },
+        patch: '',
+      },
+    ],
+    status: 'modified',
+  } satisfies ChangedFile;
+
+  const markdown = buildReviewCommentsMarkdown(
+    [file],
+    [
+      {
+        body: 'Check this.',
+        filePath: 'src/comment.ts',
+        id: 'comment-1',
+        lineNumber: 2,
+        sectionId: 'src/comment.ts:unstaged',
+        side: 'additions',
+      },
+    ],
+    false,
+    '## Review Notes',
+  );
+
+  expect(markdown).toMatch(/^## Review Notes\n\n/);
+  expect(markdown).not.toContain('Address these Review Comments');
+});
+
+test('review comment markdown omits prefix when set to empty string', () => {
+  const file = {
+    fingerprint: 'comment-export',
+    path: 'src/comment.ts',
+    sections: [
+      {
+        binary: false,
+        id: 'src/comment.ts:unstaged',
+        kind: 'unstaged',
+        newFile: {
+          contents: 'const label = "alpha";\nconst value = "needle";\n',
+          name: 'src/comment.ts',
+        },
+        oldFile: {
+          contents: 'const label = "alpha";\nconst value = "hay";\n',
+          name: 'src/comment.ts',
+        },
+        patch: '',
+      },
+    ],
+    status: 'modified',
+  } satisfies ChangedFile;
+
+  const markdown = buildReviewCommentsMarkdown(
+    [file],
+    [
+      {
+        body: 'Check this.',
+        filePath: 'src/comment.ts',
+        id: 'comment-1',
+        lineNumber: 2,
+        sectionId: 'src/comment.ts:unstaged',
+        side: 'additions',
+      },
+    ],
+    false,
+    '',
+  );
+
+  expect(markdown).toMatch(/^1\. \*\*/);
+  expect(markdown).not.toContain('Address these Review Comments');
+});
+
 test('review comment markdown includes multi-line ranges', () => {
   const file = {
     fingerprint: 'comment-range-export',

--- a/core/app/components/Panels.tsx
+++ b/core/app/components/Panels.tsx
@@ -287,10 +287,12 @@ export function DiffSearchPanel({
 export function CopyCommentsButton({
   comments,
   files,
+  reviewCommentsPrefix,
   showWhitespace,
 }: {
   comments: ReadonlyArray<ReviewComment>;
   files: ReadonlyArray<ChangedFile>;
+  reviewCommentsPrefix: string;
   showWhitespace: boolean;
 }) {
   const [copied, markCopied] = useCopiedState(2000);
@@ -299,14 +301,19 @@ export function CopyCommentsButton({
   ).length;
 
   const copyComments = useCallback(async () => {
-    const markdown = buildReviewCommentsMarkdown(files, comments, showWhitespace);
+    const markdown = buildReviewCommentsMarkdown(
+      files,
+      comments,
+      showWhitespace,
+      reviewCommentsPrefix,
+    );
     if (!markdown) {
       return;
     }
 
     await navigator.clipboard.writeText(markdown);
     markCopied();
-  }, [comments, files, markCopied, showWhitespace]);
+  }, [comments, files, markCopied, reviewCommentsPrefix, showWhitespace]);
 
   if (pendingCommentCount === 0) {
     return null;

--- a/core/config/codiff-config.schema.json
+++ b/core/config/codiff-config.schema.json
@@ -68,6 +68,11 @@
           "default": "pi-default",
           "description": "The Pi model to use for review assistance and walkthroughs when agentBackend is 'pi'."
         },
+        "reviewCommentsPrefix": {
+          "type": "string",
+          "default": "# Address these Review Comments",
+          "description": "Markdown prefix prepended to copied review comments. Set to an empty string to omit the heading entirely."
+        },
         "showOutdated": {
           "type": "boolean",
           "default": false,

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -13,6 +13,7 @@ export type CodiffSettings = {
   lastRepositoryPath: string;
   openAIModel: string;
   piModel: string;
+  reviewCommentsPrefix: string;
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;

--- a/core/lib/review-comments.ts
+++ b/core/lib/review-comments.ts
@@ -246,6 +246,7 @@ export const buildReviewCommentsMarkdown = (
   files: ReadonlyArray<ChangedFile>,
   comments: ReadonlyArray<ReviewComment>,
   showWhitespace: boolean,
+  prefix?: string,
 ) => {
   const pendingComments = comments.filter((comment) => !comment.isReadOnly && comment.body.trim());
   const filesByPath = new Map(files.map((file) => [file.path, file]));
@@ -279,7 +280,9 @@ export const buildReviewCommentsMarkdown = (
     })
     .join('\n\n');
 
-  return markdown ? `# Address these Review Comments\n\n${markdown}` : '';
+  const resolvedPrefix =
+    prefix == null ? '# Address these Review Comments\n\n' : prefix ? `${prefix}\n\n` : '';
+  return markdown ? `${resolvedPrefix}${markdown}` : '';
 };
 
 export const getReviewCommentsFromState = (state: RepositoryState): ReadonlyArray<ReviewComment> =>

--- a/core/types.ts
+++ b/core/types.ts
@@ -525,6 +525,7 @@ export type CodiffPreferences = {
   lastRepositoryPath: string;
   openAIModel: string;
   piModel: string;
+  reviewCommentsPrefix: string;
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -253,6 +253,10 @@ const mergeConfig = (raw) => {
           : defaults.settings.openAIModel,
       piModel:
         typeof rawSettings.piModel === 'string' ? rawSettings.piModel : defaults.settings.piModel,
+      reviewCommentsPrefix:
+        typeof rawSettings.reviewCommentsPrefix === 'string'
+          ? rawSettings.reviewCommentsPrefix
+          : defaults.settings.reviewCommentsPrefix,
       showOutdated:
         typeof rawSettings.showOutdated === 'boolean'
           ? rawSettings.showOutdated


### PR DESCRIPTION
The copied review comments markdown hardcodes `# Address these Review Comments` as a prefix. This bakes in an assumption about how the output will be used — it reads as an instruction from a third-party reviewer. In at least one instance, a coding agent that received pasted review comments assumed the comments came from someone else and treated them differently than if the user had written the instructions directly.

This adds a `reviewCommentsPrefix` setting so users can control the prefix. It defaults to the existing heading for backwards compatibility. Set it to any markdown string, or `""` to omit the prefix entirely.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>