### PR TITLE
Fix syntax highlighting for .mts files

### DIFF
--- a/src/__tests__/code-view-options.test.ts
+++ b/src/__tests__/code-view-options.test.ts
@@ -1,0 +1,8 @@
+import { getFiletypeFromFileName } from '@pierre/diffs';
+import { expect, test } from 'vite-plus/test';
+import '../lib/code-view-options.ts';
+
+test('registers Node TypeScript module extensions for syntax highlighting', () => {
+  expect(getFiletypeFromFileName('src/example.cts')).toBe('typescript');
+  expect(getFiletypeFromFileName('src/example.mts')).toBe('typescript');
+});

--- a/src/lib/code-view-options.ts
+++ b/src/lib/code-view-options.ts
@@ -1,10 +1,12 @@
-import { registerCustomTheme, type FileOptions } from '@pierre/diffs';
+import { registerCustomTheme, setCustomExtension, type FileOptions } from '@pierre/diffs';
 import dunkelTheme from '../themes/dunkel.json' with { type: 'json' };
 import lichtTheme from '../themes/licht.json' with { type: 'json' };
 import type { DiffSection, GitFileStatus } from '../types.ts';
 
 registerCustomTheme('Licht', async () => lichtTheme as never);
 registerCustomTheme('Dunkel', async () => dunkelTheme as never);
+setCustomExtension('cts', 'typescript');
+setCustomExtension('mts', 'typescript');
 
 export const statusLabel: Record<GitFileStatus, string> = {
   added: 'Added',


### PR DESCRIPTION
## Summary

- Register Node TypeScript module extensions with the diff highlighter
- Cover both `.mts` and `.cts` so they resolve to TypeScript syntax highlighting
- Add a focused regression test for the extension mapping

Fixes #78.

## Test plan

- `pnpm test src/__tests__/code-view-options.test.ts`
- `env GIT_CONFIG_GLOBAL=/private/tmp/codiff-empty-gitconfig pnpm test`
- `pnpm exec vp lint`
- `pnpm exec vp build`
- Manually launched patched Codiff against the `.mts` repro