### PR TITLE
Fix unstable file tree line counts for hidden whitespace changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ create the file with defaults and open it in your editor. The file supports JSON
 trailing commas, includes a JSON schema reference for editor completion, and is watched while Codiff
 is running so changes apply to open windows.
 
+Set `settings.showWhitespace` to `true` to show whitespace-only changes in diffs and file line
+counts; when it is `false`, Codiff hides those changes from the working-tree review state.
+
 ```jsonc
 {
   "$schema": "https://raw.githubusercontent.com/nkzw-tech/codiff/main/src/config/codiff-config.schema.json",

--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -47,8 +47,8 @@ const {
  * @typedef {import('../src/types.ts').ReviewSource} ReviewSource
  */
 
-/** @param {string} launchPath @param {ReviewSource} [source] @returns {Promise<RepositoryState>} */
-const readRepositoryState = async (launchPath, source = { type: 'working-tree' }) => {
+/** @param {string} launchPath @param {ReviewSource} [source] @param {{showWhitespace?: boolean}} [options] @returns {Promise<RepositoryState>} */
+const readRepositoryState = async (launchPath, source = { type: 'working-tree' }, options = {}) => {
   const state =
     source.type === 'pull-request'
       ? await readPullRequestState(launchPath, source)
@@ -58,7 +58,10 @@ const readRepositoryState = async (launchPath, source = { type: 'working-tree' }
           ? await readRangeState(launchPath, source.base, source.head, source.symmetric)
           : source.type === 'branch' || source.type === 'branch-diff'
             ? await readBranchState(launchPath, source)
-            : await readWorkingTreeState(launchPath, { eagerContents: false });
+            : await readWorkingTreeState(launchPath, {
+                eagerContents: false,
+                showWhitespace: options.showWhitespace,
+              });
   const branch = (await gitOrEmpty(state.root, ['symbolic-ref', '--short', 'HEAD'])).trim() || null;
   return { ...state, branch };
 };

--- a/electron/git-state/common.cjs
+++ b/electron/git-state/common.cjs
@@ -33,7 +33,7 @@ const execFileAsync = promisify(execFile);
  *   unstaged: boolean;
  *   untracked: boolean;
  * }} StatusItem
- * @typedef {{force?: boolean; patch?: {binary: boolean; patch: string}; patchOnly?: boolean}} ReadFileOptions
+ * @typedef {{force?: boolean; patch?: {binary: boolean; patch: string}; patchOnly?: boolean; showWhitespace?: boolean}} ReadFileOptions
  * @typedef {{number: number; owner: string; repo: string; url: string}} PullRequestReference
  * @typedef {{owner: string; repo: string}} GitHubRemote
  * @typedef {{filename: string; patch?: string; previous_filename?: string; status: string}} GitHubPullRequestFile
@@ -595,12 +595,17 @@ const createPatchForNewFile = (path, contents) => {
     .concat(noNewline, '\n');
 };
 
-/** @param {string} repoRoot @param {string} path @param {WorkingTreeSectionKind} kind */
-const getPatch = async (repoRoot, path, kind) => {
+/** @param {{showWhitespace?: boolean}} [options] @returns {Array<string>} */
+const getWhitespaceDiffArgs = (options = {}) =>
+  options.showWhitespace === false ? ['--ignore-all-space'] : [];
+
+/** @param {string} repoRoot @param {string} path @param {WorkingTreeSectionKind} kind @param {{showWhitespace?: boolean}} [options] */
+const getPatch = async (repoRoot, path, kind, options = {}) => {
+  const whitespaceArgs = getWhitespaceDiffArgs(options);
   const args =
     kind === 'staged'
-      ? ['diff', '--cached', '--patch', '--no-ext-diff', '--', path]
-      : ['diff', '--patch', '--no-ext-diff', '--', path];
+      ? ['diff', '--cached', '--patch', '--no-ext-diff', ...whitespaceArgs, '--', path]
+      : ['diff', '--patch', '--no-ext-diff', ...whitespaceArgs, '--', path];
   const patch = await git(repoRoot, args);
 
   return {
@@ -715,7 +720,7 @@ const createSection = async (repoRoot, item, kind, options = {}) => {
   const id = `${item.path}:${kind}`;
 
   if (options.patchOnly && !item.untracked) {
-    const patch = options.patch ?? (await getPatch(repoRoot, item.path, kind));
+    const patch = options.patch ?? (await getPatch(repoRoot, item.path, kind, options));
 
     if (patch.binary) {
       return {
@@ -764,7 +769,7 @@ const createSection = async (repoRoot, item, kind, options = {}) => {
     };
   }
 
-  const patch = await getPatch(repoRoot, item.path, kind);
+  const patch = await getPatch(repoRoot, item.path, kind, options);
 
   return {
     binary: patch.binary || contents.binary,
@@ -816,6 +821,7 @@ module.exports = {
   getGravatarHash,
   getImageMimeType,
   getPatch,
+  getWhitespaceDiffArgs,
   getWorkingTreeContents,
   git,
   gitBuffer,

--- a/electron/git-state/working-tree.cjs
+++ b/electron/git-state/working-tree.cjs
@@ -10,6 +10,7 @@ const {
   generatedDirectoryPathspecs,
   getFingerprint,
   getGravatarHash,
+  getWhitespaceDiffArgs,
   git,
   MAX_UNTRACKED_INITIAL_ITEMS,
   parseStatus,
@@ -133,13 +134,15 @@ const splitPatchByPath = (rawPatch) => {
 /**
  * @param {string} repoRoot
  * @param {WorkingTreeSectionKind} kind
+ * @param {{showWhitespace?: boolean}} [options]
  * @returns {Promise<Map<string, {binary: boolean; patch: string}>>}
  */
-const readPatchMap = async (repoRoot, kind) => {
+const readPatchMap = async (repoRoot, kind, options = {}) => {
+  const whitespaceArgs = getWhitespaceDiffArgs(options);
   const args =
     kind === 'staged'
-      ? ['diff', '--cached', '--patch', '--no-ext-diff']
-      : ['diff', '--patch', '--no-ext-diff'];
+      ? ['diff', '--cached', '--patch', '--no-ext-diff', ...whitespaceArgs]
+      : ['diff', '--patch', '--no-ext-diff', ...whitespaceArgs];
   return splitPatchByPath(await git(repoRoot, args));
 };
 
@@ -212,7 +215,7 @@ const listUntrackedItems = async (repoRoot) => {
 
 /**
  * @param {string} launchPath
- * @param {{eagerContents?: boolean}} [options]
+ * @param {{eagerContents?: boolean; showWhitespace?: boolean}} [options]
  * @returns {Promise<RepositoryState>}
  */
 const readWorkingTreeState = async (launchPath, options = {}) => {
@@ -224,7 +227,10 @@ const readWorkingTreeState = async (launchPath, options = {}) => {
   const status = [...parseStatus(trackedStatus), ...untrackedItems].sort(fileSort);
   const shouldUsePatchOnly = options.eagerContents === false;
   const [stagedPatches, unstagedPatches] = shouldUsePatchOnly
-    ? await Promise.all([readPatchMap(repoRoot, 'staged'), readPatchMap(repoRoot, 'unstaged')])
+    ? await Promise.all([
+        readPatchMap(repoRoot, 'staged', options),
+        readPatchMap(repoRoot, 'unstaged', options),
+      ])
     : [new Map(), new Map()];
   /** @type {Array<ChangedFile>} */
   const files = [];
@@ -239,6 +245,7 @@ const readWorkingTreeState = async (launchPath, options = {}) => {
         await createSection(repoRoot, item, 'staged', {
           patch: stagedPatches.get(item.path),
           patchOnly,
+          showWhitespace: options.showWhitespace,
         }),
       );
     }
@@ -248,6 +255,7 @@ const readWorkingTreeState = async (launchPath, options = {}) => {
         await createSection(repoRoot, item, 'unstaged', {
           patch: unstagedPatches.get(item.path),
           patchOnly,
+          showWhitespace: options.showWhitespace,
         }),
       );
     }
@@ -317,6 +325,7 @@ const readDiffSectionContent = async (launchPath, request) => {
   const item = await getStatusItemForPath(repoRoot, path);
   return createSection(repoRoot, item, /** @type {WorkingTreeSectionKind} */ (request.kind), {
     force: request.force,
+    showWhitespace: request.showWhitespace,
   });
 };
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -125,6 +125,12 @@ const skillInstallers = new Map(
 
 const getActiveAgent = () => getAgent(config.settings.agentBackend);
 
+/** @param {string} repositoryPath @param {ReviewSource} [source] */
+const readRepositoryStateWithConfig = (repositoryPath, source) =>
+  readRepositoryState(repositoryPath, source, {
+    showWhitespace: config.settings.showWhitespace,
+  });
+
 /** @param {number} webContentsId */
 const resolveWindowAgent = (webContentsId) => {
   const override = windowLaunchOptions.get(webContentsId)?.agentBackend;
@@ -710,7 +716,10 @@ const createWindow = (
   }
   windowRepositories.set(webContentsId, repositoryPath);
   windowLaunchOptions.set(webContentsId, launchOptions);
-  const initialRepositoryState = readRepositoryState(repositoryPath, launchOptions.source);
+  const initialRepositoryState = readRepositoryStateWithConfig(
+    repositoryPath,
+    launchOptions.source,
+  );
   initialRepositoryState.catch(() => {});
   windowInitialRepositoryStates.set(webContentsId, initialRepositoryState);
   if (!launchOptions.source) {
@@ -814,7 +823,7 @@ const focusOrCreateWindow = (
       windowLaunchOptions.set(matchingWebContentsId, launchOptions);
       windowInitialRepositoryStates.set(
         matchingWebContentsId,
-        readRepositoryState(repositoryPath, launchOptions.source),
+        readRepositoryStateWithConfig(repositoryPath, launchOptions.source),
       );
       if (identity) {
         windowIdentities.set(matchingWebContentsId, identity);
@@ -951,7 +960,7 @@ ipcMain.handle('codiff:getRepositoryState', async (event, source) => {
   }
   const state = initialState
     ? await initialState
-    : await readRepositoryState(repositoryPath, source || launchOptions?.source);
+    : await readRepositoryStateWithConfig(repositoryPath, source || launchOptions?.source);
   if (launchOptions) {
     windowLaunchOptions.set(event.sender.id, {
       ...launchOptions,
@@ -1002,7 +1011,10 @@ ipcMain.handle('codiff:getNarrativeWalkthrough', async (event, source) => {
   const launchOptions = windowLaunchOptions.get(event.sender.id);
   try {
     const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
-    const state = await readRepositoryState(repositoryPath, source || launchOptions?.source);
+    const state = await readRepositoryStateWithConfig(
+      repositoryPath,
+      source || launchOptions?.source,
+    );
     const walkthroughFile = launchOptions?.walkthroughFile;
     if (walkthroughFile) {
       let input;
@@ -1060,7 +1072,10 @@ ipcMain.handle('codiff:getNarrativeWalkthrough', async (event, source) => {
 ipcMain.handle('codiff:askReviewAssistant', async (event, request) => {
   const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
   const launchOptions = windowLaunchOptions.get(event.sender.id);
-  const state = await readRepositoryState(repositoryPath, request?.source || launchOptions?.source);
+  const state = await readRepositoryStateWithConfig(
+    repositoryPath,
+    request?.source || launchOptions?.source,
+  );
   const agent = resolveWindowAgent(event.sender.id);
   return readReviewAssistantReply(state, request, agent, getAgentOptions(agent));
 });
@@ -1077,7 +1092,10 @@ ipcMain.handle('codiff:createWalkthroughCommit', async (event, request) => {
 ipcMain.handle('codiff:updateWalkthroughCommitMessage', async (event, request) => {
   const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
   const launchOptions = windowLaunchOptions.get(event.sender.id);
-  const state = await readRepositoryState(repositoryPath, request?.source || launchOptions?.source);
+  const state = await readRepositoryStateWithConfig(
+    repositoryPath,
+    request?.source || launchOptions?.source,
+  );
   const agent = resolveWindowAgent(event.sender.id);
   return readCommitMessageReply(state, request, agent, getAgentOptions(agent));
 });
@@ -1094,7 +1112,10 @@ ipcMain.handle('codiff:submitPullRequestReview', async (event, request) => {
 
 ipcMain.handle('codiff:getDiffSectionContent', async (event, request) => {
   const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
-  return readDiffSectionContent(repositoryPath, request);
+  return readDiffSectionContent(repositoryPath, {
+    ...request,
+    showWhitespace: request?.showWhitespace ?? config.settings.showWhitespace,
+  });
 });
 
 ipcMain.handle('codiff:getDiffImageContent', async (event, request) => {
@@ -1154,7 +1175,7 @@ ipcMain.handle('codiff:openConfigFile', () => openConfigFile());
 
 ipcMain.handle('codiff:openFile', async (event, filePath) => {
   const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
-  const state = await readRepositoryState(repositoryPath);
+  const state = await readRepositoryStateWithConfig(repositoryPath);
   const repositoryFilePath = validateRepositoryPath(filePath);
   const absolutePath = resolve(state.root, repositoryFilePath);
 
@@ -1167,7 +1188,7 @@ ipcMain.handle('codiff:openFile', async (event, filePath) => {
 
 ipcMain.handle('codiff:showInFolder', async (event, filePath) => {
   const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
-  const state = await readRepositoryState(repositoryPath);
+  const state = await readRepositoryStateWithConfig(repositoryPath);
   const repositoryFilePath = validateRepositoryPath(filePath);
   const absolutePath = resolve(state.root, repositoryFilePath);
 
@@ -1180,6 +1201,6 @@ ipcMain.handle('codiff:showInFolder', async (event, filePath) => {
 
 ipcMain.handle('codiff:getRelativePath', async (event, filePath) => {
   const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
-  const state = await readRepositoryState(repositoryPath);
+  const state = await readRepositoryStateWithConfig(repositoryPath);
   return relative(state.root, filePath);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,14 @@ const ignoreWalkthroughPathScroll = () => {};
 
 const defaultPreferences = getPreferencesFromConfig(createDefaultConfig());
 
+const getCollapsedViewedPaths = (
+  files: ReadonlyArray<ChangedFile>,
+  viewedFiles: Readonly<Record<string, string>>,
+) =>
+  new Set(
+    files.filter((file) => viewedFiles[file.path] === file.fingerprint).map((file) => file.path),
+  );
+
 const getReloadSourceForLaunch = (
   reloadSelection: ReturnType<typeof consumeReloadSelection>,
   launchOptions: CodiffLaunchOptions,
@@ -255,6 +263,7 @@ export default function App() {
   const sidebarModeRef = useRef<SidebarMode>('tree');
   const mainModeRef = useRef<MainMode>('review');
   const sourceRequestRef = useRef(0);
+  const stateGenerationRef = useRef(0);
   const viewedRef = useRef<Record<string, string>>({});
   const narrativeWalkthroughRef = useRef<NarrativeWalkthrough | null>(null);
   const navigationResetKey = state ? `${state.root}:${getSourceKey(state.source)}` : '';
@@ -299,6 +308,7 @@ export default function App() {
       }
 
       const sourceKey = getSourceKey(currentState.source);
+      const stateGeneration = stateGenerationRef.current;
       const key = `${currentState.root}:${sourceKey}:${section.id}`;
       if (loadingSectionKeysRef.current.has(key)) {
         return;
@@ -312,11 +322,13 @@ export default function App() {
           force: true,
           kind: section.kind,
           path: file.path,
+          showWhitespace: preferencesRef.current.showWhitespace,
           source: currentState.source,
         })
         .then((loadedSection) => {
           setState((current) => {
             if (
+              stateGenerationRef.current !== stateGeneration ||
               !current ||
               current.root !== currentState.root ||
               getSourceKey(current.source) !== sourceKey
@@ -343,6 +355,7 @@ export default function App() {
         .catch(() => {
           setState((current) => {
             if (
+              stateGenerationRef.current !== stateGeneration ||
               !current ||
               current.root !== currentState.root ||
               getSourceKey(current.source) !== sourceKey
@@ -566,15 +579,10 @@ export default function App() {
       setHistoryHasMore(history.entries.length >= HISTORY_PAGE_SIZE);
       setHistoryLimit(HISTORY_PAGE_SIZE);
       setHistorySource(nextHistorySource ?? null);
+      stateGenerationRef.current += 1;
       setState(orderedState);
       setLoadError(null);
-      setCollapsed(
-        new Set(
-          orderedState.files
-            .filter((file) => nextViewed[file.path] === file.fingerprint)
-            .map((file) => file.path),
-        ),
-      );
+      setCollapsed(getCollapsedViewedPaths(orderedState.files, nextViewed));
       setItemVersionByKey({});
       setFocusCommentId(null);
       setFocusCommentRequest(0);
@@ -676,6 +684,7 @@ export default function App() {
     let canceled = false;
     let cursor = 0;
     const sourceKey = getSourceKey(state.source);
+    const stateGeneration = stateGenerationRef.current;
 
     const loadNext = async (): Promise<void> => {
       if (canceled) {
@@ -700,12 +709,14 @@ export default function App() {
           force: true,
           kind: request.section.kind,
           path: request.file.path,
+          showWhitespace: preferences.showWhitespace,
           source: state.source,
         });
 
         if (!canceled) {
           setState((current) => {
             if (
+              stateGenerationRef.current !== stateGeneration ||
               !current ||
               current.root !== state.root ||
               getSourceKey(current.source) !== sourceKey
@@ -733,6 +744,7 @@ export default function App() {
         if (!canceled) {
           setState((current) => {
             if (
+              stateGenerationRef.current !== stateGeneration ||
               !current ||
               current.root !== state.root ||
               getSourceKey(current.source) !== sourceKey
@@ -783,8 +795,61 @@ export default function App() {
     });
 
     const removeConfigListener = window.codiff.onConfigChanged((nextConfig) => {
+      const previousShowWhitespace = preferencesRef.current.showWhitespace;
+      const nextPreferences = getPreferencesFromConfig(nextConfig);
       setCodiffConfig(nextConfig);
-      setPreferences(getPreferencesFromConfig(nextConfig));
+      setPreferences(nextPreferences);
+
+      if (previousShowWhitespace === nextPreferences.showWhitespace) {
+        return;
+      }
+
+      const currentState = stateRef.current;
+      if (!currentState) {
+        return;
+      }
+
+      const request = sourceRequestRef.current + 1;
+      sourceRequestRef.current = request;
+      stateGenerationRef.current += 1;
+      loadingSectionKeysRef.current.clear();
+      setLoadingSectionIds(new Set());
+
+      window.codiff
+        .getRepositoryState(currentState.source)
+        .then((nextState) => {
+          if (sourceRequestRef.current !== request) {
+            return;
+          }
+
+          const orderedState = {
+            ...nextState,
+            files: sortFiles(nextState.files),
+          };
+          const nextSelectedPath =
+            selectedPathRef.current &&
+            orderedState.files.some((file) => file.path === selectedPathRef.current)
+              ? selectedPathRef.current
+              : (orderedState.files[0]?.path ?? null);
+          const nextViewed = usesViewedFileState(orderedState.source)
+            ? readViewed(orderedState.root)
+            : {};
+
+          setState(orderedState);
+          setSelectedPath(nextSelectedPath);
+          setReloadDeltaPaths(new Set());
+          setItemVersionByKey({});
+          setReviewComments(getReviewCommentsFromState(orderedState));
+          setViewed(nextViewed);
+          setCollapsed(getCollapsedViewedPaths(orderedState.files, nextViewed));
+          setLoadError(null);
+        })
+        .catch((error: unknown) => {
+          if (sourceRequestRef.current !== request) {
+            return;
+          }
+          setLoadError(getRepositoryLoadError(error));
+        });
     });
 
     return () => {
@@ -1276,13 +1341,9 @@ export default function App() {
               ? session.selectedPath
               : (orderedState.files[0]?.path ?? null);
           const nextCollapsed =
-            session?.collapsed ??
-            new Set(
-              orderedState.files
-                .filter((file) => nextViewed[file.path] === file.fingerprint)
-                .map((file) => file.path),
-            );
+            session?.collapsed ?? getCollapsedViewedPaths(orderedState.files, nextViewed);
 
+          stateGenerationRef.current += 1;
           setState(orderedState);
           setHistorySource(getHistorySource(orderedState.source) ?? historySource);
           setCollapsed(new Set(nextCollapsed));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -789,14 +789,17 @@ export default function App() {
 
     window.codiff.getConfig().then((nextConfig) => {
       if (!canceled) {
+        const nextPreferences = getPreferencesFromConfig(nextConfig);
+        preferencesRef.current = nextPreferences;
         setCodiffConfig(nextConfig);
-        setPreferences(getPreferencesFromConfig(nextConfig));
+        setPreferences(nextPreferences);
       }
     });
 
     const removeConfigListener = window.codiff.onConfigChanged((nextConfig) => {
       const previousShowWhitespace = preferencesRef.current.showWhitespace;
       const nextPreferences = getPreferencesFromConfig(nextConfig);
+      preferencesRef.current = nextPreferences;
       setCodiffConfig(nextConfig);
       setPreferences(nextPreferences);
 

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -266,6 +266,56 @@ test('empty code font family removes the root CSS variable', async () => {
   container.remove();
 });
 
+test('showWhitespace config changes reload the current repository state', async () => {
+  let configListener: ((config: ReturnType<typeof createDefaultConfig>) => void) | null = null;
+  const nextConfig = createDefaultConfig();
+  nextConfig.settings.showWhitespace = true;
+  const initialState = {
+    ...repositoryState,
+    files: [createChangedFile('src/initial.ts')],
+  };
+  const reloadedState = {
+    ...repositoryState,
+    files: [createChangedFile('src/reloaded.ts')],
+  };
+  const getRepositoryState = vi
+    .fn<Window['codiff']['getRepositoryState']>()
+    .mockResolvedValueOnce(initialState)
+    .mockResolvedValueOnce(reloadedState);
+  window.codiff = createCodiffMock({
+    getRepositoryState,
+    onConfigChanged: vi.fn((callback) => {
+      configListener = callback;
+      return () => {};
+    }),
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<App />);
+  });
+
+  await waitFor(() => {
+    expect(container.textContent).toContain('src/initial.ts');
+  });
+
+  await act(async () => {
+    configListener?.(nextConfig);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  await waitFor(() => {
+    expect(container.textContent).toContain('src/reloaded.ts');
+  });
+  expect(getRepositoryState).toHaveBeenLastCalledWith({ type: 'working-tree' });
+
+  await act(async () => root.unmount());
+  container.remove();
+});
+
 test('sidebar commit button toggles back to tree when commit view is open', async () => {
   window.codiff = createCodiffMock({
     getRepositoryState: vi.fn(async () => ({

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -114,6 +114,30 @@ test('patch-only text sections are loadable for full context expansion', () => {
   ).toBe(false);
 });
 
+test('empty patch-only sections are not visible or countable', () => {
+  const file = {
+    fingerprint: 'empty-patch-only',
+    path: 'src/spacing.ts',
+    sections: [
+      {
+        binary: false,
+        id: 'src/spacing.ts:unstaged',
+        kind: 'unstaged',
+        loadState: 'ready',
+        patch: '',
+      },
+    ],
+    status: 'modified',
+  } satisfies ChangedFile;
+
+  expect(fileHasVisibleDiff(file, false)).toBe(false);
+  expect(getDiffLineCount(file, false)).toEqual({
+    additions: 0,
+    countable: false,
+    deletions: 0,
+  });
+});
+
 test('mode-only changes are visible without content hunks', () => {
   const file = {
     fingerprint: 'mode-only',

--- a/src/__tests__/git-state.test.ts
+++ b/src/__tests__/git-state.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
+import { fileHasVisibleDiff, getDiffLineCount } from '../lib/diff.ts';
 import type {
   DiffSection,
   DiffSectionContentRequest,
@@ -79,8 +80,15 @@ type GitStateModule = {
   readRepositoryChangeSignature: (
     launchPath: string,
   ) => Promise<{ root: string; signature: string }>;
-  readRepositoryState: (launchPath: string, source?: ReviewSource) => Promise<RepositoryState>;
-  readWorkingTreeState: (launchPath: string) => Promise<RepositoryState>;
+  readRepositoryState: (
+    launchPath: string,
+    source?: ReviewSource,
+    options?: { showWhitespace?: boolean },
+  ) => Promise<RepositoryState>;
+  readWorkingTreeState: (
+    launchPath: string,
+    options?: { eagerContents?: boolean; showWhitespace?: boolean },
+  ) => Promise<RepositoryState>;
   resolvePullRequestContentRefs: (
     repoRoot: string,
     pullRequest: { number: number; owner: string; repo: string; url: string },
@@ -627,6 +635,27 @@ test('readWorkingTreeState separates staged and unstaged modifications', async (
     expect(state.files[0].sections[0].newFile?.contents).toBe('two\n');
     expect(state.files[0].sections[1].oldFile?.contents).toBe('two\n');
     expect(state.files[0].sections[1].newFile?.contents).toBe('three\n');
+  });
+});
+
+test('readRepositoryState uses hidden-whitespace patches for patch-only working tree files', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(repo, 'src/code.ts', 'const value = 1;\n');
+    await commitAll(repo, 'initial commit');
+    await writeRepoFile(repo, 'src/code.ts', 'const  value = 1;\n');
+
+    const state = await readRepositoryState(repo, undefined, { showWhitespace: false });
+    const file = state.files.find((candidate) => candidate.path === 'src/code.ts');
+
+    expect(file?.sections[0]?.oldFile).toBeUndefined();
+    expect(file?.sections[0]?.newFile).toBeUndefined();
+    expect(file?.sections[0]?.patch).toBe('');
+    expect(file ? fileHasVisibleDiff(file, false) : null).toBe(false);
+    expect(file ? getDiffLineCount(file, false) : null).toEqual({
+      additions: 0,
+      countable: false,
+      deletions: 0,
+    });
   });
 });
 

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,6 +1,14 @@
 import type { FileTreeRowDecorationRenderer } from '@pierre/trees';
 import { FileTree, useFileTree } from '@pierre/trees/react';
-import { useCallback, useEffect, useMemo, useRef, type MouseEvent, type RefObject } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type MouseEvent,
+  type RefObject,
+} from 'react';
 import { matchesShortcut } from '../../config/keymap.ts';
 import type { CodiffKeymap } from '../../config/types.ts';
 import type {
@@ -103,6 +111,18 @@ export function Sidebar({
     mode === 'tree' && currentSource.type === 'working-tree' && commitFiles.length > 0;
   const showFooter = showTotalLineCount || showCommitButton;
   const lineCountsByPathRef = useRef(lineCountsByPath);
+  const lineCountsSignature = useMemo(
+    () =>
+      [...lineCountsByPath]
+        .map(
+          ([path, lineCount]) =>
+            `${path}\0${lineCount.countable ? 1 : 0}\0${lineCount.additions}\0${
+              lineCount.deletions
+            }`,
+        )
+        .join('\u0001'),
+    [lineCountsByPath],
+  );
   const reloadDeltaGitStatusCSS = useMemo(
     () => getReloadDeltaGitStatusCSS(reloadDeltaPaths),
     [reloadDeltaPaths],
@@ -176,13 +196,13 @@ export function Sidebar({
   useTreeShadowStyle(treeHostRef, reloadDeltaGitStatusStyleAttribute, reloadDeltaGitStatusCSS);
   useTreeShadowStyle(treeHostRef, viewedRowStyleAttribute, viewedRowCSS);
 
-  useEffect(() => {
-    model.resetPaths(paths);
-  }, [model, paths]);
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     lineCountsByPathRef.current = lineCountsByPath;
   }, [lineCountsByPath]);
+
+  useEffect(() => {
+    model.resetPaths(paths);
+  }, [lineCountsSignature, model, paths]);
 
   useEffect(() => {
     model.setGitStatus(status);

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -111,18 +111,6 @@ export function Sidebar({
     mode === 'tree' && currentSource.type === 'working-tree' && commitFiles.length > 0;
   const showFooter = showTotalLineCount || showCommitButton;
   const lineCountsByPathRef = useRef(lineCountsByPath);
-  const lineCountsSignature = useMemo(
-    () =>
-      [...lineCountsByPath]
-        .map(
-          ([path, lineCount]) =>
-            `${path}\0${lineCount.countable ? 1 : 0}\0${lineCount.additions}\0${
-              lineCount.deletions
-            }`,
-        )
-        .join('\u0001'),
-    [lineCountsByPath],
-  );
   const reloadDeltaGitStatusCSS = useMemo(
     () => getReloadDeltaGitStatusCSS(reloadDeltaPaths),
     [reloadDeltaPaths],
@@ -198,11 +186,14 @@ export function Sidebar({
 
   useLayoutEffect(() => {
     lineCountsByPathRef.current = lineCountsByPath;
-  }, [lineCountsByPath]);
+    if (model.getFileTreeContainer()) {
+      model.render({});
+    }
+  }, [lineCountsByPath, model]);
 
   useEffect(() => {
     model.resetPaths(paths);
-  }, [lineCountsSignature, model, paths]);
+  }, [model, paths]);
 
   useEffect(() => {
     model.setGitStatus(status);

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -76,7 +76,7 @@
         "showWhitespace": {
           "type": "boolean",
           "default": false,
-          "description": "Show whitespace characters in diffs."
+          "description": "Show whitespace-only changes in diffs and file line counts."
         },
         "theme": {
           "type": "string",

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -275,6 +275,8 @@ export const parseSectionDiffWithOptions = (
     } catch {
       fileDiff = createEmptyFileDiff(file, section);
     }
+  } else if (section.patch.trim().length === 0) {
+    fileDiff = createEmptyFileDiff(file, section);
   } else {
     const parsedFileDiff = parsePatchFiles(section.patch)[0]?.files[0];
     fileDiff = parsedFileDiff

--- a/src/types.ts
+++ b/src/types.ts
@@ -451,6 +451,7 @@ export type DiffSectionContentRequest = {
   force?: boolean;
   kind: DiffSection['kind'];
   path: string;
+  showWhitespace?: boolean;
   source?: ReviewSource;
 };
 


### PR DESCRIPTION
This fixes cases where file tree added/removed counts changed after selecting or scrolling to a file.

The root issue was that initial working-tree patches did not apply the `showWhitespace` setting, while lazy-loaded file content did. That made counts change after a file loaded more detail. Working-tree patch reads now use the same whitespace setting from the start, and changing `showWhitespace` reloads the current review state.

Also included:
- ignored stale lazy-load responses after reloads
- fixed empty patch-only sections so whitespace-only hidden changes do not count as real diffs
- refreshed tree row decorations when only line counts change
- updated config docs for `showWhitespace`

Validation:
- `vp check --fix`
- focused tests: 104 passed
- `vp build`
