### PR TITLE
Update walkthrough guidelines

### DIFF
--- a/bin/walkthrough-guide.md
+++ b/bin/walkthrough-guide.md
@@ -59,6 +59,24 @@ choose.
 - Do not invent bugs, risks, tests, or validation. Describe what the diff and conversation
   actually support.
 
+## hunkId format
+
+Every `hunkId` has the shape `<file path>:<scope>:h<ordinal>`. The `<file path>` is
+the file's repository-relative path, `<scope>` identifies the diff the hunk came from,
+and `h<ordinal>` is the hunk's 1-based position within that file's patch (`h1`, `h2`, …).
+The `<scope>` segment depends on which diff you anchored against:
+
+- `staged` — the staged diff (`git diff --staged`).
+- `unstaged` — the working-tree diff (`git diff`).
+- `pull-request:<number>` — a pull request.
+- `<commit SHA>` — every commit-like target: a single commit, a branch comparison, or a
+  ref range. This is always the **full 40-character SHA of the diff's new (head) side**,
+  resolved with `git rev-parse` — never a ref name or a `branch:`/`range:` prefix:
+  - single commit (`codiff <ref>`): the resolved commit SHA.
+  - branch comparison (`codiff <branch>` — current branch vs `<branch>`): the resolved
+    **`HEAD`** SHA, _not_ `<branch>`.
+  - ref range (`codiff base..head` or `base...head`): the resolved SHA of `head`.
+
 ## Schema
 
 The document must conform to the following JSON schema:

--- a/claude/skills/codiff/SKILL.md
+++ b/claude/skills/codiff/SKILL.md
@@ -37,14 +37,14 @@ This skill is just the handoff: fetch the guide, author the document, open Codif
 4. **Open Codiff** with that file:
 
    ```bash
-   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json
+   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json /path/to/repository
    ```
 
    Forward an explicit target after the flag if the user gave one:
 
    ```bash
-   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json HEAD
-   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json /path/to/repository
+   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json HEAD /path/to/repository
+   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json pr 123 /path/to/repository
    ```
 
    The launcher passes `CLAUDE_SESSION_ID` to Codiff with `--agent claude` so follow-up

--- a/codex/skills/codiff/SKILL.md
+++ b/codex/skills/codiff/SKILL.md
@@ -37,14 +37,14 @@ This skill is just the handoff: fetch the guide, author the document, open Codif
 4. **Open Codiff** with that file:
 
    ```bash
-   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json
+   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json /path/to/repository
    ```
 
    Forward an explicit target after the flag if the user gave one:
 
    ```bash
-   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json HEAD
-   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json /path/to/repository
+   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json HEAD /path/to/repository
+   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json pr 123 /path/to/repository
    ```
 
    The launcher passes `CODEX_THREAD_ID` to Codiff so follow-up questions reuse this

--- a/electron/narrative-walkthrough-schema.cjs
+++ b/electron/narrative-walkthrough-schema.cjs
@@ -23,8 +23,6 @@ const hunkGroupProperties = {
   changeType: { enum: [...CHANGE_TYPES], type: 'string' },
   commitNote: { type: 'string' },
   hunkIds: {
-    description:
-      'Deterministic hunk ids from the repository digest, in the display order Codiff should render them. Generated-like files are represented by one synthetic hunk id per changed section.',
     items: { type: 'string' },
     maxItems: MAX_HUNKS_PER_WALKTHROUGH_GROUP,
     minItems: 1,

--- a/pi/skills/codiff/SKILL.md
+++ b/pi/skills/codiff/SKILL.md
@@ -37,14 +37,14 @@ This skill is just the handoff: fetch the guide, author the document, open Codif
 4. **Open Codiff** with that file:
 
    ```bash
-   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json
+   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json /path/to/repository
    ```
 
    Forward an explicit target after the flag if the user gave one:
 
    ```bash
-   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json HEAD
-   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json /path/to/repository
+   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json HEAD /path/to/repository
+   node scripts/open-codiff.mjs --file /tmp/codiff-walkthrough-<id>.json pr 123 /path/to/repository
    ```
 
    The launcher passes the Pi session id to Codiff with `--agent pi` when it can resolve

--- a/src/walkthrough/narrative-walkthrough.schema.json
+++ b/src/walkthrough/narrative-walkthrough.schema.json
@@ -49,7 +49,6 @@
                   "type": "string"
                 },
                 "hunkIds": {
-                  "description": "Deterministic hunk ids from the repository digest, in the display order Codiff should render them. Generated-like files are represented by one synthetic hunk id per changed section.",
                   "items": {
                     "type": "string"
                   },
@@ -137,7 +136,6 @@
             "type": "string"
           },
           "hunkIds": {
-            "description": "Deterministic hunk ids from the repository digest, in the display order Codiff should render them. Generated-like files are represented by one synthetic hunk id per changed section.",
             "items": {
               "type": "string"
             },


### PR DESCRIPTION
When I use the `/codiff` skill in Claude Code (using Opus 4.8) it has a couple of issues.

It doesn't understand what hunkIds are and it wastes time going through Codiff's source code. I added a couple of examples to `walkthrough-guide.md` and removed the `hunkIds` description from the schema because it focused on the phrase "repository digest" and tried to find references to it in the source code.

Also, after generating the walkthrough json it would open it from the skills directory, and then Codiff wouldn't know to associate it with the repo's path. I've added the path as the last argument to the CLI in the examples in `SKILL.md` files