### PR TITLE
Add icons to comment buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1992,6 +1992,7 @@
 }
 
 .review-comment-action {
+  align-items: center;
   background: transparent;
   border: 1px solid var(--file-border);
   border-radius: var(--review-comment-radius);
@@ -2002,7 +2003,9 @@
   color: var(--text);
   corner-shape: squircle;
   cursor: pointer;
+  display: inline-flex;
   font: 700 11px/1 var(--font-sans);
+  gap: 4px;
   height: 24px;
   padding: 0 8px;
   transform: scale(1);
@@ -2011,6 +2014,14 @@
     box-shadow 250ms ease,
     color 160ms ease,
     transform 250ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.review-comment-action-icon {
+  color: currentColor;
+  display: block;
+  flex: none;
+  height: 14px;
+  width: 14px;
 }
 
 .review-comment-action:disabled {

--- a/src/app/components/ReviewCodeView.tsx
+++ b/src/app/components/ReviewCodeView.tsx
@@ -1,6 +1,7 @@
 import { CaretDownIcon as CaretDown } from '@phosphor-icons/react/CaretDown';
 import { CheckIcon as Check } from '@phosphor-icons/react/Check';
 import { ColumnsIcon as Columns } from '@phosphor-icons/react/Columns';
+import { GithubLogoIcon as GithubLogo } from '@phosphor-icons/react/GithubLogo';
 import { ImageBrokenIcon as ImageBroken } from '@phosphor-icons/react/ImageBroken';
 import { SquareSplitVerticalIcon as SquareSplitVertical } from '@phosphor-icons/react/SquareSplitVertical';
 import { XIcon as X } from '@phosphor-icons/react/X';
@@ -284,10 +285,14 @@ function AgentAvatar({ agentId }: { agentId: 'codex' | 'claude' | 'pi' }) {
       alt=""
       className="review-comment-avatar-codex"
       draggable={false}
-      src={agentId === 'pi' ? piIconUrl : agentId === 'claude' ? claudeIconUrl : codexIconUrl}
+      src={agentIconUrl(agentId)}
     />
   );
 }
+
+const agentIconUrl = (agentId: 'codex' | 'claude' | 'pi') => {
+  return agentId === 'pi' ? piIconUrl : agentId === 'claude' ? claudeIconUrl : codexIconUrl;
+};
 
 const canAskCodexForComment = (comment: ReviewComment) =>
   !comment.isReadOnly && comment.body.trim().length > 0 && comment.codexReply?.status !== 'loading';
@@ -781,6 +786,13 @@ function ReviewCommentEditor({
                 }
                 type="button"
               >
+                <img
+                  alt=""
+                  aria-hidden
+                  className="review-comment-action-icon"
+                  draggable={false}
+                  src={agentIconUrl(agentId)}
+                />
                 Ask
               </button>
             ) : null}
@@ -794,6 +806,12 @@ function ReviewCommentEditor({
                 }
                 type="button"
               >
+                <GithubLogo
+                  aria-hidden
+                  className="review-comment-action-icon"
+                  size={14}
+                  weight="bold"
+                />
                 {comment.githubSubmit?.status === 'submitting' ? 'Sending' : 'Comment'}
               </button>
             ) : null}


### PR DESCRIPTION
When looking over a PR I wasn't sure what would happen once I clicked "Ask" or "Comment". I think adding an icon to each of them would make it a lot clearer

before
<img width="659" height="129" alt="Screenshot 2026-06-15 at 20 52 30" src="https://github.com/user-attachments/assets/468700cd-e0ec-44d9-b287-795537bfa3b1" />

after
<img width="661" height="143" alt="Screenshot 2026-06-15 at 20 51 12" src="https://github.com/user-attachments/assets/88c0d8da-7fd1-474b-bbf4-38de35c86b0b" />
