### PR TITLE
Make the header full width and move copy+PR actions to header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -156,13 +156,13 @@
 .app-shell {
   display: grid;
   grid-template-columns: 292px 0 minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
   height: 100%;
   overflow: hidden;
 }
 
 .app-shell.sidebar-collapsed {
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: auto minmax(0, 1fr);
 }
 
 .app-shell.sidebar-collapsed .sidebar {
@@ -173,35 +173,31 @@
   display: none;
 }
 
-.collapsed-sidebar-bar {
+.app-header {
   -webkit-app-region: drag;
   -webkit-backdrop-filter: blur(28px) saturate(1.3);
   align-items: center;
   backdrop-filter: blur(28px) saturate(1.3);
   background: var(--sidebar-bg);
   border-bottom: 1px solid var(--sidebar-border);
-  border-radius: 0;
   box-sizing: border-box;
-  corner-shape: initial;
   display: flex;
   gap: 8px;
   grid-column: 1 / -1;
-  height: 40px;
-  margin: 0;
+  min-height: 44px;
   padding: 0 14px 0 78px;
 }
 
-.app-shell.window-fullscreen .collapsed-sidebar-bar {
+.app-shell.window-fullscreen .app-header {
   padding-left: 14px;
 }
 
-.collapsed-sidebar-label {
+.app-header-label {
   color: var(--sidebar-text);
   flex: 1;
   font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 600;
-  line-height: 1.35;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -509,40 +505,6 @@
   min-height: 0;
   overflow: hidden;
   position: relative;
-}
-
-.sidebar-header {
-  -webkit-app-region: drag;
-  border-bottom: 1px solid var(--sidebar-border);
-  flex: none;
-  min-width: 0;
-  padding: 0 14px;
-}
-
-.sidebar-path-row {
-  align-items: center;
-  display: flex;
-  gap: 8px;
-  min-height: 38px;
-  min-width: 0;
-  padding-left: 64px;
-}
-
-.app-shell.window-fullscreen .sidebar-path-row {
-  padding-left: 0;
-}
-
-.sidebar-path {
-  color: var(--sidebar-text);
-  flex: 1;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 1.35;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .sidebar-search-row {
@@ -857,16 +819,6 @@
   min-height: 0;
   overflow: hidden;
   position: relative;
-}
-
-.window-drag-region {
-  -webkit-app-region: drag;
-  height: 12px;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: 20;
 }
 
 .review-source-loading {
@@ -2169,73 +2121,55 @@
   word-break: break-word;
 }
 
-.review-action-bar {
+.app-header-actions {
   -webkit-app-region: no-drag;
   align-items: center;
-  bottom: 16px;
   display: inline-flex;
-  gap: 12px;
-  position: fixed;
-  right: 16px;
-  z-index: 12;
+  flex: none;
+  gap: 8px;
+  margin-left: auto;
 }
 
-.copy-comments-button,
-.review-submit-button {
-  -webkit-backdrop-filter: blur(22px) saturate(1.35);
+.header-action-button {
+  -webkit-app-region: no-drag;
   align-items: center;
-  backdrop-filter: blur(22px) saturate(1.35);
-  background: color-mix(in srgb, var(--code-bg) 78%, transparent);
+  background: transparent;
   border: 1px solid var(--file-border);
-  border-radius: 50%;
-  box-shadow:
-    0 0 0 1px rgb(255 255 255 / 0.16) inset,
-    0 0 0 1px var(--file-border),
-    0 18px 80px -54px rgb(0 0 0 / 0.8),
-    0 16px 46px -30px rgb(0 0 0 / 0.72),
-    0 12px 24px -18px rgb(0 0 0 / 0.9);
+  border-radius: 999px;
+  color: var(--text);
+  corner-shape: squircle;
   cursor: pointer;
   display: inline-flex;
-  height: 46px;
+  flex: none;
+  font: 700 12px/1 var(--font-sans);
+  gap: 6px;
+  height: 28px;
   justify-content: center;
-  padding: 0;
-  transition: all 250ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  padding: 0 11px;
   transform: scale(1);
-  width: 46px;
+  transition:
+    background 160ms ease,
+    color 160ms ease,
+    transform 250ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-.copy-comments-button {
-  color: var(--copy-icon);
-}
-
-.review-submit-button {
-  color: var(--text);
-}
-
-.copy-comments-button:hover,
-.review-submit-button:hover:not(:disabled) {
-  box-shadow:
-    0 0 0 1px rgb(255 255 255 / 0.2) inset,
-    0 0 0 1px var(--file-border),
-    0 26px 96px -48px rgb(0 0 0 / 0.92),
-    0 22px 62px -30px rgb(0 0 0 / 0.82),
-    0 16px 32px -18px rgb(0 0 0 / 0.96);
+.header-action-button:not(:disabled):hover {
+  background: rgb(127 127 127 / 0.12);
   transform: scale(1.05);
 }
 
-.copy-comments-button:active,
-.review-submit-button:active:not(:disabled) {
+.header-action-button:not(:disabled):active {
   transform: scale(0.95);
 }
 
-.review-submit-button:disabled {
+.header-action-button:disabled {
   color: var(--muted);
   cursor: default;
-  opacity: 0.58;
+  opacity: 0.5;
 }
 
 .copy-comments-button.copied {
-  background: color-mix(in srgb, var(--code-bg) 80%, var(--viewed) 14%);
+  background: color-mix(in srgb, var(--viewed) 14%, transparent);
   color: var(--viewed);
 }
 
@@ -2247,17 +2181,7 @@
   color: var(--danger);
 }
 
-.copy-comments-icon {
-  display: block;
-  flex: none;
-  transform: scaleX(-1);
-}
-
-.copy-comments-icon.check {
-  transform: translateY(-1px);
-}
-
-.review-submit-icon {
+.header-action-icon {
   display: block;
   flex: none;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2164,36 +2164,52 @@ export default function App() {
         sidebarCollapsed ? undefined : { gridTemplateColumns: `${sidebarWidth}px 0 minmax(0, 1fr)` }
       }
     >
-      <div aria-hidden className="window-drag-region" />
-      {sidebarCollapsed ? (
-        <div className="collapsed-sidebar-bar">
-          <button
-            className="sidebar-toggle-button"
-            onClick={expandSidebar}
-            title={`Expand sidebar (${getShortcutLabel(codiffConfig.keymap, 'toggleSidebar')})`}
-            type="button"
+      <header className="app-header">
+        <button
+          className="sidebar-toggle-button"
+          onClick={sidebarCollapsed ? expandSidebar : toggleSidebar}
+          title={`${sidebarCollapsed ? 'Expand' : 'Collapse'} sidebar (${getShortcutLabel(
+            codiffConfig.keymap,
+            'toggleSidebar',
+          )})`}
+          type="button"
+        >
+          <svg
+            aria-hidden
+            fill="none"
+            height="16"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width="16"
           >
-            <svg
-              aria-hidden
-              fill="none"
-              height="16"
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width="16"
-            >
-              <rect height="18" rx="2" ry="2" width="18" x="3" y="3" />
-              <line x1="9" x2="9" y1="3" y2="21" />
-            </svg>
-          </button>
-          <div className="collapsed-sidebar-label" title={state.root}>
-            {sidebarLabel}
-            {sidebarSourceLabel}
-          </div>
+            <rect height="18" rx="2" ry="2" width="18" x="3" y="3" />
+            <line x1="9" x2="9" y1="3" y2="21" />
+          </svg>
+        </button>
+        <div className="app-header-label" title={state.root}>
+          {sidebarLabel}
+          {sidebarSourceLabel}
         </div>
-      ) : null}
+        {!isSwitchingSource ? (
+          <div className="app-header-actions">
+            <CopyCommentsButton
+              comments={reviewComments}
+              files={orderedFiles}
+              showWhitespace={showWhitespace}
+            />
+            {state.source.type === 'pull-request' ? (
+              <PullRequestReviewButtons
+                disabled={pullRequestReviewSubmitting != null}
+                onSubmitReview={submitPullRequestReview}
+                submittingEvent={pullRequestReviewSubmitting}
+              />
+            ) : null}
+          </div>
+        ) : null}
+      </header>
       <RepositoryChangeBanner
         onReload={reloadWindow}
         visible={localChangesDetected && (pendingSource ?? state.source).type === 'working-tree'}
@@ -2221,52 +2237,7 @@ export default function App() {
         visible={commandBarVisible}
       />
       <KeyboardShortcutsHelp keymap={codiffConfig.keymap} visible={shortcutsHelpVisible} />
-      {!isSwitchingSource ? (
-        <div className="review-action-bar">
-          <CopyCommentsButton
-            comments={reviewComments}
-            files={orderedFiles}
-            showWhitespace={showWhitespace}
-          />
-          {isPullRequest ? (
-            <PullRequestReviewButtons
-              disabled={pullRequestReviewSubmitting != null}
-              onSubmitReview={submitPullRequestReview}
-              submittingEvent={pullRequestReviewSubmitting}
-            />
-          ) : null}
-        </div>
-      ) : null}
       <aside className="squircle sidebar">
-        <div className="sidebar-header">
-          <div className="sidebar-path-row">
-            <button
-              className="sidebar-toggle-button"
-              onClick={toggleSidebar}
-              title={`Collapse sidebar (${getShortcutLabel(codiffConfig.keymap, 'toggleSidebar')})`}
-              type="button"
-            >
-              <svg
-                aria-hidden
-                fill="none"
-                height="16"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                width="16"
-              >
-                <rect height="18" rx="2" ry="2" width="18" x="3" y="3" />
-                <line x1="9" x2="9" y1="3" y2="21" />
-              </svg>
-            </button>
-            <div className="sidebar-path" title={state.root}>
-              {sidebarLabel}
-              {sidebarSourceLabel}
-            </div>
-          </div>
-        </div>
         <Sidebar
           branchSource={historySource?.type === 'branch-diff' ? historySource : null}
           commitFiles={state.files}

--- a/src/app/components/Panels.tsx
+++ b/src/app/components/Panels.tsx
@@ -317,16 +317,17 @@ export function CopyCommentsButton({
       aria-label={`Copy ${pendingCommentCount} review ${
         pendingCommentCount === 1 ? 'comment' : 'comments'
       }`}
-      className={`copy-comments-button${copied ? ' copied' : ''}`}
+      className={`header-action-button copy-comments-button${copied ? ' copied' : ''}`}
       onClick={() => void copyComments()}
       title="Copy review comments"
       type="button"
     >
       {copied ? (
-        <Check aria-hidden className="copy-comments-icon check" size={22} weight="bold" />
+        <Check aria-hidden className="header-action-icon check" size={16} weight="bold" />
       ) : (
-        <LucideCopy aria-hidden className="copy-comments-icon" size={21} strokeWidth={2.25} />
+        <LucideCopy aria-hidden className="header-action-icon" size={15} strokeWidth={2.25} />
       )}
+      <span>{copied ? 'Copied' : 'Copy comments'}</span>
     </button>
   );
 }
@@ -344,30 +345,25 @@ export function PullRequestReviewButtons({
     <>
       <button
         aria-label="Approve pull request"
-        className="review-submit-button approve"
+        className="header-action-button review-submit-button approve"
         disabled={disabled}
         onClick={() => onSubmitReview('APPROVE')}
         title="Approve pull request"
         type="button"
       >
-        <Check aria-hidden className="review-submit-icon approve" size={22} weight="bold" />
+        <Check aria-hidden className="header-action-icon approve" size={16} weight="bold" />
+        <span>Approve</span>
       </button>
       <button
         aria-label="Request changes"
-        className="review-submit-button request-changes"
+        className="header-action-button review-submit-button request-changes"
         disabled={disabled}
         onClick={() => onSubmitReview('REQUEST_CHANGES')}
         title="Request changes"
         type="button"
       >
-        <X
-          aria-hidden
-          className={`review-submit-icon request-changes${
-            submittingEvent === 'REQUEST_CHANGES' ? ' submitting' : ''
-          }`}
-          size={22}
-          weight="bold"
-        />
+        <X aria-hidden className="header-action-icon request-changes" size={16} weight="bold" />
+        <span>Request changes</span>
       </button>
     </>
   );


### PR DESCRIPTION
## Current issues

The action buttons are currently hovering at the bottom of the window:

<img width="223" height="101" alt="Screenshot 2026-06-15 at 20 58 14" src="https://github.com/user-attachments/assets/e72e87b9-7121-497d-b2a6-08cf75d385c8" />

This has some issues with the walkthrough's footer (as you can see in the screenshot) but also, and continuing my notes from #83, the GH buttons are unclear: at first I wasn't sure what they do so I clicked the checkmark and accidentally approved a PR 😬

An unrelated issue for me is that the window title is almost always truncated and when I have multiple Codiff windows open it makes it hard to understand which is which:

<img width="294" height="83" alt="Screenshot 2026-06-15 at 21 01 13" src="https://github.com/user-attachments/assets/f2f1aaf9-e93f-4c5e-a226-0f1ee4989921" />

## Proposed header

Right now when the sidebar is collapsed the header takes up the full width anyway so I thought I'd make it more consistent, and now that it's always there (and wide enough) there's room to put the floating buttons:

<img width="1554" height="63" alt="Screenshot 2026-06-15 at 21 07 05" src="https://github.com/user-attachments/assets/237cfa12-ddb8-470b-8fca-48fb70d33b3e" />

## Related suggestions

* I wanted to add an "Open in GitHub" button but wasn't sure how you'd feel about it
* these buttons are probably too verbose. there wasn't a tooltip component already in the repo and adding one felt like too much for an already presumptuous PR from a first time contributor 🙃
* personally instead of submitting comments one by one and then accepting/rejecting a PR without a message I would prefer to go with what github's web UI encourages, which is to create all the comments as "drafts" and then publish them all at once under a review decision