### PR TITLE
Add custom walkthrough prompt setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ is running so changes apply to open windows.
     "openAIModel": "gpt-5.3-codex-spark",
     "showWhitespace": false,
     "theme": "system",
+    "walkthroughPrompt": "",
     "wordWrap": false,
   },
   "keymap": {
@@ -164,6 +165,10 @@ CODIFF_CLAUDE_PATH=/absolute/path/to/claude codiff --agent claude -w
 
 Claude Code rides your existing `claude` login (subscription or `ANTHROPIC_API_KEY`); run `claude`
 once and complete `/login` if you have not already.
+
+Set `settings.walkthroughPrompt` to add custom instructions to generated walkthrough prompts. Use it
+to request a specific language, tone, or level of detail while Codiff keeps its walkthrough guide,
+hunk ids, review-order constraints, and JSON schema in place.
 
 To drive Codiff from your agent, install its skills from the application menu (`Install Codex Skill`
 or `Install Claude Code Skill`). Codiff updates keep the installed skill current. Invoke it from the

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -13,6 +13,7 @@
     "showOutdated": false,
     "showWhitespace": false,
     "theme": "system",
+    "walkthroughPrompt": "",
     "wordWrap": false
   },
   "keymap": {

--- a/electron/__tests__/narrative-walkthrough.test.ts
+++ b/electron/__tests__/narrative-walkthrough.test.ts
@@ -9,7 +9,12 @@ const {
   narrativeWalkthroughSchema,
   normalizeNarrativeWalkthrough,
 } = require('../narrative-walkthrough.cjs') as {
-  buildNarrativeWalkthroughPrompt: (state: any, context?: unknown, agentLabel?: string) => string;
+  buildNarrativeWalkthroughPrompt: (
+    state: any,
+    context?: unknown,
+    agentLabel?: string,
+    customPrompt?: string,
+  ) => string;
   narrativeWalkthroughResponseSchema: {
     properties: Record<string, any>;
     required: ReadonlyArray<string>;
@@ -220,6 +225,44 @@ test('prompts small walkthroughs to group similar hunks into compact chapters', 
   expect(prompt).toContain('Use 1 story chapter');
   expect(prompt).toContain('For one- or two-file diffs, prefer one chapter');
   expect(prompt).toContain('Similar same-file hunks should usually be one stop');
+});
+
+test('prompts generated walkthroughs with custom user guidance without replacing core constraints', () => {
+  const prompt = buildNarrativeWalkthroughPrompt(
+    {
+      branch: 'main',
+      files: files.slice(0, 1),
+      generatedAt: 1,
+      root: '/repo',
+      source: { type: 'working-tree' },
+    },
+    null,
+    'Claude Code',
+    'Answer in Japanese and use concise reviewer-facing explanations.',
+  );
+
+  expect(prompt).toContain('Custom walkthrough instructions:');
+  expect(prompt).toContain('Answer in Japanese and use concise reviewer-facing explanations.');
+  expect(prompt).toContain('Current Codiff walkthrough guide:');
+  expect(prompt).toContain('Return JSON only.');
+  expect(prompt).toContain('Repository change digest:');
+});
+
+test('omits blank custom walkthrough prompt guidance', () => {
+  const prompt = buildNarrativeWalkthroughPrompt(
+    {
+      branch: 'main',
+      files: files.slice(0, 1),
+      generatedAt: 1,
+      root: '/repo',
+      source: { type: 'working-tree' },
+    },
+    null,
+    'Codex',
+    '   ',
+  );
+
+  expect(prompt).not.toContain('Custom walkthrough instructions:');
 });
 
 test('repository digest exposes deterministic hunk ids and counts', () => {

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -262,6 +262,10 @@ const mergeConfig = (raw) => {
           ? rawSettings.showWhitespace
           : defaults.settings.showWhitespace,
       theme: normalizeTheme(rawSettings.theme),
+      walkthroughPrompt:
+        typeof rawSettings.walkthroughPrompt === 'string'
+          ? rawSettings.walkthroughPrompt
+          : defaults.settings.walkthroughPrompt,
       wordWrap:
         typeof rawSettings.wordWrap === 'boolean'
           ? rawSettings.wordWrap

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1048,7 +1048,13 @@ ipcMain.handle('codiff:getNarrativeWalkthrough', async (event, source) => {
       launchOptions?.walkthroughContext,
       agent.readSessionContext(launchOptions?.[agent.sessionLaunchOptionKey]),
     );
-    return readNarrativeWalkthrough(state, agent, getAgentOptions(agent), walkthroughContext);
+    return readNarrativeWalkthrough(
+      state,
+      agent,
+      getAgentOptions(agent),
+      walkthroughContext,
+      config.settings.walkthroughPrompt,
+    );
   } catch (error) {
     return {
       reason: error instanceof Error ? error.message : String(error),

--- a/electron/narrative-walkthrough.cjs
+++ b/electron/narrative-walkthrough.cjs
@@ -591,6 +591,19 @@ If the context and digest conflict, trust the digest.
 `
     : '';
 
+/** @param {unknown} customPrompt */
+const buildCustomPromptInput = (customPrompt) => {
+  const prompt = typeof customPrompt === 'string' ? customPrompt.trim() : '';
+
+  return prompt
+    ? `Custom walkthrough instructions:
+${prompt}
+
+Use these instructions to customize language, tone, and review detail. If they conflict with the JSON schema, current Codiff walkthrough guide, repository digest, hunk ids, or review-order constraints above, keep Codiff's constraints and the digest as the source of truth.
+`
+    : '';
+};
+
 const buildWalkthroughSizingGuidance = (state) => {
   const fileCount = state.files.length;
   const hunkCount = state.files.reduce(
@@ -648,6 +661,7 @@ const buildNarrativeWalkthroughPrompt = (
   state,
   context,
   agentLabel = 'Codex',
+  customPrompt,
 ) => `You are authoring Codiff's narrative walkthrough JSON.
 
 Return JSON only. Do not inspect the repository or run shell commands; use only the guide, optional conversation context, and repository digest below.
@@ -658,15 +672,16 @@ Current Codiff walkthrough guide:
 ${readFileSync(join(root, 'bin/walkthrough-guide.md'), 'utf8').trim()}
 
 ${buildWalkthroughContextInput(context, agentLabel)}
+${buildCustomPromptInput(customPrompt)}
 Repository change digest:
 ${JSON.stringify(buildPromptInput(state), null, 2)}
 `;
 
-const readNarrativeWalkthrough = async (state, agent, agentOptions, context) => {
+const readNarrativeWalkthrough = async (state, agent, agentOptions, context, customPrompt) => {
   try {
     const response = await agent.run(
       state.root,
-      buildNarrativeWalkthroughPrompt(state, context, agent.label),
+      buildNarrativeWalkthroughPrompt(state, context, agent.label, customPrompt),
       narrativeWalkthroughResponseSchema,
       'walkthrough.json',
       `${agent.label} walkthrough timed out.`,

--- a/src/__tests__/App-render.test.tsx
+++ b/src/__tests__/App-render.test.tsx
@@ -132,6 +132,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
     showOutdated: false,
     showWhitespace: false,
     theme: 'system' as const,
+    walkthroughPrompt: defaultSettings.walkthroughPrompt,
     wordWrap: false,
   })),
   getRepositoryHistory: vi.fn(async () => ({

--- a/src/__tests__/config-defaults.test.ts
+++ b/src/__tests__/config-defaults.test.ts
@@ -59,6 +59,24 @@ test('electron config normalizes code font settings', () => {
   expect(mergeConfig({ settings: { codeFontSize: 99 } }).settings.codeFontSize).toBe(32);
 });
 
+test('electron config keeps custom walkthrough prompt text only when it is a string', () => {
+  expect(
+    mergeConfig({
+      settings: {
+        walkthroughPrompt: 'Respond in German with product-review terminology.',
+      },
+    }).settings.walkthroughPrompt,
+  ).toBe('Respond in German with product-review terminology.');
+
+  expect(
+    mergeConfig({
+      settings: {
+        walkthroughPrompt: ['Respond in German'],
+      },
+    }).settings.walkthroughPrompt,
+  ).toBe('');
+});
+
 test('electron defaults load from packaged app shape', () => {
   const packageRoot = mkdtempSync(join(tmpdir(), 'codiff-package-shape.'));
   mkdirSync(join(packageRoot, 'config'));

--- a/src/config/codiff-config.schema.json
+++ b/src/config/codiff-config.schema.json
@@ -84,6 +84,11 @@
           "default": "system",
           "description": "Application color theme. 'system' follows OS preference."
         },
+        "walkthroughPrompt": {
+          "type": "string",
+          "default": "",
+          "description": "Additional instructions appended to generated walkthrough prompts. Use this to request a language, tone, or level of detail while Codiff keeps its walkthrough guide, hunk ids, review-order constraints, and schema."
+        },
         "wordWrap": {
           "type": "boolean",
           "default": false,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -16,6 +16,7 @@ export type CodiffSettings = {
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
+  walkthroughPrompt: string;
   wordWrap: boolean;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -494,6 +494,7 @@ export type CodiffPreferences = {
   showOutdated: boolean;
   showWhitespace: boolean;
   theme: CodiffTheme;
+  walkthroughPrompt: string;
   wordWrap: boolean;
 };
 


### PR DESCRIPTION
## Summary

- Add `settings.walkthroughPrompt` so users can customize generated narrative walkthrough language, tone, and detail.
- Append custom prompt text to the new narrative walkthrough prompt without replacing Codiff's guide, hunk ids, review-order constraints, repository digest, or JSON schema.
- Document the new setting and cover config normalization plus prompt inclusion with tests.

Reworks #57 after the new walkthrough mode shipped. Addresses #56.

## Validation

- `CI=true PATH=/opt/homebrew/bin:$PATH pnpm exec vp test electron/__tests__/narrative-walkthrough.test.ts src/__tests__/config-defaults.test.ts`
- `CI=true PATH=/opt/homebrew/bin:$PATH pnpm exec vp test`
- `CI=true PATH=/opt/homebrew/bin:$PATH pnpm exec vp check --fix`
- `CI=true PATH=/opt/homebrew/bin:$PATH pnpm exec vp build`
