### PR TITLE
Trust system certificates for share uploads

### DIFF
--- a/electron/__tests__/shared-walkthrough-upload.test.ts
+++ b/electron/__tests__/shared-walkthrough-upload.test.ts
@@ -10,6 +10,7 @@ const { uploadSharedWalkthrough } = require('../shared-walkthrough-upload.cjs') 
     openClaimPage?: boolean;
     serviceUrl: string;
     snapshot: unknown;
+    trustCertificates?: () => { reason?: string; status: string };
     uploader?: { email: string; name: string };
   }) => Promise<string>;
 };
@@ -149,5 +150,63 @@ test('includes the underlying cause when a share request cannot connect', async 
     }),
   ).rejects.toThrow(
     'Codiff share upload intent request failed: fetch failed: ENOTFOUND - getaddrinfo ENOTFOUND api.codiff.dev',
+  );
+});
+
+test('loads certificate trust before the first share request', async () => {
+  const events: Array<string> = [];
+  const trustCertificates = vi.fn(() => {
+    events.push('certificates');
+    return { status: 'applied' };
+  });
+  const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+    events.push(String(input));
+    return Response.json({
+      claimUrl: 'https://codiff.example/connect/CODE?secret=secret',
+      code: 'CODE',
+      pollUrl: 'https://codiff.example/api/upload-intents/CODE?secret=secret',
+      secret: 'secret',
+      status: 'claimed',
+    });
+  });
+
+  await expect(
+    uploadSharedWalkthrough({
+      authenticate: async () => {},
+      fetchImpl,
+      openClaimPage: false,
+      openExternal: async () => {},
+      serviceUrl: 'https://codiff.example',
+      snapshot: { kind: 'codiff-walkthrough-share', version: 1 },
+      trustCertificates,
+    }),
+  ).rejects.toThrow('Codiff share upload failed (200).');
+
+  expect(trustCertificates).toHaveBeenCalledOnce();
+  expect(events[0]).toBe('certificates');
+  expect(events[1]).toBe('https://codiff.example/api/upload-intents');
+});
+
+test('explains certificate trust status for certificate-chain failures', async () => {
+  const certificateError = new Error('self signed certificate in certificate chain');
+  Object.assign(certificateError, { code: 'SELF_SIGNED_CERT_IN_CHAIN' });
+  const networkError = new Error('fetch failed', { cause: certificateError });
+
+  await expect(
+    uploadSharedWalkthrough({
+      authenticate: async () => {},
+      fetchImpl: vi.fn(async () => {
+        throw networkError;
+      }),
+      openExternal: async () => {},
+      serviceUrl: 'https://api.codiff.dev',
+      snapshot: { kind: 'codiff-walkthrough-share', version: 1 },
+      trustCertificates: () => ({
+        reason: 'this Node/Electron runtime does not expose system certificate APIs',
+        status: 'unavailable',
+      }),
+    }),
+  ).rejects.toThrow(
+    'Codiff share upload intent request failed: fetch failed: SELF_SIGNED_CERT_IN_CHAIN - self signed certificate in certificate chain System certificate trust was not applied (this Node/Electron runtime does not expose system certificate APIs).',
   );
 });

--- a/electron/__tests__/system-certificates.test.ts
+++ b/electron/__tests__/system-certificates.test.ts
@@ -1,0 +1,70 @@
+import { createRequire } from 'node:module';
+import { expect, test, vi } from 'vite-plus/test';
+
+const require = createRequire(import.meta.url);
+const { createSystemCertificateTrust } = require('../system-certificates.cjs') as {
+  createSystemCertificateTrust: (tlsImpl: {
+    getCACertificates?: (source?: string) => Array<string>;
+    setDefaultCACertificates?: (certificates: Array<string>) => void;
+  }) => () => { reason?: string; status: string };
+};
+
+test('merges default, extra, and system certificates once', () => {
+  const setDefaultCACertificates = vi.fn();
+  const trustSystemCertificates = createSystemCertificateTrust({
+    getCACertificates: (source) => {
+      if (source === 'default') {
+        return ['default-ca', 'shared-ca'];
+      }
+      if (source === 'extra') {
+        return ['extra-ca', 'shared-ca'];
+      }
+      if (source === 'system') {
+        return ['system-ca', 'extra-ca'];
+      }
+      return [];
+    },
+    setDefaultCACertificates,
+  });
+
+  expect(trustSystemCertificates()).toEqual({ status: 'applied' });
+  expect(trustSystemCertificates()).toEqual({ status: 'applied' });
+  expect(setDefaultCACertificates).toHaveBeenCalledOnce();
+  expect(setDefaultCACertificates).toHaveBeenCalledWith([
+    'default-ca',
+    'shared-ca',
+    'extra-ca',
+    'system-ca',
+  ]);
+});
+
+test('does not mark certificate trust as initialized after a failed apply', () => {
+  const setDefaultCACertificates = vi
+    .fn()
+    .mockImplementationOnce(() => {
+      throw new Error('keychain busy');
+    })
+    .mockImplementationOnce(() => {});
+  const trustSystemCertificates = createSystemCertificateTrust({
+    getCACertificates: (source) => (source === 'system' ? ['system-ca'] : []),
+    setDefaultCACertificates,
+  });
+
+  expect(trustSystemCertificates()).toEqual({ reason: 'keychain busy', status: 'failed' });
+  expect(trustSystemCertificates()).toEqual({ status: 'applied' });
+  expect(setDefaultCACertificates).toHaveBeenCalledTimes(2);
+});
+
+test('reports unavailable and empty system certificate stores', () => {
+  expect(createSystemCertificateTrust({})()).toEqual({
+    reason: 'this Node/Electron runtime does not expose system certificate APIs',
+    status: 'unavailable',
+  });
+
+  expect(
+    createSystemCertificateTrust({
+      getCACertificates: () => [],
+      setDefaultCACertificates: vi.fn(),
+    })(),
+  ).toEqual({ reason: 'the system certificate store was empty', status: 'empty-system' });
+});

--- a/electron/shared-walkthrough-upload.cjs
+++ b/electron/shared-walkthrough-upload.cjs
@@ -1,22 +1,73 @@
 // @ts-check
 
+const { trustSystemCertificates } = require('./system-certificates.cjs');
+
 const poll = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const CERTIFICATE_ERROR_CODES = new Set([
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_GET_ISSUER_CERT',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+]);
+
 /** @param {unknown} error */
-const describeFetchError = (error) => {
+const getErrorCause = (error) =>
+  error && typeof error === 'object' && 'cause' in error && error.cause ? error.cause : null;
+
+/** @param {unknown} error */
+const getErrorCode = (error) =>
+  error && typeof error === 'object' && 'code' in error && typeof error.code === 'string'
+    ? error.code
+    : '';
+
+/** @param {unknown} error */
+const getCertificateErrorCode = (error) => {
+  for (
+    let current = error;
+    current && typeof current === 'object';
+    current = getErrorCause(current)
+  ) {
+    const code = getErrorCode(current);
+    if (CERTIFICATE_ERROR_CODES.has(code)) {
+      return code;
+    }
+  }
+  return '';
+};
+
+/**
+ * @param {ReturnType<typeof trustSystemCertificates>} certificateTrust
+ * @param {string} code
+ */
+const describeCertificateTrust = (certificateTrust, code) => {
+  if (!code || certificateTrust.status === 'applied') {
+    return '';
+  }
+
+  const reason = certificateTrust.reason ? ` (${certificateTrust.reason})` : '';
+  return `System certificate trust was not applied${reason}.`;
+};
+
+/**
+ * @param {unknown} error
+ * @param {ReturnType<typeof trustSystemCertificates>} certificateTrust
+ */
+const describeFetchError = (error, certificateTrust) => {
   const message = error instanceof Error ? error.message : String(error);
-  const cause =
-    error && typeof error === 'object' && 'cause' in error && error.cause ? error.cause : null;
+  const cause = getErrorCause(error);
   if (!cause || typeof cause !== 'object') {
     return message;
   }
 
-  const causeCode = 'code' in cause && typeof cause.code === 'string' ? cause.code : '';
+  const causeCode = getErrorCode(cause);
   const causeMessage = cause instanceof Error ? cause.message : String(cause);
   const causeDetail = [causeCode, causeMessage].filter(
     (detail, index, details) => detail && details.indexOf(detail) === index,
   );
-  return causeDetail.length > 0 ? `${message}: ${causeDetail.join(' - ')}` : message;
+  const detail = causeDetail.length > 0 ? `${message}: ${causeDetail.join(' - ')}` : message;
+  const trustDetail = describeCertificateTrust(certificateTrust, getCertificateErrorCode(error));
+  return [detail, trustDetail].filter(Boolean).join(' ');
 };
 
 /**
@@ -27,6 +78,7 @@ const describeFetchError = (error) => {
  *   openExternal: (url: string) => Promise<void>;
  *   serviceUrl: string;
  *   snapshot: unknown;
+ *   trustCertificates?: typeof trustSystemCertificates;
  *   uploader?: {email?: string; name?: string};
  * }} options
  */
@@ -37,8 +89,11 @@ const uploadSharedWalkthrough = async ({
   openExternal,
   serviceUrl,
   snapshot,
+  trustCertificates = trustSystemCertificates,
   uploader,
 }) => {
+  const certificateTrust = trustCertificates();
+
   const baseUrl = serviceUrl.replace(/\/+$/, '');
   await authenticate();
 
@@ -47,9 +102,12 @@ const uploadSharedWalkthrough = async ({
     try {
       return await fetchImpl(input, init);
     } catch (error) {
-      throw new Error(`Codiff share ${phase} failed: ${describeFetchError(error)}`, {
-        cause: error,
-      });
+      throw new Error(
+        `Codiff share ${phase} failed: ${describeFetchError(error, certificateTrust)}`,
+        {
+          cause: error,
+        },
+      );
     }
   };
 

--- a/electron/system-certificates.cjs
+++ b/electron/system-certificates.cjs
@@ -1,0 +1,86 @@
+// @ts-check
+
+const tls = require('node:tls');
+
+/**
+ * @typedef {{reason?: string; status: 'applied' | 'empty-system' | 'failed' | 'unavailable'}} CertificateTrustStatus
+ */
+
+/** @param {unknown} error */
+const getErrorMessage = (error) => (error instanceof Error ? error.message : String(error));
+
+/**
+ * @param {{
+ *   getCACertificates?: (source?: string) => Array<string>;
+ *   setDefaultCACertificates?: (certificates: Array<string>) => void;
+ * }} tlsImpl
+ */
+const createSystemCertificateTrust = (tlsImpl = tls) => {
+  let initialized = false;
+
+  /** @param {'default' | 'extra' | 'system'} source */
+  const readCertificates = (source) => {
+    try {
+      return {
+        certificates:
+          typeof tlsImpl.getCACertificates === 'function' ? tlsImpl.getCACertificates(source) : [],
+        error: '',
+      };
+    } catch (error) {
+      return { certificates: [], error: getErrorMessage(error) };
+    }
+  };
+
+  /** @returns {CertificateTrustStatus} */
+  return () => {
+    if (initialized) {
+      return { status: 'applied' };
+    }
+
+    if (
+      typeof tlsImpl.getCACertificates !== 'function' ||
+      typeof tlsImpl.setDefaultCACertificates !== 'function'
+    ) {
+      return {
+        reason: 'this Node/Electron runtime does not expose system certificate APIs',
+        status: 'unavailable',
+      };
+    }
+
+    const defaultCertificates = readCertificates('default');
+    const extraCertificates = readCertificates('extra');
+    const systemCertificates = readCertificates('system');
+    const readError = [defaultCertificates, extraCertificates, systemCertificates].find(
+      ({ error }) => error,
+    )?.error;
+    if (readError) {
+      return { reason: readError, status: 'failed' };
+    }
+
+    if (systemCertificates.certificates.length === 0) {
+      return { reason: 'the system certificate store was empty', status: 'empty-system' };
+    }
+
+    try {
+      tlsImpl.setDefaultCACertificates([
+        ...new Set([
+          ...defaultCertificates.certificates,
+          ...extraCertificates.certificates,
+          ...systemCertificates.certificates,
+        ]),
+      ]);
+    } catch (error) {
+      return { reason: getErrorMessage(error), status: 'failed' };
+    }
+
+    initialized = true;
+    return { status: 'applied' };
+  };
+};
+
+const trustSystemCertificates = createSystemCertificateTrust();
+
+module.exports = {
+  createSystemCertificateTrust,
+  trustSystemCertificates,
+};


### PR DESCRIPTION
## Summary
- add a Node/Electron TLS helper that merges default, NODE_EXTRA_CA_CERTS, and system certificate stores
- use it before Codiff share upload fetches and include targeted diagnostics for certificate-chain failures
- add focused tests for certificate merging, retry behavior, upload ordering, and TLS diagnostics

## Validation
- pnpm exec vp check --fix
- pnpm exec vp build
- pnpm exec vp test electron/__tests__/system-certificates.test.ts electron/__tests__/shared-walkthrough-upload.test.ts
