### PR TITLE
Fix blank renderer in dev: source .cjs served without ESM interop

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,44 @@ import tailwindcss from '@tailwindcss/vite';
 import react, { reactCompilerPreset } from '@vitejs/plugin-react';
 import { defineConfig } from 'vite-plus';
 
+// shared/narrative-walkthrough-diff.cjs is a CommonJS module (`module.exports =
+// { ... }`) shared with the Electron main process, but core/ imports it with
+// named ESM imports. The dev server doesn't apply CommonJS->ESM interop to
+// source .cjs files, so it serves the raw `module.exports` — `module` is
+// undefined in the browser and the named imports resolve to nothing, blanking
+// the renderer. This dev-only transform wraps the module so `module.exports`
+// resolves, then re-exports each key as a named ESM export. The production
+// Rollup build already handles CommonJS, so it is unaffected.
+const cjsSourceInterop = () => ({
+  // Dev server only — the production Rollup build handles CommonJS natively, and
+  // injecting ESM exports there would break it ("export statement outside a
+  // module"), since rolldown treats the .cjs as a CommonJS script.
+  apply: 'serve' as const,
+  enforce: 'pre' as const,
+  name: 'codiff-cjs-source-interop',
+  transform(code: string, id: string) {
+    if (!id.split('?')[0].endsWith('shared/narrative-walkthrough-diff.cjs')) {
+      return null;
+    }
+    const match = code.match(/module\.exports\s*=\s*\{([\s\S]*)\}\s*;?\s*$/);
+    if (!match) {
+      return null;
+    }
+    const names = match[1]
+      .split(',')
+      .map((entry) => entry.split(':')[0].trim())
+      .filter((name) => /^[A-Za-z_$][\w$]*$/.test(name));
+    // The exported identifiers are already top-level `const`s in the file, so
+    // re-export the existing bindings instead of redeclaring them. The local
+    // `module` shim makes the original `module.exports = { ... }` a harmless
+    // assignment rather than a reference to an undefined `module`.
+    return {
+      code: `const module = { exports: {} };\n${code}\nexport default module.exports;\nexport { ${names.join(', ')} };\n`,
+      map: null,
+    };
+  },
+});
+
 export default defineConfig({
   base: './',
   fmt: {
@@ -48,6 +86,7 @@ export default defineConfig({
     ],
   },
   plugins: [
+    cjsSourceInterop(),
     babel({
       presets: [reactCompilerPreset()],
     }),


### PR DESCRIPTION
## Summary

`vp dev` / `pnpm dev:app` renders a blank window. The dev server serves the source CommonJS module `shared/narrative-walkthrough-diff.cjs` without applying CommonJS→ESM interop, so the named imports in `core/lib/narrative-walkthrough.ts` resolve to nothing and the renderer never mounts. The production build is fine (Rollup handles CommonJS), so only dev is affected.

## Repro (fresh clone)

- `nkzw-tech/codiff` @ 4c73efa, Node v24.11.0, pnpm 11.0.6, `@voidzero-dev/vite-plus-core` 0.1.24, rolldown 1.0.0-rc.9
- `pnpm install && pnpm dev`, then launch the app → blank window
- The dev server serves `/shared/narrative-walkthrough-diff.cjs?import` as raw `module.exports = { ... }` with no ESM exports. Feeding those exact bytes plus a matching named import to an ESM linker reproduces the browser error:

  ```
  SyntaxError: The requested module '/shared/narrative-walkthrough-diff.cjs?import' does not provide an export named 'filterPatchToHunkIds'
  ```

## Root cause

Vite's dev server only applies CommonJS→ESM interop to pre-bundled `node_modules` deps, not to source `.cjs` files. `core/` imports this shared module with named ESM imports, but it's authored as CommonJS because the Electron main process `require()`s it. `optimizeDeps.include` doesn't help — the file is pre-bundled but the relative source import isn't redirected to the optimized chunk.

## Fix

A small dev-only Vite plugin that, for this one shared module, shims `module` and re-exports its existing top-level bindings as named ESM exports. Production Rollup output is unchanged. `vp check` passes (format, lint, types).

## Note

Happy to take a different direction if you'd prefer — e.g. authoring the shared module as ESM (Node ≥22 supports `require(esm)` for the Electron side), or handling this upstream in vite-plus/rolldown. This patch is the minimal change that unblocks `vp dev`.