### PR TITLE
[codex] Add Arcadia repository support

### DIFF
--- a/bin/arguments.js
+++ b/bin/arguments.js
@@ -2,9 +2,11 @@ import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parseArgs } from 'node:util';
+import arcDetection from '../electron/arc-detection.cjs';
 import reviewSource from '../electron/review-source.cjs';
 
-const { parseReviewUrl, resolveReviewUrl } = reviewSource;
+const { shouldUseArcRepository } = arcDetection;
+const { parseArcReviewUrl, parseReviewUrl, resolveReviewUrl } = reviewSource;
 
 export const flagDefinitions = [
   {
@@ -17,6 +19,17 @@ export const flagDefinitions = [
     argument: '<ref>',
     description: 'Review the current branch against a target branch.',
     name: 'branch',
+    type: 'string',
+  },
+  {
+    description: 'Review an Arc repository instead of a Git repository.',
+    name: 'arc',
+    type: 'boolean',
+  },
+  {
+    argument: '<ref>',
+    description: 'Review the current Arc branch against a target branch.',
+    name: 'arc-base',
     type: 'string',
   },
   {
@@ -91,6 +104,8 @@ export const usageExamples = [
   { command: 'codiff', description: 'Review staged and unstaged changes.' },
   { command: 'codiff /path/to/repo', description: 'Review changes in a specific repository.' },
   { command: 'codiff main', description: 'Review the current branch against main.' },
+  { command: 'codiff --arc', description: 'Review local Arc changes.' },
+  { command: 'codiff --arc --arc-base trunk', description: 'Review Arc branch changes.' },
   { command: 'codiff a1b2c3d', description: 'Review a specific commit.' },
   { command: "codiff '#75'", description: 'Review pull request #75.' },
   { command: 'codiff pr 75', description: 'Review pull request #75 (alternate syntax).' },
@@ -231,6 +246,12 @@ export const parseArguments = (args) => {
 
   let commitRef = typeof values.commit === 'string' ? values.commit : null;
   let branchRef = typeof values.branch === 'string' ? values.branch : null;
+  let arcBase = typeof values['arc-base'] === 'string' ? values['arc-base'] : null;
+  let arc = values.arc === true || arcBase != null;
+  let arcCommitRef = null;
+  let arcPullRequestNumber = null;
+  let arcPullRequestUrl = null;
+  let arcRange = null;
   const codexSessionId =
     typeof values['codex-session'] === 'string' ? values['codex-session'] : null;
   const claudeSessionId =
@@ -262,6 +283,15 @@ export const parseArguments = (args) => {
     if (planFilePath) {
       requestedPath ??= arg;
       continue;
+    }
+    if (arcPullRequestNumber == null) {
+      const arcReview = parseArcReviewUrl(arg);
+      if (arcReview) {
+        arc = true;
+        arcPullRequestNumber = arcReview.number;
+        arcPullRequestUrl = arcReview.url;
+        continue;
+      }
     }
     if (!pullRequestUrl && isPullRequestUrlArgument(arg)) {
       pullRequestUrl = arg;
@@ -303,6 +333,9 @@ export const parseArguments = (args) => {
   }
 
   const repositoryPath = resolve(requestedPath ?? process.cwd());
+  const canUseArcRepository = !planFilePath && !pullRequestUrl;
+  const canInferSource = canUseArcRepository && pullRequestNumber == null;
+  const useArcRepository = canUseArcRepository && (arc || shouldUseArcRepository(repositoryPath));
   let range = null;
   if (rangeCandidate) {
     // Only honor the range when both ends resolve in this repository; otherwise
@@ -312,6 +345,10 @@ export const parseArguments = (args) => {
       isCommitRef(repositoryPath, rangeCandidate.head)
         ? rangeCandidate
         : null;
+    if (!range && useArcRepository) {
+      arc = true;
+      arcRange = rangeCandidate;
+    }
   }
   if (!range && !commitRef && !branchRef && sourceCandidate) {
     const source = resolveSourceCandidate(repositoryPath, sourceCandidate);
@@ -319,9 +356,44 @@ export const parseArguments = (args) => {
       branchRef = source.branchRef;
     } else if (source?.commitRef) {
       commitRef = source.commitRef;
+    } else if (
+      canInferSource &&
+      useArcRepository &&
+      !existsSync(resolve(sourceCandidate)) &&
+      !isExplicitPathArgument(sourceCandidate)
+    ) {
+      arc = true;
+      if (isCommitRefArgument(sourceCandidate)) {
+        arcCommitRef = sourceCandidate;
+      } else {
+        arcBase ??= sourceCandidate;
+      }
     } else if (requestedPath == null) {
       requestedPath = sourceCandidate;
     }
+  }
+  if (useArcRepository && commitRef && !branchRef && !range && !arcRange) {
+    arc = true;
+    arcCommitRef = commitRef;
+    commitRef = null;
+  }
+  if (useArcRepository && pullRequestNumber != null && !pullRequestUrl) {
+    arc = true;
+    arcPullRequestNumber = pullRequestNumber;
+    pullRequestNumber = null;
+    pullRequestProvider = null;
+  }
+  if (
+    canInferSource &&
+    !arc &&
+    !arcBase &&
+    !range &&
+    !commitRef &&
+    !branchRef &&
+    !sourceCandidate &&
+    shouldUseArcRepository(repositoryPath)
+  ) {
+    arc = true;
   }
 
   return {
@@ -332,6 +404,12 @@ export const parseArguments = (args) => {
     ...(piSessionId ? { piSessionId } : {}),
     ...(planFilePath ? { planFilePath: resolve(planFilePath) } : {}),
     ...(branchRef ? { branchRef } : {}),
+    ...(arc ? { arc: true } : {}),
+    ...(arcBase ? { arcBase } : {}),
+    ...(arcCommitRef ? { arcCommitRef } : {}),
+    ...(arcPullRequestNumber != null ? { arcPullRequestNumber } : {}),
+    ...(arcPullRequestUrl ? { arcPullRequestUrl } : {}),
+    ...(arcRange ? { arcRange } : {}),
     ...(range ? { range } : {}),
     commitRef,
     help: values.help === true,

--- a/bin/codiff-app
+++ b/bin/codiff-app
@@ -32,6 +32,8 @@ show_help() {
   printf '\n'
   printf '%s\n' "${blue_bold}Options:${reset}"
   printf '  %-38s%s%s%s\n' "--agent <codex|claude|opencode|pi>" "$gray" "Override the agent backend for this session." "$reset"
+  printf '  %-38s%s%s%s\n' "--arc" "$gray" "Review an Arc repository instead of a Git repository." "$reset"
+  printf '  %-38s%s%s%s\n' "--arc-base <ref>" "$gray" "Review the current Arc branch against a target branch." "$reset"
   printf '  %-38s%s%s%s\n' "--branch <ref>" "$gray" "Review the current branch against a target branch." "$reset"
   printf '  %-38s%s%s%s\n' "--commit <ref>" "$gray" "Review a specific commit." "$reset"
   printf '  %-38s%s%s%s\n' "--codex-session <id>" "$gray" "Attach Codex session metadata to a walkthrough." "$reset"
@@ -51,6 +53,8 @@ show_help() {
   printf '  %-32s%s%s%s\n' "codiff" "$gray" "Review staged and unstaged changes." "$reset"
   printf '  %-32s%s%s%s\n' "codiff /path/to/repo" "$gray" "Review changes in a specific repository." "$reset"
   printf '  %-32s%s%s%s\n' "codiff main" "$gray" "Review the current branch against main." "$reset"
+  printf '  %-32s%s%s%s\n' "codiff --arc" "$gray" "Review local Arc changes." "$reset"
+  printf '  %-32s%s%s%s\n' "codiff --arc --arc-base trunk" "$gray" "Review Arc branch changes." "$reset"
   printf '  %-32s%s%s%s\n' "codiff a1b2c3d" "$gray" "Review a specific commit." "$reset"
   printf '  %-32s%s%s%s\n' "codiff '#75'" "$gray" "Review pull request #75." "$reset"
   printf '  %-32s%s%s%s\n' "codiff pr 75" "$gray" "Review pull request #75 (alternate syntax)." "$reset"
@@ -88,6 +92,10 @@ pi_session_id=""
 agent_backend=""
 branch_ref=""
 commit_ref=""
+arc=0
+arc_base=""
+arc_commit_ref=""
+arc_range=""
 pull_request_source=""
 pull_request_provider=""
 source_ref=""
@@ -100,6 +108,7 @@ expect_claude_session=0
 expect_opencode_session=0
 expect_pi_session=0
 expect_agent=0
+expect_arc_base=0
 expect_branch_ref=0
 expect_commit_ref=0
 expect_pull_request_number=0
@@ -139,6 +148,22 @@ is_explicit_path_arg() {
   return 1
 }
 
+is_range_ref_arg() {
+  if is_explicit_path_arg "$1"; then
+    return 1
+  fi
+
+  printf '%s' "$1" | grep -Eq '^[^.][^[:space:]]*(\.\.\.?)[^.][^[:space:]]*$'
+}
+
+is_arc_repository() {
+  (cd "$1" 2>/dev/null && arc root >/dev/null 2>&1)
+}
+
+arc_review_number() {
+  printf '%s' "$1" | sed -n 's#^https\{0,1\}://a\.yandex-team\.ru/review/\([1-9][0-9]*\)\(/.*\)\{0,1\}$#\1#p'
+}
+
 is_git_branch_ref() {
   git -C "$1" show-ref --verify --quiet "refs/heads/$2" 2>/dev/null ||
     git -C "$1" show-ref --verify --quiet "refs/remotes/$2" 2>/dev/null
@@ -176,6 +201,13 @@ for arg in "$@"; do
   if [ "$expect_agent" -eq 1 ]; then
     agent_backend="$arg"
     expect_agent=0
+    continue
+  fi
+
+  if [ "$expect_arc_base" -eq 1 ]; then
+    arc_base="$arg"
+    arc=1
+    expect_arc_base=0
     continue
   fi
 
@@ -279,6 +311,16 @@ for arg in "$@"; do
     --agent=*)
       agent_backend="${arg#--agent=}"
       ;;
+    --arc)
+      arc=1
+      ;;
+    --arc-base)
+      expect_arc_base=1
+      ;;
+    --arc-base=*)
+      arc_base="${arg#--arc-base=}"
+      arc=1
+      ;;
     --branch)
       expect_branch_ref=1
       ;;
@@ -324,7 +366,11 @@ for arg in "$@"; do
     -*)
       ;;
     *)
-      if [ -z "$pull_request_source" ] && printf '%s' "$arg" | grep -Eiq '^(pr|pull-request)$'; then
+      arc_review="$(arc_review_number "$arg")"
+      if [ -n "$arc_review" ] && [ -z "$pull_request_source" ]; then
+        pull_request_source="$arc_review"
+        arc=1
+      elif [ -z "$pull_request_source" ] && printf '%s' "$arg" | grep -Eiq '^(pr|pull-request)$'; then
         pull_request_provider="pr"
         expect_pull_request_number=1
       elif [ -z "$pull_request_source" ] && printf '%s' "$arg" | grep -Eiq '^(mr|merge-request)$'; then
@@ -355,7 +401,22 @@ if [ -n "$source_ref" ] && [ -z "$commit_ref" ] && [ -z "$branch_ref" ]; then
     *) repository_context="$PWD/$repository_context" ;;
   esac
 
-  if is_commit_ref_arg "$source_ref" && is_git_commit_ref "$repository_context" "$source_ref"; then
+  use_arc_repository=0
+  if [ "$arc" -eq 1 ] || is_arc_repository "$repository_context"; then
+    use_arc_repository=1
+  fi
+
+  if [ "$use_arc_repository" -eq 1 ] && is_range_ref_arg "$source_ref"; then
+    arc_range="$source_ref"
+    arc=1
+  elif [ "$use_arc_repository" -eq 1 ] && [ ! -e "$source_ref" ] && ! is_explicit_path_arg "$source_ref"; then
+    arc=1
+    if is_commit_ref_arg "$source_ref"; then
+      arc_commit_ref="$source_ref"
+    else
+      arc_base="$source_ref"
+    fi
+  elif is_commit_ref_arg "$source_ref" && is_git_commit_ref "$repository_context" "$source_ref"; then
     commit_ref="$source_ref"
   elif is_git_branch_ref "$repository_context" "$source_ref"; then
     branch_ref="$source_ref"
@@ -474,6 +535,10 @@ if [ -n "$plan_file_path" ]; then
     fi
     sleep 0.05
   done
+elif [ "$arc" -eq 1 ] && [ -n "$pull_request_source" ] && [ "$walkthrough" -eq 1 ]; then
+  open_codiff --walkthrough --arc "pr" "$pull_request_source" "$repository_path"
+elif [ "$arc" -eq 1 ] && [ -n "$pull_request_source" ]; then
+  open_codiff --arc "pr" "$pull_request_source" "$repository_path"
 elif [ -n "$pull_request_source" ] && [ -n "$pull_request_provider" ] && [ "$walkthrough" -eq 1 ]; then
   open_codiff --walkthrough "$pull_request_provider" "$pull_request_source" "$repository_path"
 elif [ -n "$pull_request_source" ] && [ -n "$pull_request_provider" ]; then
@@ -482,6 +547,18 @@ elif [ -n "$pull_request_source" ] && [ "$walkthrough" -eq 1 ]; then
   open_codiff --walkthrough "$pull_request_source" "$repository_path"
 elif [ -n "$pull_request_source" ]; then
   open_codiff "$pull_request_source" "$repository_path"
+elif [ "$arc" -eq 1 ] && [ -n "$arc_range" ] && [ "$walkthrough" -eq 1 ]; then
+  open_codiff --walkthrough --arc "$arc_range" "$repository_path"
+elif [ "$arc" -eq 1 ] && [ -n "$arc_range" ]; then
+  open_codiff --arc "$arc_range" "$repository_path"
+elif [ "$arc" -eq 1 ] && [ -n "$arc_commit_ref" ] && [ "$walkthrough" -eq 1 ]; then
+  open_codiff --walkthrough --arc --commit "$arc_commit_ref" "$repository_path"
+elif [ "$arc" -eq 1 ] && [ -n "$arc_commit_ref" ]; then
+  open_codiff --arc --commit "$arc_commit_ref" "$repository_path"
+elif [ "$arc" -eq 1 ] && [ -n "$arc_base" ] && [ "$walkthrough" -eq 1 ]; then
+  open_codiff --walkthrough --arc --arc-base "$arc_base" "$repository_path"
+elif [ "$arc" -eq 1 ] && [ -n "$arc_base" ]; then
+  open_codiff --arc --arc-base "$arc_base" "$repository_path"
 elif [ -n "$commit_ref" ] && [ "$walkthrough" -eq 1 ]; then
   open_codiff --walkthrough --commit "$commit_ref" "$repository_path"
 elif [ -n "$commit_ref" ]; then
@@ -491,7 +568,15 @@ elif [ -n "$branch_ref" ] && [ "$walkthrough" -eq 1 ]; then
 elif [ -n "$branch_ref" ]; then
   open_codiff --branch "$branch_ref" "$repository_path"
 elif [ "$walkthrough" -eq 1 ]; then
-  open_codiff --walkthrough "$repository_path"
+  if [ "$arc" -eq 1 ]; then
+    open_codiff --walkthrough --arc "$repository_path"
+  else
+    open_codiff --walkthrough "$repository_path"
+  fi
 else
-  open_codiff "$repository_path"
+  if [ "$arc" -eq 1 ]; then
+    open_codiff --arc "$repository_path"
+  else
+    open_codiff "$repository_path"
+  fi
 fi

--- a/bin/codiff.js
+++ b/bin/codiff.js
@@ -119,6 +119,12 @@ const run = async () => {
 
   const {
     agentBackend,
+    arc,
+    arcBase,
+    arcCommitRef,
+    arcPullRequestNumber,
+    arcPullRequestUrl,
+    arcRange,
     branchRef,
     claudeSessionId,
     codexSessionId,
@@ -182,24 +188,51 @@ const run = async () => {
       return;
     }
 
-    const source = range
-      ? {
-          base: range.base,
-          head: range.head,
-          symmetric: range.symmetric,
-          type: 'range',
-        }
-      : pullRequestUrl
+    const source = arc
+      ? arcRange
         ? {
-            ...(pullRequestProvider ? { provider: pullRequestProvider } : {}),
-            type: 'pull-request',
-            url: pullRequestUrl,
+            base: arcRange.base,
+            head: arcRange.head,
+            symmetric: arcRange.symmetric,
+            type: 'arc-range',
           }
-        : commitRef
-          ? { ref: commitRef, type: 'commit' }
-          : branchRef
-            ? { ref: branchRef, type: 'branch' }
-            : undefined;
+        : arcCommitRef
+          ? {
+              ref: arcCommitRef,
+              type: 'arc-commit',
+            }
+          : arcPullRequestNumber != null
+            ? {
+                number: arcPullRequestNumber,
+                type: 'arc-pull-request',
+                ...(arcPullRequestUrl ? { url: arcPullRequestUrl } : {}),
+              }
+            : arcBase
+              ? {
+                  base: arcBase,
+                  type: 'arc-branch',
+                }
+              : {
+                  type: 'arc-working-tree',
+                }
+      : range
+        ? {
+            base: range.base,
+            head: range.head,
+            symmetric: range.symmetric,
+            type: 'range',
+          }
+        : pullRequestUrl
+          ? {
+              ...(pullRequestProvider ? { provider: pullRequestProvider } : {}),
+              type: 'pull-request',
+              url: pullRequestUrl,
+            }
+          : commitRef
+            ? { ref: commitRef, type: 'commit' }
+            : branchRef
+              ? { ref: branchRef, type: 'branch' }
+              : undefined;
 
     try {
       const commonOptions = {
@@ -249,6 +282,15 @@ const run = async () => {
   const childEnv = {
     ...process.env,
     CODIFF_AGENT_BACKEND: agentBackend ?? '',
+    CODIFF_ARC: arc ? '1' : '',
+    CODIFF_ARC_BASE: arcBase ?? '',
+    CODIFF_ARC_COMMIT_REF: arcCommitRef ?? '',
+    CODIFF_ARC_PULL_REQUEST_NUMBER:
+      arcPullRequestNumber == null ? '' : String(arcPullRequestNumber),
+    CODIFF_ARC_PULL_REQUEST_URL: arcPullRequestUrl ?? '',
+    CODIFF_ARC_RANGE: arcRange
+      ? `${arcRange.base}${arcRange.symmetric ? '...' : '..'}${arcRange.head}`
+      : '',
     CODIFF_BRANCH_REF: branchRef ?? '',
     CODIFF_CLAUDE_SESSION_ID: claudeSessionId ?? '',
     CODIFF_COMMIT_REF: commitRef ?? '',

--- a/bin/share-codiff.mjs
+++ b/bin/share-codiff.mjs
@@ -88,24 +88,50 @@ if (!pullRequestUrl && parsed.pullRequestNumber != null) {
   );
 }
 
-const source = parsed.range
-  ? {
-      base: parsed.range.base,
-      head: parsed.range.head,
-      symmetric: parsed.range.symmetric,
-      type: 'range',
-    }
-  : pullRequestUrl
+const source = parsed.arc
+  ? parsed.arcRange
     ? {
-        ...(parsed.pullRequestProvider ? { provider: parsed.pullRequestProvider } : {}),
-        type: 'pull-request',
-        url: pullRequestUrl,
+        base: parsed.arcRange.base,
+        head: parsed.arcRange.head,
+        symmetric: parsed.arcRange.symmetric,
+        type: 'arc-range',
       }
-    : parsed.commitRef
-      ? { ref: parsed.commitRef, type: 'commit' }
-      : parsed.branchRef
-        ? { ref: parsed.branchRef, type: 'branch' }
-        : { type: 'working-tree' };
+    : parsed.arcCommitRef
+      ? {
+          ref: parsed.arcCommitRef,
+          type: 'arc-commit',
+        }
+      : parsed.arcPullRequestNumber != null
+        ? {
+            number: parsed.arcPullRequestNumber,
+            type: 'arc-pull-request',
+          }
+        : parsed.arcBase
+          ? {
+              base: parsed.arcBase,
+              type: 'arc-branch',
+            }
+          : {
+              type: 'arc-working-tree',
+            }
+  : parsed.range
+    ? {
+        base: parsed.range.base,
+        head: parsed.range.head,
+        symmetric: parsed.range.symmetric,
+        type: 'range',
+      }
+    : pullRequestUrl
+      ? {
+          ...(parsed.pullRequestProvider ? { provider: parsed.pullRequestProvider } : {}),
+          type: 'pull-request',
+          url: pullRequestUrl,
+        }
+      : parsed.commitRef
+        ? { ref: parsed.commitRef, type: 'commit' }
+        : parsed.branchRef
+          ? { ref: parsed.branchRef, type: 'branch' }
+          : { type: 'working-tree' };
 
 try {
   const sessionId =

--- a/bin/walkthrough-guide.md
+++ b/bin/walkthrough-guide.md
@@ -71,6 +71,8 @@ The `<scope>` segment depends on which diff you anchored against:
 
 - `staged` — the staged diff (`git diff --staged`).
 - `unstaged` — the working-tree diff (`git diff`).
+- `arc` — an Arc diff, including Arc working-tree, Arc commit, Arc range, Arc branch, and
+  Arcanum pull-request sources.
 - `pull-request:<number>` — a pull request.
 - `<commit SHA>` — every commit-like target: a single commit, a branch comparison, or a
   ref range. This is always the **full 40-character SHA of the diff's new (head) side**,

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -107,6 +107,7 @@ import {
   getSourceKey,
   getSourceLabel,
   shouldStartInHistoryWhenEmpty,
+  isWorkingTreeSource,
   supportsDiffSearchContentPreload,
   supportsLazyDiffContent,
   usesViewedFileState,
@@ -406,7 +407,7 @@ export default function App() {
     (file: ChangedFile, _section: DiffSection) => {
       const refresh = async () => {
         const currentState = stateRef.current;
-        if (!currentState || currentState.source.type !== 'working-tree') {
+        if (!currentState || !isWorkingTreeSource(currentState.source)) {
           return true;
         }
         const sourceRequest = sourceRequestRef.current;
@@ -479,7 +480,7 @@ export default function App() {
         if (!nextViewed) {
           const next = { ...current };
           delete next[file.path];
-          if (repositoryState.source.type === 'working-tree') {
+          if (isWorkingTreeSource(repositoryState.source)) {
             writeViewed(repositoryState.root, next);
           }
           return next;
@@ -489,7 +490,7 @@ export default function App() {
           ...current,
           [file.path]: file.fingerprint,
         };
-        if (repositoryState.source.type === 'working-tree') {
+        if (isWorkingTreeSource(repositoryState.source)) {
           writeViewed(repositoryState.root, next);
         }
         return next;
@@ -1590,7 +1591,7 @@ export default function App() {
     const currentState = stateRef.current;
     if (
       !currentState ||
-      currentState.source.type !== 'working-tree' ||
+      !isWorkingTreeSource(currentState.source) ||
       currentState.files.length === 0
     ) {
       return;
@@ -1620,7 +1621,7 @@ export default function App() {
 
       setViewed((current) => {
         const next = updateReviewIdentityViewed(current, reviewIdentity, isViewed);
-        if (currentState.source.type === 'working-tree') {
+        if (isWorkingTreeSource(currentState.source)) {
           writeViewed(currentState.root, next);
         }
         return next;
@@ -2068,7 +2069,8 @@ export default function App() {
       const currentState = stateRef.current;
       const comment = reviewCommentsRef.current.find((candidate) => candidate.id === commentId);
       if (
-        currentState?.source.type !== 'pull-request' ||
+        (currentState?.source.type !== 'pull-request' &&
+          currentState?.source.type !== 'arc-pull-request') ||
         !comment ||
         comment.body.trim().length === 0 ||
         comment.remoteSubmit?.status === 'submitting'
@@ -2124,7 +2126,18 @@ export default function App() {
   const submitPullRequestReview = useCallback(
     (event: PullRequestReviewEvent) => {
       const currentState = stateRef.current;
-      if (currentState?.source.type !== 'pull-request' || pullRequestReviewSubmitting) {
+      if (pullRequestReviewSubmitting) {
+        return;
+      }
+
+      // TODO(arcadia): Wire this to a real Arcanum review-verdict API once one is available.
+      // Posting a regular comment is not equivalent to Approve/Request changes.
+      if (currentState?.source.type === 'arc-pull-request') {
+        window.alert('Arcadia review verdicts are not supported yet. Add inline comments instead.');
+        return;
+      }
+
+      if (currentState?.source.type !== 'pull-request') {
         return;
       }
 
@@ -2211,7 +2224,9 @@ export default function App() {
         root: currentState.root,
         source: currentState.source,
         title:
-          currentState.source.type === 'commit' ? currentState.commitMetadata?.subject : undefined,
+          currentState.source.type === 'commit' || currentState.source.type === 'arc-commit'
+            ? currentState.commitMetadata?.subject
+            : undefined,
       },
       reviewComments: currentState.reviewComments,
       version: 1,
@@ -2298,7 +2313,9 @@ export default function App() {
       ? selectedOrSearchPath
       : (visibleFiles[0]?.path ?? null);
   const hasDiffSearchQuery = diffSearchQuery.trim().length > 0;
-  const isPullRequest = state.source.type === 'pull-request';
+  const canSubmitRemoteComments =
+    state.source.type === 'pull-request' || state.source.type === 'arc-pull-request';
+  const canSubmitPullRequestReview = state.source.type === 'pull-request';
   const isSwitchingSource = pendingSource != null;
   const showAgentUnavailablePanel =
     sidebarMode === 'walkthrough' &&
@@ -2310,8 +2327,9 @@ export default function App() {
       walkthroughError?.code === 'PI_NOT_FOUND');
 
   const sidebarLabel = `${compactPath(state.root)}${state.branch ? ` (${state.branch})` : ''}`;
-  const sidebarSourceLabel =
-    state.source.type !== 'working-tree' ? ` · ${getSourceLabel(state.source)}` : '';
+  const sidebarSourceLabel = !isWorkingTreeSource(state.source)
+    ? ` · ${getSourceLabel(state.source)}`
+    : '';
   const emptySourceDetail = getEmptySourceDetail(state.source, state.root);
 
   const showNarrativeWalkthrough = narrativeWalkthrough != null && sidebarMode === 'walkthrough';
@@ -2319,7 +2337,7 @@ export default function App() {
     ? buildCommitModel(narrativeNavigation.walkthroughView, state.files)
     : buildGenericCommitModel(state.files);
   const showPlainCommitView =
-    mainMode === 'commit' && state.source.type === 'working-tree' && state.files.length > 0;
+    mainMode === 'commit' && isWorkingTreeSource(state.source) && state.files.length > 0;
   const diffLineHeight = getCodeFontLineHeight(
     normalizeCodeFontSizePreference(preferences.codeFontSize),
   );
@@ -2331,14 +2349,17 @@ export default function App() {
     agentLabel,
     collapsed,
     comments: visibleReviewComments,
-    commitMetadata: state.source.type === 'commit' ? (state.commitMetadata ?? null) : null,
+    commitMetadata:
+      state.source.type === 'commit' || state.source.type === 'arc-commit'
+        ? (state.commitMetadata ?? null)
+        : null,
     diffLineHeight,
     diffStyle,
     focusCommentId,
     focusCommentRequest,
     gitIdentity,
     hunkNavigation,
-    isPullRequest,
+    isPullRequest: canSubmitRemoteComments,
     itemVersionByKey,
     keymap: codiffConfig.keymap,
     loadingSectionIds,
@@ -2425,7 +2446,7 @@ export default function App() {
       ) : null}
       <RepositoryChangeBanner
         onReload={reloadWindow}
-        visible={localChangesDetected && (pendingSource ?? state.source).type === 'working-tree'}
+        visible={localChangesDetected && isWorkingTreeSource(pendingSource ?? state.source)}
       />
       <WalkthroughOutdatedBanner
         onDismiss={() => setWalkthroughFileError(null)}
@@ -2458,7 +2479,7 @@ export default function App() {
             reviewCommentsPrefix={preferences.reviewCommentsPrefix}
             showWhitespace={showWhitespace}
           />
-          {isPullRequest ? (
+          {canSubmitPullRequestReview ? (
             <PullRequestReviewButtons
               disabled={pullRequestReviewSubmitting != null}
               onSubmitReview={submitPullRequestReview}
@@ -2498,7 +2519,11 @@ export default function App() {
           </div>
         </div>
         <Sidebar
-          branchSource={historySource?.type === 'branch-diff' ? historySource : null}
+          branchSource={
+            historySource?.type === 'arc-branch' || historySource?.type === 'branch-diff'
+              ? historySource
+              : null
+          }
           commitFiles={state.files}
           commitViewOpen={showPlainCommitView}
           currentSource={pendingSource ?? state.source}
@@ -2520,7 +2545,11 @@ export default function App() {
           onSelectSource={selectSource}
           onShareWalkthrough={enabledShareWalkthrough}
           onToggleCommitView={showPlainCommitView ? closeCommitView : openCommitView}
-          pullRequestSource={historySource?.type === 'pull-request' ? historySource : null}
+          pullRequestSource={
+            historySource?.type === 'arc-pull-request' || historySource?.type === 'pull-request'
+              ? historySource
+              : null
+          }
           reloadDeltaPaths={reloadDeltaPaths}
           searchQuery={sidebarMode === 'history' ? historySearchQuery : fileSearchQuery}
           selectedPath={visibleSelectedPath}

--- a/core/SharedWalkthroughApp.tsx
+++ b/core/SharedWalkthroughApp.tsx
@@ -41,7 +41,7 @@ import {
   updateReviewIdentityCollapsed,
   updateReviewIdentityViewed,
 } from './lib/review-identity.ts';
-import { getSourceLabel, getSourceKey } from './lib/source.ts';
+import { getSourceLabel, getSourceKey, isWorkingTreeSource } from './lib/source.ts';
 import type {
   ChangedFile,
   PullRequestExistingReviewComment,
@@ -369,7 +369,9 @@ export function SharedWalkthroughApp({ snapshot }: { snapshot: SharedWalkthrough
     gitIdentity: null,
     hunkNavigation: null,
     initialMarkdownPreviewSectionIds,
-    isPullRequest: snapshot.repository.source.type === 'pull-request',
+    isPullRequest:
+      snapshot.repository.source.type === 'pull-request' ||
+      snapshot.repository.source.type === 'arc-pull-request',
     isReadOnly: true,
     itemVersionByKey,
     keymap: createDefaultConfig().keymap,
@@ -412,10 +414,9 @@ export function SharedWalkthroughApp({ snapshot }: { snapshot: SharedWalkthrough
     </div>
   );
 
-  const sourceLabel =
-    snapshot.repository.source.type === 'working-tree'
-      ? ''
-      : ` · ${getSourceLabel(snapshot.repository.source)}`;
+  const sourceLabel = isWorkingTreeSource(snapshot.repository.source)
+    ? ''
+    : ` · ${getSourceLabel(snapshot.repository.source)}`;
   const rootLabel = `${compactPath(snapshot.repository.root)}${snapshot.branch ? ` (${snapshot.branch})` : ''}`;
 
   return (

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -632,6 +632,143 @@ test('branch history keeps branch diff available after selecting uncommitted cha
   }
 });
 
+test('Arc branch history keeps Arc sources after selecting local changes and commits', async () => {
+  const branchSource = {
+    base: 'trunk',
+    type: 'arc-branch',
+  } satisfies ReviewSource;
+  const branchState = {
+    ...repositoryState,
+    branch: 'users/reviewer/feature',
+    source: branchSource,
+  } satisfies RepositoryState;
+  const workingTreeState = {
+    ...repositoryState,
+    branch: 'users/reviewer/feature',
+    source: { type: 'arc-working-tree' },
+  } satisfies RepositoryState;
+  const commitState = {
+    ...repositoryState,
+    branch: 'users/reviewer/feature',
+    source: { ref: '99e7b27', type: 'arc-commit' },
+  } satisfies RepositoryState;
+  const getRepositoryState = vi.fn(async (requestedSource?: ReviewSource) =>
+    requestedSource?.type === 'arc-working-tree'
+      ? workingTreeState
+      : requestedSource?.type === 'arc-commit'
+        ? commitState
+        : branchState,
+  );
+
+  window.codiff = createCodiffMock({
+    getRepositoryHistory: vi.fn(async () => ({
+      entries: [
+        {
+          author: 'Reviewer',
+          committedAt: Date.now(),
+          parents: [],
+          ref: '99e7b27',
+          subject: 'Add Arc branch diff review mode',
+        },
+      ],
+      root: '/repo',
+    })),
+    getRepositoryState,
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  const findButton = (label: string) =>
+    Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes(label),
+    );
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+      expect(findButton('Arc branch diff')).toBeTruthy();
+    });
+
+    await act(async () => {
+      findButton('Arc local changes')?.click();
+    });
+
+    await waitFor(() => {
+      expect(getRepositoryState).toHaveBeenCalledWith({ type: 'arc-working-tree' });
+      expect(findButton('Arc branch diff')).toBeTruthy();
+    });
+
+    await act(async () => {
+      findButton('Add Arc branch diff review mode')?.click();
+    });
+
+    await waitFor(() => {
+      expect(getRepositoryState).toHaveBeenCalledWith({ ref: '99e7b27', type: 'arc-commit' });
+    });
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('empty Arc working tree starts in history with Arc history source', async () => {
+  const arcWorkingTreeSource = { type: 'arc-working-tree' } satisfies ReviewSource;
+  const arcWorkingTreeState = {
+    ...repositoryState,
+    branch: 'users/reviewer/feature',
+    files: [],
+    source: arcWorkingTreeSource,
+  } satisfies RepositoryState;
+  const getRepositoryHistory = vi.fn(async () => ({
+    entries: [
+      {
+        author: 'Reviewer',
+        committedAt: Date.now(),
+        parents: [],
+        ref: '99e7b27',
+        subject: 'Arc history commit',
+      },
+    ],
+    root: '/repo',
+  }));
+
+  window.codiff = createCodiffMock({
+    getRepositoryHistory,
+    getRepositoryState: vi.fn(async () => arcWorkingTreeState),
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+      expect(container.textContent).toContain('Arc history commit');
+    });
+    expect(getRepositoryHistory).toHaveBeenCalledWith(expect.any(Number), arcWorkingTreeSource);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
 test('repository reload restores branch diff scope after selecting uncommitted changes', async () => {
   const branchSource = {
     baseRef: 'base123',
@@ -1041,6 +1178,78 @@ test('commit details render inline in the diff view', async () => {
     expect(copyButton.getAttribute('aria-label')).toBe('Commit hash copied');
     expect(copyButton.textContent).toContain(commitMetadata.shortRef);
     expect(copyButton.textContent).not.toContain('Copied');
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('Arc commit details render inline in the diff view', async () => {
+  const changedFile = createChangedFile('src/app.ts');
+  const commitMetadata = {
+    author: {
+      date: '2026-01-01T12:00:00Z',
+      email: '',
+      name: 'Arc Author',
+    },
+    body: 'Arc commit body.',
+    committer: {
+      date: '2026-01-01T12:00:00Z',
+      email: '',
+      name: 'Arc Author',
+    },
+    files: [
+      {
+        additions: 1,
+        binary: false,
+        deletions: 1,
+        path: 'src/app.ts',
+        status: 'modified' as const,
+      },
+    ],
+    parents: ['parent-sha'],
+    ref: 'arc1234',
+    refs: [],
+    shortRef: 'arc1234',
+    signature: { status: 'N' },
+    stats: {
+      additions: 1,
+      binaryFiles: 0,
+      deletions: 1,
+      files: 1,
+      renamedFiles: 0,
+    },
+    subject: 'Arc commit subject',
+    trailers: [],
+  } satisfies CommitMetadata;
+
+  window.codiff = createCodiffMock({
+    getRepositoryState: vi.fn(async () => ({
+      ...repositoryState,
+      commitMetadata,
+      files: [changedFile],
+      source: { ref: 'arc1234', type: 'arc-commit' } satisfies ReviewSource,
+    })),
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+      expect(container.querySelector('.commit-details-panel')?.textContent).toContain(
+        'Arc commit body.',
+      );
+    });
   } finally {
     if (root) {
       await act(async () => root?.unmount());

--- a/core/__tests__/App.test.tsx
+++ b/core/__tests__/App.test.tsx
@@ -516,7 +516,7 @@ test('repository load errors hide raw git output for non-repositories', () => {
   expect(error).toEqual({
     kind: 'not-a-repository',
     message:
-      'Codiff was opened outside a Git repository. Run `codiff` from inside a repo, or choose File → Open Folder… to open one.',
+      'Codiff was opened outside a Git or Arc repository. Run `codiff` from inside a repo, or choose File → Open Folder… to open one.',
   });
 });
 

--- a/core/__tests__/codiff-cli.test.ts
+++ b/core/__tests__/codiff-cli.test.ts
@@ -100,6 +100,100 @@ test('parseArguments treats HEAD positional revisions as commit refs', () => {
   });
 });
 
+test('parseArguments reads Arc options', () => {
+  expect(parseArguments(['--arc'])).toEqual({
+    arc: true,
+    commitRef: null,
+    help: false,
+    pullRequestNumber: null,
+    pullRequestUrl: null,
+    requestedPath: resolve(process.cwd()),
+    version: false,
+    walkthrough: false,
+  });
+
+  expect(parseArguments(['--arc-base', 'trunk', '/arcadia'])).toEqual({
+    arc: true,
+    arcBase: 'trunk',
+    commitRef: null,
+    help: false,
+    pullRequestNumber: null,
+    pullRequestUrl: null,
+    requestedPath: '/arcadia',
+    version: false,
+    walkthrough: false,
+  });
+});
+
+test.sequential('parseArguments auto-detects Arc repositories', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-cli-arc-'));
+  const fakeBin = join(directory, 'bin');
+  const workspace = join(directory, 'workspace');
+  const previousPath = process.env.PATH;
+
+  try {
+    await mkdir(fakeBin);
+    await mkdir(workspace);
+    await writeFile(
+      join(fakeBin, 'arc'),
+      '#!/bin/sh\nif [ "$1" = "root" ]; then pwd; exit 0; fi\nexit 1\n',
+    );
+    await chmod(join(fakeBin, 'arc'), 0o755);
+    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+    const realWorkspace = await realpath(workspace);
+    await git(realWorkspace, ['init']);
+
+    await withCwd(realWorkspace, () => {
+      expect(parseArguments([])).toMatchObject({
+        arc: true,
+        commitRef: null,
+        requestedPath: realWorkspace,
+      });
+      expect(parseArguments(['trunk'])).toMatchObject({
+        arc: true,
+        arcBase: 'trunk',
+        commitRef: null,
+        requestedPath: realWorkspace,
+      });
+      expect(parseArguments(['base..head'])).toMatchObject({
+        arc: true,
+        arcRange: {
+          base: 'base',
+          head: 'head',
+          symmetric: false,
+        },
+        commitRef: null,
+        requestedPath: realWorkspace,
+      });
+      expect(parseArguments(['HEAD'])).toMatchObject({
+        arc: true,
+        arcCommitRef: 'HEAD',
+        commitRef: null,
+        requestedPath: realWorkspace,
+      });
+      expect(parseArguments(['pr', '123'])).toMatchObject({
+        arc: true,
+        arcPullRequestNumber: 123,
+        commitRef: null,
+        pullRequestNumber: null,
+        requestedPath: realWorkspace,
+      });
+      expect(parseArguments(['https://a.yandex-team.ru/review/456/files'])).toMatchObject({
+        arc: true,
+        arcPullRequestNumber: 456,
+        arcPullRequestUrl: 'https://a.yandex-team.ru/review/456',
+        commitRef: null,
+        pullRequestNumber: null,
+        pullRequestUrl: null,
+        requestedPath: realWorkspace,
+      });
+    });
+  } finally {
+    process.env.PATH = previousPath;
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
 test('parseArguments treats plain branch refs as branch refs', async () => {
   await withCwd(refRepositoryPath, () => {
     expect(parseArguments(['feature'])).toEqual({

--- a/core/__tests__/git-state.test.ts
+++ b/core/__tests__/git-state.test.ts
@@ -1,5 +1,14 @@
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -8,6 +17,8 @@ import { expect, test } from 'vite-plus/test';
 import { fileHasVisibleDiff, getDiffLineCount } from '../lib/diff.ts';
 import type {
   DiffSection,
+  DiffImageContentRequest,
+  DiffImageContentResult,
   DiffSectionContentRequest,
   RepositoryState,
   ReviewSource,
@@ -63,9 +74,15 @@ type GitStateModule = {
     limit?: number,
     source?: ReviewSource,
   ) => Promise<{ entries: ReadonlyArray<unknown>; root: string }>;
+  normalizeArcanumReviewComment: (
+    comment: Record<string, unknown>,
+    prNumber: number,
+    prUrl?: string,
+  ) => unknown;
   normalizeGitHubPullRequestCommit: (commit: Record<string, unknown>) => unknown;
   normalizeGitHubReviewComment: (comment: Record<string, unknown>) => unknown;
   normalizePullRequestComment: (comment: Record<string, unknown>) => Record<string, unknown>;
+  parseArcNameStatus: (raw: string) => Array<{ oldPath?: string; path: string; status: string }>;
   parseGitHubPullRequestUrl: (value: string) => {
     number: number;
     owner: string;
@@ -73,13 +90,18 @@ type GitStateModule = {
     url: string;
   };
   parseStatus: (raw: string) => Array<StatusEntry>;
+  readDiffImageContent: (
+    launchPath: string,
+    request: DiffImageContentRequest,
+  ) => Promise<DiffImageContentResult>;
   readDiffSectionContent: (
     launchPath: string,
     request: DiffSectionContentRequest,
   ) => Promise<DiffSection>;
+  readGitIdentity: (launchPath: string) => Promise<{ email: string; name: string }>;
   readRepositoryChangeSignature: (
     launchPath: string,
-  ) => Promise<{ root: string; signature: string }>;
+  ) => Promise<{ head?: string; root: string; signature: string }>;
   readRepositoryState: (
     launchPath: string,
     source?: ReviewSource,
@@ -103,6 +125,20 @@ type GitStateModule = {
     comments: ReadonlyArray<Record<string, unknown>>,
     resolvedCommentIds: ReadonlySet<number>,
   ) => Array<Record<string, unknown>>;
+  submitPullRequestComment: (
+    launchPath: string,
+    request: {
+      comment: {
+        body: string;
+        filePath: string;
+        lineNumber: number;
+        side: 'additions' | 'deletions';
+        startLineNumber?: number;
+        startSide?: 'additions' | 'deletions';
+      };
+      source: Extract<ReviewSource, { type: 'arc-pull-request' | 'pull-request' }>;
+    },
+  ) => Promise<unknown>;
 };
 
 const execFileAsync = promisify(execFile);
@@ -113,18 +149,23 @@ const {
   createPullRequestSection,
   getPullRequestHeadImageSource,
   listRepositoryHistory,
+  normalizeArcanumReviewComment,
   normalizeGitHubPullRequestCommit,
   normalizeGitHubReviewComment,
   normalizePullRequestComment,
+  parseArcNameStatus,
   parseGitHubPullRequestUrl,
   parseStatus,
+  readDiffImageContent,
   readDiffSectionContent,
+  readGitIdentity,
   readRepositoryChangeSignature,
   readRepositoryState,
   readWalkthroughRepositoryState,
   readWorkingTreeState,
   resolvePullRequestContentRefs,
   selectUnresolvedReviewComments,
+  submitPullRequestComment,
 } = require('../../electron/git-state.cjs') as GitStateModule;
 
 const git = async (repo: string, args: ReadonlyArray<string>) => {
@@ -177,6 +218,550 @@ test('parseStatus reads staged rename paths in porcelain v1 -z order', () => {
       untracked: false,
     },
   ]);
+});
+
+test('parseArcNameStatus reads git-style name status rows', () => {
+  expect(parseArcNameStatus('M\tmodified.ts\nA\tadded.ts\nD\tdeleted.ts\n')).toEqual([
+    {
+      path: 'added.ts',
+      status: 'added',
+    },
+    {
+      path: 'deleted.ts',
+      status: 'deleted',
+    },
+    {
+      path: 'modified.ts',
+      status: 'modified',
+    },
+  ]);
+  expect(parseArcNameStatus('R100\told.ts\tnew.ts\n')).toEqual([
+    {
+      oldPath: 'old.ts',
+      path: 'new.ts',
+      status: 'renamed',
+    },
+  ]);
+});
+
+test('normalizeArcanumReviewComment reads inline anchors and ranges', () => {
+  expect(
+    normalizeArcanumReviewComment(
+      {
+        anchor: {
+          review_request: {
+            diff: {
+              file: {
+                entry_id: {
+                  content_id_after: {
+                    path: 'src/file.ts',
+                  },
+                },
+                position: {
+                  line: 10,
+                  side: 'new',
+                  size: 3,
+                },
+              },
+            },
+          },
+        },
+        content: 'Arc comment',
+        created_at: '2026-06-25T08:12:50.000000Z',
+        id: 456,
+        user: {
+          name: 'reviewer',
+        },
+      },
+      123,
+      'https://a.yandex-team.ru/review/123',
+    ),
+  ).toMatchObject({
+    author: { login: 'reviewer' },
+    body: 'Arc comment',
+    filePath: 'src/file.ts',
+    id: 'arcanum:456',
+    lineNumber: 12,
+    side: 'additions',
+    startLineNumber: 10,
+    submittedAt: '2026-06-25T08:12:50.000000Z',
+  });
+});
+
+test.sequential('readRepositoryState auto-detects Arc repositories', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-git-state-arc-'));
+  const fakeBin = join(directory, 'bin');
+  const workspace = join(directory, 'workspace');
+  const previousPath = process.env.PATH;
+
+  try {
+    await mkdir(fakeBin);
+    await mkdir(workspace);
+    await mkdir(join(workspace, 'src'));
+    await writeFile(join(workspace, 'src/new.ts'), 'new file\n');
+    await writeFile(
+      join(workspace, 'image.png'),
+      Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l6D6NwAAAABJRU5ErkJggg==',
+        'base64',
+      ),
+    );
+    await writeFile(
+      join(fakeBin, 'arc'),
+      `#!/bin/sh
+if [ "$1" = "root" ]; then pwd; exit 0; fi
+if [ "$1" = "info" ]; then printf '{"user_login":"arc-login","author":"last-author"}'; exit 0; fi
+if [ "$1" = "branch" ]; then printf "  trunk\\n* feature\\n"; exit 0; fi
+if [ "$1" = "log" ]; then printf '[{"commit":"abc123","parents":["def456"],"author":"arc-user","date":"2026-06-25T13:42:44+03:00","message":"Arc subject\\\\n\\\\nArc body"}]'; exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "status" ]; then printf '{"id":123,"url":"https://a.yandex-team.ru/review/123","author":"arc-author","summary":"Arc PR title","status":"open","from_branch":"users/me/feature","from_id":"abc123","to_branch":"trunk"}'; exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "changes" ]; then printf "\\033[1marc diff base head src/pr.ts\\033[0m\\ndiff --git a/src/pr.ts b/src/pr.ts\\n--- a/src/pr.ts\\n+++ b/src/pr.ts\\n@@ -1 +1 @@\\n-old\\n+new\\n"; exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "history" ]; then printf '{"iterations":[{"timestamp":"2026-06-25T08:03:29.000000Z","commit":"pr123","message":"PR subject"}]}'; exit 0; fi
+if [ "$1" = "status" ]; then printf "?? image.png\\n?? src/new.ts\\n"; exit 0; fi
+if [ "$1" = "diff" ]; then
+  for arg in "$@"; do
+    if [ "$arg" = "--name-status" ]; then printf "M\\tsrc/a.ts\\n"; exit 0; fi
+  done
+  printf "diff --git a/src/a.ts b/src/a.ts\\n--- a/src/a.ts\\n+++ b/src/a.ts\\n@@ -1 +1 @@\\n-old\\n+new\\n"
+  exit 0
+fi
+exit 1
+`,
+    );
+    await writeFile(
+      join(fakeBin, 'ya'),
+      `#!/bin/sh
+printf '%s\\n' "$@" > "${join(directory, 'ya-args.txt')}"
+if [ "$6" = "arcanum_pr_data" ]; then
+  node <<'NODE'
+const text = JSON.stringify({
+  data: [
+    {
+      anchor: {
+        review_request: {
+          diff: {
+            file: {
+              entry_id: {
+                content_id_after: {
+                  path: 'src/pr.ts',
+                },
+              },
+              position: {
+                line: 2,
+                side: 'new',
+                size: 2,
+              },
+            },
+          },
+          id: 123,
+        },
+      },
+      content: 'Existing Arc comment',
+      created_at: '2026-06-25T08:12:50.000000Z',
+      id: 456,
+      user: {
+        name: 'arc-reviewer',
+      },
+    },
+  ],
+});
+process.stdout.write(
+  JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    result: { content: [{ type: 'text', text }], isError: false },
+  }),
+);
+NODE
+  exit 0
+fi
+if [ "$6" = "arcanum_post_comment" ]; then
+  node <<'NODE'
+const text = JSON.stringify({
+  data: {
+    anchor: {
+      review_request: {
+        diff: {
+          file: {
+            entry_id: {
+              content_id_after: {
+                path: 'src/pr.ts',
+              },
+            },
+            position: {
+              line: 4,
+              side: 'old',
+              size: 1,
+            },
+          },
+        },
+        id: 123,
+      },
+    },
+    content: 'Submitted Arc comment',
+    created_at: '2026-06-25T09:12:50.000000Z',
+    id: 789,
+    user: {
+      name: 'me',
+    },
+  },
+});
+process.stdout.write(
+  JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    result: { content: [{ type: 'text', text }], isError: false },
+  }),
+);
+NODE
+  exit 0
+fi
+exit 1
+`,
+    );
+    await chmod(join(fakeBin, 'arc'), 0o755);
+    await chmod(join(fakeBin, 'ya'), 0o755);
+    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+    const realWorkspace = await realpath(workspace);
+    const { stdout: arcanumFixture } = await execFileAsync(
+      'ya',
+      [
+        'tool',
+        'mcp',
+        'connect',
+        'devtools',
+        '--tool',
+        'arcanum_pr_data',
+        '--raw',
+        '--arg',
+        'pr_id:123',
+      ],
+      { cwd: realWorkspace, encoding: 'utf8' },
+    );
+    expect(JSON.parse(JSON.parse(arcanumFixture).result.content[0].text).data[0].content).toBe(
+      'Existing Arc comment',
+    );
+
+    const state = await readRepositoryState(realWorkspace);
+    expect(state.branch).toBe('feature');
+    expect(state.root).toBe(realWorkspace);
+    expect(state.source).toEqual({ type: 'arc-working-tree' });
+    expect(state.files).toHaveLength(3);
+    const modifiedFile = state.files.find((file) => file.path === 'src/a.ts');
+    expect(modifiedFile?.sections[0]?.patch).toContain('diff --git a/src/a.ts b/src/a.ts');
+    const untrackedFile = state.files.find((file) => file.path === 'src/new.ts');
+    expect(untrackedFile?.status).toBe('untracked');
+    expect(untrackedFile?.sections[0]?.patch).toContain('new file mode 100644');
+    const beforeSignature = await readRepositoryChangeSignature(realWorkspace);
+    await writeFile(join(workspace, 'src/new.ts'), 'new file changed\n');
+    const afterSignature = await readRepositoryChangeSignature(realWorkspace);
+    expect(beforeSignature.root).toBe(realWorkspace);
+    expect(beforeSignature.head).toBe('abc123');
+    expect(afterSignature.signature).not.toBe(beforeSignature.signature);
+    const image = await readDiffImageContent(realWorkspace, {
+      kind: 'arc',
+      path: 'image.png',
+      source: { type: 'arc-working-tree' },
+    });
+    expect(image.status).toBe('ready');
+    expect(image.status === 'ready' ? image.newImage?.mimeType : null).toBe('image/png');
+
+    const history = await listRepositoryHistory(realWorkspace, 2, {
+      base: 'trunk',
+      type: 'arc-branch',
+    });
+    expect(history.root).toBe(realWorkspace);
+    expect(history.entries).toEqual([
+      {
+        author: 'arc-user',
+        committedAt: Date.parse('2026-06-25T13:42:44+03:00'),
+        parents: ['def456'],
+        ref: 'abc123',
+        subject: 'Arc subject',
+      },
+    ]);
+
+    const commitState = await readRepositoryState(realWorkspace, {
+      ref: 'abc123',
+      type: 'arc-commit',
+    });
+    expect(commitState.commitMetadata).toMatchObject({
+      author: {
+        email: '',
+        name: 'arc-user',
+      },
+      body: 'Arc body',
+      files: [
+        {
+          additions: 1,
+          binary: false,
+          deletions: 1,
+          path: 'src/a.ts',
+          status: 'modified',
+        },
+      ],
+      parents: ['def456'],
+      ref: 'abc123',
+      shortRef: 'abc123',
+      stats: {
+        additions: 1,
+        binaryFiles: 0,
+        deletions: 1,
+        files: 1,
+        renamedFiles: 0,
+      },
+      subject: 'Arc subject',
+    });
+
+    const pullRequestState = await readRepositoryState(realWorkspace, {
+      number: 123,
+      type: 'arc-pull-request',
+    });
+    expect(pullRequestState.source).toMatchObject({
+      author: 'arc-author',
+      fromBranch: 'users/me/feature',
+      headSha: 'abc123',
+      number: 123,
+      status: 'open',
+      title: 'Arc PR title',
+      toBranch: 'trunk',
+      type: 'arc-pull-request',
+      url: 'https://a.yandex-team.ru/review/123',
+    });
+    expect(pullRequestState.files).toHaveLength(1);
+    expect(pullRequestState.files[0]?.path).toBe('src/pr.ts');
+    expect(pullRequestState.files[0]?.sections[0]?.patch).not.toContain('\u001b');
+    expect(pullRequestState.reviewComments).toMatchObject([
+      {
+        author: { login: 'arc-reviewer' },
+        body: 'Existing Arc comment',
+        filePath: 'src/pr.ts',
+        id: 'arcanum:456',
+        lineNumber: 3,
+        side: 'additions',
+        startLineNumber: 2,
+      },
+    ]);
+    await expect(readGitIdentity(realWorkspace)).resolves.toMatchObject({
+      email: '',
+      name: 'arc-login',
+    });
+
+    const submittedComment = await submitPullRequestComment(realWorkspace, {
+      comment: {
+        body: 'Submitted Arc comment',
+        filePath: 'src/pr.ts',
+        lineNumber: 4,
+        side: 'deletions',
+      },
+      source: {
+        number: 123,
+        type: 'arc-pull-request',
+        url: 'https://a.yandex-team.ru/review/123',
+      },
+    });
+    expect(submittedComment).toMatchObject({
+      author: { login: 'me' },
+      body: 'Submitted Arc comment',
+      filePath: 'src/pr.ts',
+      id: 'arcanum:789',
+      lineNumber: 4,
+      side: 'deletions',
+    });
+    const yaArgs = await readFile(join(directory, 'ya-args.txt'), 'utf8');
+    expect(yaArgs).toContain('arcanum_post_comment');
+    expect(yaArgs).toContain('comment_data:{"content":"Submitted Arc comment"');
+    expect(yaArgs).toContain('diff_side:old');
+    expect(yaArgs).toContain('file_line_number:4');
+    expect(yaArgs).toContain('file_path:src/pr.ts');
+    expect(yaArgs).toContain('pr_id:123');
+
+    const pullRequestHistory = await listRepositoryHistory(realWorkspace, 2, {
+      number: 123,
+      type: 'arc-pull-request',
+    });
+    expect(pullRequestHistory.entries[0]).toMatchObject({
+      ref: 'pr123',
+      subject: 'PR subject',
+    });
+  } finally {
+    process.env.PATH = previousPath;
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test.sequential('readRepositoryState surfaces Arc pull request comment load errors', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-git-state-arc-pr-error-'));
+  const fakeBin = join(directory, 'bin');
+  const workspace = join(directory, 'workspace');
+  const previousPath = process.env.PATH;
+
+  try {
+    await mkdir(fakeBin);
+    await mkdir(workspace);
+    await writeFile(
+      join(fakeBin, 'arc'),
+      `#!/bin/sh
+if [ "$1" = "root" ]; then pwd; exit 0; fi
+if [ "$1" = "branch" ]; then printf "* feature\\n"; exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "status" ]; then printf '{"id":123,"url":"https://a.yandex-team.ru/review/123","summary":"Arc PR title"}'; exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "changes" ]; then printf "diff --git a/src/pr.ts b/src/pr.ts\\n--- a/src/pr.ts\\n+++ b/src/pr.ts\\n@@ -1 +1 @@\\n-old\\n+new\\n"; exit 0; fi
+exit 1
+`,
+    );
+    await writeFile(
+      join(fakeBin, 'ya'),
+      `#!/bin/sh
+printf 'arcanum unavailable' >&2
+exit 42
+`,
+    );
+    await chmod(join(fakeBin, 'arc'), 0o755);
+    await chmod(join(fakeBin, 'ya'), 0o755);
+    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+
+    await expect(
+      readRepositoryState(await realpath(workspace), {
+        number: 123,
+        type: 'arc-pull-request',
+      }),
+    ).rejects.toThrow(/Could not load Arcanum comments for PR #123/);
+  } finally {
+    process.env.PATH = previousPath;
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test.sequential('readWalkthroughRepositoryState falls back to HEAD for a clean Arc working tree', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-git-state-arc-clean-'));
+  const fakeBin = join(directory, 'bin');
+  const workspace = join(directory, 'workspace');
+  const previousPath = process.env.PATH;
+
+  try {
+    await mkdir(fakeBin);
+    await mkdir(workspace);
+    await writeFile(
+      join(fakeBin, 'arc'),
+      `#!/bin/sh
+if [ "$1" = "root" ]; then pwd; exit 0; fi
+if [ "$1" = "branch" ]; then printf "* feature\\n"; exit 0; fi
+if [ "$1" = "status" ]; then exit 0; fi
+if [ "$1" = "log" ]; then printf '[{"commit":"abc123","parents":["def456"],"author":"arc-user","date":"2026-06-25T13:42:44+03:00","message":"Arc subject"}]'; exit 0; fi
+if [ "$1" = "diff" ]; then
+  has_head=false
+  has_name_status=false
+  for arg in "$@"; do
+    if [ "$arg" = "HEAD" ]; then has_head=true; fi
+    if [ "$arg" = "--name-status" ]; then has_name_status=true; fi
+  done
+  if [ "$has_head" = "true" ] && [ "$has_name_status" = "true" ]; then printf "M\\tsrc/head.ts\\n"; exit 0; fi
+  if [ "$has_head" = "true" ]; then printf "diff --git a/src/head.ts b/src/head.ts\\n--- a/src/head.ts\\n+++ b/src/head.ts\\n@@ -1 +1 @@\\n-old\\n+new\\n"; exit 0; fi
+  exit 0
+fi
+exit 1
+`,
+    );
+    await chmod(join(fakeBin, 'arc'), 0o755);
+    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+
+    const state = await readWalkthroughRepositoryState(await realpath(workspace));
+
+    expect(state.source).toEqual({ ref: 'abc123', type: 'arc-commit' });
+    expect(state.files.map((file) => file.path)).toEqual(['src/head.ts']);
+  } finally {
+    process.env.PATH = previousPath;
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test.sequential('readDiffImageContent loads Arc commit image revisions', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-git-state-arc-image-'));
+  const fakeBin = join(directory, 'bin');
+  const workspace = join(directory, 'workspace');
+  const previousPath = process.env.PATH;
+
+  try {
+    await mkdir(fakeBin);
+    await mkdir(workspace);
+    await writeFile(
+      join(fakeBin, 'arc'),
+      `#!/bin/sh
+if [ "$1" = "root" ]; then pwd; exit 0; fi
+if [ "$1" = "diff" ]; then
+  for arg in "$@"; do
+    if [ "$arg" = "--name-status" ]; then printf "M\\timage.png\\n"; exit 0; fi
+  done
+  printf "diff --git a/image.png b/image.png\\n--- a/image.png\\n+++ b/image.png\\n@@ -1 +1 @@\\n-old\\n+new\\n"
+  exit 0
+fi
+if [ "$1" = "show" ] && [ "$2" = "abc123^:image.png" ]; then printf "old-image"; exit 0; fi
+if [ "$1" = "show" ] && [ "$2" = "abc123:image.png" ]; then printf "new-image"; exit 0; fi
+exit 1
+`,
+    );
+    await chmod(join(fakeBin, 'arc'), 0o755);
+    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+
+    const image = await readDiffImageContent(await realpath(workspace), {
+      kind: 'arc',
+      path: 'image.png',
+      source: { ref: 'abc123', type: 'arc-commit' },
+    });
+
+    expect(image.status).toBe('ready');
+    expect(image.status === 'ready' ? image.oldImage?.dataUrl : null).toContain(
+      Buffer.from('old-image').toString('base64'),
+    );
+    expect(image.status === 'ready' ? image.newImage?.dataUrl : null).toContain(
+      Buffer.from('new-image').toString('base64'),
+    );
+  } finally {
+    process.env.PATH = previousPath;
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test.sequential('readDiffImageContent loads Arc pull request image revisions', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-git-state-arc-pr-image-'));
+  const fakeBin = join(directory, 'bin');
+  const workspace = join(directory, 'workspace');
+  const previousPath = process.env.PATH;
+
+  try {
+    await mkdir(fakeBin);
+    await mkdir(workspace);
+    await writeFile(
+      join(fakeBin, 'arc'),
+      `#!/bin/sh
+if [ "$1" = "root" ]; then pwd; exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "status" ]; then printf '{"id":123,"url":"https://a.yandex-team.ru/review/123","from_id":"head123","to_branch":"trunk"}'; exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "changes" ]; then printf "diff --git a/image.png b/image.png\\n--- a/image.png\\n+++ b/image.png\\n@@ -1 +1 @@\\n-old\\n+new\\n"; exit 0; fi
+if [ "$1" = "merge-base" ] && [ "$2" = "trunk" ] && [ "$3" = "head123" ]; then printf "base123\\n"; exit 0; fi
+if [ "$1" = "show" ] && [ "$2" = "base123:image.png" ]; then printf "old-pr-image"; exit 0; fi
+if [ "$1" = "show" ] && [ "$2" = "head123:image.png" ]; then printf "new-pr-image"; exit 0; fi
+exit 1
+`,
+    );
+    await chmod(join(fakeBin, 'arc'), 0o755);
+    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+
+    const image = await readDiffImageContent(await realpath(workspace), {
+      kind: 'arc',
+      path: 'image.png',
+      source: { number: 123, type: 'arc-pull-request' },
+    });
+
+    expect(image.status).toBe('ready');
+    expect(image.status === 'ready' ? image.oldImage?.dataUrl : null).toContain(
+      Buffer.from('old-pr-image').toString('base64'),
+    );
+    expect(image.status === 'ready' ? image.newImage?.dataUrl : null).toContain(
+      Buffer.from('new-pr-image').toString('base64'),
+    );
+  } finally {
+    process.env.PATH = previousPath;
+    await rm(directory, { force: true, recursive: true });
+  }
 });
 
 test('parseGitHubPullRequestUrl reads canonical pull request URLs', () => {

--- a/core/__tests__/narrative-walkthrough-view.test.ts
+++ b/core/__tests__/narrative-walkthrough-view.test.ts
@@ -572,6 +572,11 @@ test('working-tree walkthroughs are committable even without commit seed text', 
     commit: undefined,
     source: { type: 'working-tree' },
   };
+  const arc: NarrativeWalkthrough = {
+    ...walkthrough(),
+    commit: undefined,
+    source: { type: 'arc-working-tree' },
+  };
   const committedReview: NarrativeWalkthrough = {
     ...walkthrough(),
     commit: {},
@@ -579,6 +584,7 @@ test('working-tree walkthroughs are committable even without commit seed text', 
   };
 
   expect(isWalkthroughCommittable(wt)).toBe(true);
+  expect(isWalkthroughCommittable(arc)).toBe(true);
   expect(isWalkthroughCommittable(committedReview)).toBe(false);
 });
 

--- a/core/__tests__/review-comments.test.ts
+++ b/core/__tests__/review-comments.test.ts
@@ -66,6 +66,50 @@ test('getReviewCommentsFromState carries the outdated flag through to review com
   expect(comments.find((comment) => comment.id === 'github:2')?.isOutdated).toBeUndefined();
 });
 
+test('getReviewCommentsFromState maps Arc pull request comments onto Arc diff sections', () => {
+  const comments = getReviewCommentsFromState({
+    ...createPullRequestState(),
+    files: [
+      {
+        fingerprint: 'fingerprint',
+        path: 'src/a.ts',
+        sections: [
+          {
+            binary: false,
+            id: 'src/a.ts:arc',
+            kind: 'arc',
+            patch: '',
+          },
+        ],
+        status: 'modified',
+      },
+    ],
+    reviewComments: [
+      {
+        author: { login: 'arc-reviewer' },
+        body: 'Arc comment.',
+        filePath: 'src/a.ts',
+        id: 'arcanum:1',
+        lineNumber: 5,
+        side: 'additions',
+      },
+    ],
+    source: {
+      number: 123,
+      type: 'arc-pull-request',
+    },
+  });
+
+  expect(comments).toMatchObject([
+    {
+      author: { login: 'arc-reviewer' },
+      body: 'Arc comment.',
+      id: 'arcanum:1',
+      sectionId: 'src/a.ts:arc',
+    },
+  ]);
+});
+
 test('getVisibleReviewComments hides outdated comments unless they are shown', () => {
   const comments = [
     createReviewComment({ id: 'github:1', isOutdated: true }),

--- a/core/app/components/Panels.tsx
+++ b/core/app/components/Panels.tsx
@@ -113,14 +113,15 @@ export function FirstRunPanel({
 }) {
   return (
     <>
-      <strong>Open a Git repository</strong>
+      <strong>Open a repository</strong>
       <p>
         Install the terminal helper, then run{' '}
-        <code className="walkthrough-inline-code">codiff</code> from a Git repository in Terminal.
+        <code className="walkthrough-inline-code">codiff</code> from a Git or Arc repository in
+        Terminal.
       </p>
       <p>
         You can also choose <span className="empty-panel-menu-path">File → Open Folder…</span> to
-        open a Git repository.
+        open a repository.
       </p>
       <div className="empty-panel-actions">
         <button disabled={installing} onClick={onInstallTerminalHelper} type="button">
@@ -140,9 +141,9 @@ export function RepositoryLoadErrorPanel({ error }: { error: RepositoryLoadError
   if (error.kind === 'not-a-repository') {
     return (
       <>
-        <strong>No Git repository found</strong>
+        <strong>No repository found</strong>
         <p>
-          Codiff was opened outside a Git repository. Run{' '}
+          Codiff was opened outside a Git or Arc repository. Run{' '}
           <code className="walkthrough-inline-code">codiff</code> from inside a repo, or choose{' '}
           <span className="empty-panel-menu-path">File → Open Folder…</span> to open one.
         </p>

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -89,6 +89,7 @@ import {
 } from '../../lib/review-comments.ts';
 import { getReviewIdentity, isReviewIdentityViewed } from '../../lib/review-identity.ts';
 import { applySearchHighlights } from '../../lib/search-highlights.ts';
+import { isWorkingTreeSource } from '../../lib/source.ts';
 import type {
   ChangedFile,
   CommitMetadata,
@@ -1453,7 +1454,7 @@ export function ReviewCodeView({
       : (blocks?.map((block) => block.file).filter((file): file is ChangedFile => file != null) ??
         []);
   const initialEditableMarkdownSections =
-    !isReadOnly && source.type === 'working-tree'
+    !isReadOnly && isWorkingTreeSource(source)
       ? initialMarkdownFiles.flatMap((file) => {
           const section = file.sections.at(-1);
           return file.status !== 'deleted' && isMarkdownFilePath(file.path) && section
@@ -1477,7 +1478,7 @@ export function ReviewCodeView({
   >({});
   const [selectedLines, setSelectedLines] = useState<CodeViewLineSelection | null>(null);
   const selectedLinesRef = useRef<CodeViewLineSelection | null>(null);
-  const commitRef = source.type === 'commit' ? source.ref : null;
+  const commitRef = source.type === 'commit' || source.type === 'arc-commit' ? source.ref : null;
   const commitDetailsItemId = commitRef ? `commit-details:${commitRef}` : null;
   const [commitDetailsLayoutPass, setCommitDetailsLayoutPass] = useState(0);
   const [commitDetailsCollapseState, setCommitDetailsCollapseState] = useState<{
@@ -1628,7 +1629,7 @@ export function ReviewCodeView({
         const canEditMarkdown =
           canRenderMarkdown &&
           !isReadOnly &&
-          source.type === 'working-tree' &&
+          isWorkingTreeSource(source) &&
           file.status !== 'deleted' &&
           file.sections.at(-1)?.id === section.id;
         const isMarkdownPreview = canRenderMarkdown && markdownPreviewSections.has(section.id);
@@ -1847,7 +1848,7 @@ export function ReviewCodeView({
     reviewBlocks,
     selectedPath,
     showWhitespace,
-    source.type,
+    source,
     viewed,
     reviewIdentityByPath,
     walkthroughNotes,
@@ -2124,7 +2125,7 @@ export function ReviewCodeView({
       clearCommentLineHighlight();
       if (
         markdownPreviewSections.has(section.id) &&
-        source.type === 'working-tree' &&
+        isWorkingTreeSource(source) &&
         file.status !== 'deleted'
       ) {
         if (refreshingMarkdownSectionsRef.current.has(section.id)) {
@@ -2153,7 +2154,7 @@ export function ReviewCodeView({
         return next;
       });
     },
-    [clearCommentLineHighlight, markdownPreviewSections, onRefreshMarkdown, source.type],
+    [clearCommentLineHighlight, markdownPreviewSections, onRefreshMarkdown, source],
   );
 
   const workerPoolOptions = useMemo(

--- a/core/app/components/Sidebar.tsx
+++ b/core/app/components/Sidebar.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../lib/diff.ts';
 import { fileTreeSort, statusForTree } from '../../lib/files.ts';
 import { isNativeInputTarget } from '../../lib/keyboard.ts';
-import { getShortRef, getSourceKey } from '../../lib/source.ts';
+import { getShortRef, getSourceKey, isWorkingTreeSource } from '../../lib/source.ts';
 import type { ChangedFile, HistoryEntry, NarrativeWalkthrough, ReviewSource } from '../../types.ts';
 import { Gravatar } from './Gravatar.tsx';
 import { NarrativeSidebar } from './walkthrough/NarrativeSidebar.tsx';
@@ -64,7 +64,7 @@ export function Sidebar({
   walkthroughLoading,
   walkthroughUnread,
 }: {
-  branchSource: Extract<ReviewSource, { type: 'branch-diff' }> | null;
+  branchSource: Extract<ReviewSource, { type: 'arc-branch' | 'branch-diff' }> | null;
   commitFiles: ReadonlyArray<ChangedFile>;
   commitViewOpen: boolean;
   currentSource: ReviewSource;
@@ -112,7 +112,7 @@ export function Sidebar({
   );
   const showTotalLineCount = mode !== 'history' && totalLineCount.countable;
   const showCommitButton =
-    mode === 'tree' && currentSource.type === 'working-tree' && commitFiles.length > 0;
+    mode === 'tree' && isWorkingTreeSource(currentSource) && commitFiles.length > 0;
   const showFooter = showTotalLineCount || showCommitButton;
   const lineCountsByPathRef = useRef(lineCountsByPath);
   const reloadDeltaGitStatusCSS = useMemo(
@@ -532,7 +532,7 @@ function HistorySidebar({
   pullRequestSource,
   searchQuery,
 }: {
-  branchSource: Extract<ReviewSource, { type: 'branch-diff' }> | null;
+  branchSource: Extract<ReviewSource, { type: 'arc-branch' | 'branch-diff' }> | null;
   currentSource: ReviewSource;
   entries: ReadonlyArray<HistoryEntry>;
   hasMore: boolean;
@@ -546,15 +546,22 @@ function HistorySidebar({
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const listRef = useRef<HTMLDivElement>(null);
   const rows = useMemo(() => {
+    const contextSource = pullRequestSource ?? branchSource ?? currentSource;
+    const localSource = (
+      contextSource.type.startsWith('arc-')
+        ? { type: 'arc-working-tree' }
+        : { type: 'working-tree' }
+    ) satisfies ReviewSource;
+    const commitType = contextSource.type.startsWith('arc-') ? 'arc-commit' : 'commit';
     const commitRows = entries.map((entry) => ({
       author: entry.author,
       committedAt: entry.committedAt,
       gravatarUrl: entry.gravatarUrl,
-      key: `commit:${entry.ref}`,
+      key: `${commitType}:${entry.ref}`,
       kind: 'entry' as const,
       ref: entry.ref,
       scope: entry.scope,
-      source: { ref: entry.ref, type: 'commit' } satisfies ReviewSource,
+      source: { ref: entry.ref, type: commitType } satisfies ReviewSource,
       subject: entry.subject,
     }));
     const matchesQuery = (row: (typeof commitRows)[number]) =>
@@ -579,9 +586,18 @@ function HistorySidebar({
               gravatarUrl: undefined,
               key: getSourceKey(pullRequestSource),
               kind: 'entry' as const,
-              ref: pullRequestSource.number ? `PR #${pullRequestSource.number}` : 'PR',
+              ref:
+                pullRequestSource.type === 'arc-pull-request'
+                  ? `Arc PR #${pullRequestSource.number}`
+                  : pullRequestSource.number
+                    ? `PR #${pullRequestSource.number}`
+                    : 'PR',
               source: pullRequestSource satisfies ReviewSource,
-              subject: pullRequestSource.title || 'Pull Request',
+              subject:
+                pullRequestSource.title ||
+                (pullRequestSource.type === 'arc-pull-request'
+                  ? 'Arc Pull Request'
+                  : 'Pull Request'),
             }
           : null,
         {
@@ -610,11 +626,13 @@ function HistorySidebar({
               author: null,
               committedAt: null,
               gravatarUrl: undefined,
-              key: 'working-tree',
+              key: getSourceKey(localSource),
               kind: 'entry' as const,
               ref: '',
-              source: { type: 'working-tree' } satisfies ReviewSource,
-              subject: 'Uncommitted changes',
+              source: localSource,
+              subject: contextSource.type.startsWith('arc-')
+                ? 'Arc local changes'
+                : 'Uncommitted changes',
             }
           : null,
         !normalizedQuery
@@ -626,7 +644,10 @@ function HistorySidebar({
               kind: 'entry' as const,
               ref: 'branch',
               source: branchSource satisfies ReviewSource,
-              subject: `Branch diff vs ${branchSource.ref}`,
+              subject:
+                branchSource.type === 'arc-branch'
+                  ? `Arc branch diff vs ${branchSource.base}`
+                  : `Branch diff vs ${branchSource.ref}`,
             }
           : null,
         localRows.length > 0
@@ -647,16 +668,18 @@ function HistorySidebar({
             author: null,
             committedAt: null,
             gravatarUrl: undefined,
-            key: 'working-tree',
+            key: getSourceKey(localSource),
             kind: 'entry' as const,
             ref: '',
-            source: { type: 'working-tree' } satisfies ReviewSource,
-            subject: 'Uncommitted changes',
+            source: localSource,
+            subject: contextSource.type.startsWith('arc-')
+              ? 'Arc local changes'
+              : 'Uncommitted changes',
           }
         : null,
       ...localRows,
     ].filter((row): row is NonNullable<typeof row> => row != null);
-  }, [branchSource, entries, normalizedQuery, pullRequestSource]);
+  }, [branchSource, currentSource, entries, normalizedQuery, pullRequestSource]);
   const maybeLoadMore = useCallback(() => {
     const element = listRef.current;
     if (!element || loading || !hasMore || normalizedQuery) {
@@ -690,9 +713,12 @@ function HistorySidebar({
             type="button"
           >
             <span className="history-entry-ref">
-              {row.source.type === 'commit'
+              {row.source.type === 'commit' || row.source.type === 'arc-commit'
                 ? getShortRef(row.source.ref)
-                : row.source.type === 'pull-request' || row.source.type === 'branch-diff'
+                : row.source.type === 'pull-request' ||
+                    row.source.type === 'arc-pull-request' ||
+                    row.source.type === 'branch-diff' ||
+                    row.source.type === 'arc-branch'
                   ? row.ref
                   : 'local'}
             </span>

--- a/core/lib/app-types.ts
+++ b/core/lib/app-types.ts
@@ -114,7 +114,10 @@ export type ReviewComment = {
 
 export type SidebarMode = 'tree' | 'walkthrough' | 'history';
 
-export type PullRequestSource = Extract<ReviewSource, { type: 'pull-request' }>;
+export type PullRequestSource = Extract<
+  ReviewSource,
+  { type: 'arc-pull-request' | 'pull-request' }
+>;
 
 export type WalkthroughNote = {
   action: 'review' | 'scan' | 'skim';

--- a/core/lib/code-view-options.ts
+++ b/core/lib/code-view-options.ts
@@ -17,6 +17,7 @@ export const statusLabel: Record<GitFileStatus, string> = {
 };
 
 export const sectionLabel: Record<DiffSection['kind'], string> = {
+  arc: 'Arc',
   commit: 'Commit',
   'pull-request': 'PR',
   staged: 'Staged',

--- a/core/lib/narrative-walkthrough.ts
+++ b/core/lib/narrative-walkthrough.ts
@@ -16,6 +16,7 @@ import type {
   WalkthroughStop,
 } from '../types.ts';
 import { getDiffLineCount, getVisibleDiffSections } from './diff.ts';
+import { isWorkingTreeSource } from './source.ts';
 
 export type NarrativeLineCount = {
   added: number;
@@ -253,7 +254,7 @@ export const getUncoveredWalkthroughFileLineItems = (
   });
 
 export const isWalkthroughCommittable = (walkthrough: NarrativeWalkthrough): boolean =>
-  walkthrough.source.type === 'working-tree';
+  isWorkingTreeSource(walkthrough.source);
 
 const groupSupportByReason = (
   support: ReadonlyArray<WalkthroughSupportGroup>,

--- a/core/lib/reload-selection.ts
+++ b/core/lib/reload-selection.ts
@@ -39,6 +39,39 @@ const isReviewSource = (value: unknown): value is ReviewSource => {
     return true;
   }
 
+  if (value.type === 'arc-working-tree') {
+    return true;
+  }
+
+  if (value.type === 'arc-branch') {
+    return typeof value.base === 'string';
+  }
+
+  if (value.type === 'arc-commit') {
+    return typeof value.ref === 'string';
+  }
+
+  if (value.type === 'arc-pull-request') {
+    return (
+      typeof value.number === 'number' &&
+      isOptionalString(value.author) &&
+      isOptionalString(value.fromBranch) &&
+      isOptionalString(value.headSha) &&
+      isOptionalString(value.status) &&
+      isOptionalString(value.title) &&
+      isOptionalString(value.toBranch) &&
+      isOptionalString(value.url)
+    );
+  }
+
+  if (value.type === 'arc-range') {
+    return (
+      typeof value.base === 'string' &&
+      typeof value.head === 'string' &&
+      typeof value.symmetric === 'boolean'
+    );
+  }
+
   if (value.type === 'commit') {
     return typeof value.ref === 'string';
   }

--- a/core/lib/review-comments.ts
+++ b/core/lib/review-comments.ts
@@ -291,7 +291,7 @@ export const buildReviewCommentsMarkdown = (
 };
 
 export const getReviewCommentsFromState = (state: RepositoryState): ReadonlyArray<ReviewComment> =>
-  state.source.type === 'pull-request'
+  state.source.type === 'pull-request' || state.source.type === 'arc-pull-request'
     ? (state.reviewComments ?? []).flatMap((comment) => {
         const file = state.files.find((candidate) => candidate.path === comment.filePath);
         const section = file?.sections[0];

--- a/core/lib/source.ts
+++ b/core/lib/source.ts
@@ -5,6 +5,9 @@ import { compactPath } from './files.ts';
 const rangeLabel = (source: Extract<ReviewSource, { type: 'range' }>) =>
   `${source.base}${source.symmetric ? '...' : '..'}${source.head}`;
 
+const arcRangeLabel = (source: Extract<ReviewSource, { type: 'arc-range' }>) =>
+  `${source.base}${source.symmetric ? '...' : '..'}${source.head}`;
+
 type SourceCapabilities = {
   emptyTitle: string;
   historySource: boolean;
@@ -15,6 +18,46 @@ type SourceCapabilities = {
 };
 
 const sourceCapabilitiesByType = {
+  'arc-branch': {
+    emptyTitle: 'No Arc branch changes',
+    historySource: true,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: true,
+    startInHistoryWhenEmpty: true,
+    viewedFileState: false,
+  },
+  'arc-commit': {
+    emptyTitle: 'No changes in Arc commit',
+    historySource: false,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: false,
+    startInHistoryWhenEmpty: false,
+    viewedFileState: false,
+  },
+  'arc-pull-request': {
+    emptyTitle: 'No Arc PR changes',
+    historySource: true,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: false,
+    startInHistoryWhenEmpty: false,
+    viewedFileState: false,
+  },
+  'arc-range': {
+    emptyTitle: 'No changes in Arc range',
+    historySource: false,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: false,
+    startInHistoryWhenEmpty: false,
+    viewedFileState: false,
+  },
+  'arc-working-tree': {
+    emptyTitle: 'No Arc local changes',
+    historySource: true,
+    lazyDiffContent: true,
+    preloadDiffSearchContent: true,
+    startInHistoryWhenEmpty: true,
+    viewedFileState: true,
+  },
   branch: {
     emptyTitle: 'No branch changes',
     historySource: true,
@@ -68,18 +111,34 @@ const sourceCapabilitiesByType = {
 export const getSourceCapabilities = (source: ReviewSource) =>
   sourceCapabilitiesByType[source.type];
 
-export const getSourceKey = (source: ReviewSource) =>
-  source.type === 'commit'
-    ? `commit:${source.ref}`
-    : source.type === 'branch-diff'
-      ? `branch-diff:${source.ref}:${source.baseRef}:${source.headRef}`
-      : source.type === 'branch'
-        ? `branch:${source.ref}`
-        : source.type === 'range'
-          ? `range:${rangeLabel(source)}`
-          : source.type === 'pull-request'
-            ? `pull-request:${source.provider ?? ''}:${source.host ?? ''}:${source.projectPath ?? `${source.owner ?? ''}/${source.repo ?? ''}`}#${source.number ?? source.url}`
-            : 'working-tree';
+export const getSourceKey = (source: ReviewSource) => {
+  switch (source.type) {
+    case 'arc-branch':
+      return `arc-branch:${source.base}`;
+    case 'arc-commit':
+      return `arc-commit:${source.ref}`;
+    case 'arc-pull-request':
+      return `arc-pull-request:${source.number}`;
+    case 'arc-range':
+      return `arc-range:${arcRangeLabel(source)}`;
+    case 'arc-working-tree':
+      return 'arc-working-tree';
+    case 'branch':
+      return `branch:${source.ref}`;
+    case 'branch-diff':
+      return `branch-diff:${source.ref}:${source.baseRef}:${source.headRef}`;
+    case 'commit':
+      return `commit:${source.ref}`;
+    case 'pull-request':
+      return `pull-request:${source.provider ?? ''}:${source.host ?? ''}:${
+        source.projectPath ?? `${source.owner ?? ''}/${source.repo ?? ''}`
+      }#${source.number ?? source.url}`;
+    case 'range':
+      return `range:${rangeLabel(source)}`;
+    case 'working-tree':
+      return 'working-tree';
+  }
+};
 
 const getErrorMessage = (error: unknown) =>
   error instanceof Error ? error.message : String(error);
@@ -90,7 +149,7 @@ export const getRepositoryLoadError = (error: unknown): RepositoryLoadError => {
     ? {
         kind: 'not-a-repository',
         message:
-          'Codiff was opened outside a Git repository. Run `codiff` from inside a repo, or choose File → Open Folder… to open one.',
+          'Codiff was opened outside a Git or Arc repository. Run `codiff` from inside a repo, or choose File → Open Folder… to open one.',
       }
     : {
         kind: 'generic',
@@ -100,20 +159,37 @@ export const getRepositoryLoadError = (error: unknown): RepositoryLoadError => {
 
 export const getShortRef = (ref: string) => ref.slice(0, 7);
 
-export const getSourceLabel = (source: ReviewSource) =>
-  source.type === 'commit'
-    ? getShortRef(source.ref)
-    : source.type === 'branch' || source.type === 'branch-diff'
-      ? `Branch vs ${source.ref}`
-      : source.type === 'range'
-        ? rangeLabel(source)
-        : source.type === 'pull-request'
-          ? source.number
-            ? `${source.provider === 'gitlab' ? 'MR' : 'PR'} #${source.number}`
-            : source.provider === 'gitlab'
-              ? 'Merge request'
-              : 'Pull request'
-          : 'Uncommitted';
+export const getSourceLabel = (source: ReviewSource) => {
+  switch (source.type) {
+    case 'arc-branch':
+      return `Arc branch vs ${source.base}`;
+    case 'arc-commit':
+      return `Arc commit ${getShortRef(source.ref)}`;
+    case 'arc-pull-request':
+      return source.title
+        ? `Arc PR #${source.number}: ${source.title}`
+        : `Arc PR #${source.number}`;
+    case 'arc-range':
+      return `Arc ${arcRangeLabel(source)}`;
+    case 'arc-working-tree':
+      return 'Arc local changes';
+    case 'branch':
+    case 'branch-diff':
+      return `Branch vs ${source.ref}`;
+    case 'commit':
+      return getShortRef(source.ref);
+    case 'pull-request':
+      return source.number
+        ? `${source.provider === 'gitlab' ? 'MR' : 'PR'} #${source.number}`
+        : source.provider === 'gitlab'
+          ? 'Merge request'
+          : 'Pull request';
+    case 'range':
+      return rangeLabel(source);
+    case 'working-tree':
+      return 'Uncommitted';
+  }
+};
 
 export const getHistorySource = (source: ReviewSource): ReviewSource | undefined =>
   getSourceCapabilities(source).historySource ? source : undefined;
@@ -130,6 +206,9 @@ export const shouldStartInHistoryWhenEmpty = (source: ReviewSource) =>
 export const usesViewedFileState = (source: ReviewSource) =>
   getSourceCapabilities(source).viewedFileState;
 
+export const isWorkingTreeSource = (source: ReviewSource) =>
+  source.type === 'working-tree' || source.type === 'arc-working-tree';
+
 export const getEmptySourceTitle = (source: ReviewSource) =>
   getSourceCapabilities(source).emptyTitle;
 
@@ -139,6 +218,14 @@ export const getEmptySourceDetail = (
 ): { kind: 'code' | 'text'; text: string; title?: string } =>
   source.type === 'commit'
     ? { kind: 'text', text: getShortRef(source.ref) }
-    : source.type === 'branch' || source.type === 'branch-diff'
-      ? { kind: 'text', text: source.ref }
-      : { kind: 'code', text: compactPath(root), title: root };
+    : source.type === 'arc-commit'
+      ? { kind: 'text', text: getShortRef(source.ref) }
+      : source.type === 'arc-pull-request'
+        ? { kind: 'text', text: `#${source.number}` }
+        : source.type === 'arc-range'
+          ? { kind: 'text', text: arcRangeLabel(source) }
+          : source.type === 'arc-branch'
+            ? { kind: 'text', text: source.base }
+            : source.type === 'branch' || source.type === 'branch-diff'
+              ? { kind: 'text', text: source.ref }
+              : { kind: 'code', text: compactPath(root), title: root };

--- a/core/types.ts
+++ b/core/types.ts
@@ -4,7 +4,7 @@ import type { CodiffDiffStyle } from './config/types.ts';
 export type DiffSection = {
   binary: boolean;
   id: string;
-  kind: 'commit' | 'pull-request' | 'staged' | 'unstaged';
+  kind: 'arc' | 'commit' | 'pull-request' | 'staged' | 'unstaged';
   loadState?: 'binary' | 'deferred' | 'directory' | 'error' | 'ready' | 'too-large';
   newFile?: {
     cacheKey?: string;
@@ -38,6 +38,38 @@ export type ChangedFile = {
 };
 
 export type ReviewSource =
+  | {
+      type: 'arc-working-tree';
+    }
+  | {
+      /** Target branch the current Arc branch is compared against. */
+      base: string;
+      type: 'arc-branch';
+    }
+  | {
+      /** Arc base ref (left side). For symmetric ranges, Arc compares merge-base(base, head) to head. */
+      base: string;
+      /** Arc head ref (right side). */
+      head: string;
+      /** `true` for Arc `--base`, `false` for a direct two-ref diff. */
+      symmetric: boolean;
+      type: 'arc-range';
+    }
+  | {
+      ref: string;
+      type: 'arc-commit';
+    }
+  | {
+      author?: string;
+      fromBranch?: string;
+      headSha?: string;
+      number: number;
+      status?: string;
+      title?: string;
+      toBranch?: string;
+      type: 'arc-pull-request';
+      url?: string;
+    }
   | {
       type: 'working-tree';
     }
@@ -662,12 +694,12 @@ export type PullRequestReviewEvent = 'APPROVE' | 'REQUEST_CHANGES';
 
 export type SubmitPullRequestCommentRequest = {
   comment: PullRequestReviewComment;
-  source: Extract<ReviewSource, { type: 'pull-request' }>;
+  source: Extract<ReviewSource, { type: 'arc-pull-request' | 'pull-request' }>;
 };
 
 export type SubmitPullRequestReviewRequest = {
   body?: string;
   comments: ReadonlyArray<PullRequestReviewComment>;
   event: PullRequestReviewEvent;
-  source: Extract<ReviewSource, { type: 'pull-request' }>;
+  source: Extract<ReviewSource, { type: 'arc-pull-request' | 'pull-request' }>;
 };

--- a/electron/__tests__/codex.test.ts
+++ b/electron/__tests__/codex.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -128,12 +128,16 @@ test('runs Codex walkthroughs as fresh ephemeral repository-scoped calls', async
   const directory = await mkdtemp(join(tmpdir(), 'codiff-codex-'));
   const fakeCodexPath = join(directory, 'codex');
   const argsPath = join(directory, 'args.txt');
+  const cwdPath = join(directory, 'cwd.txt');
   const previousCodexPath = process.env.CODIFF_CODEX_PATH;
 
   try {
+    const repoPath = join(directory, 'repo');
+    await mkdir(repoPath);
     await writeFile(
       fakeCodexPath,
       `#!/bin/sh
+pwd > "${cwdPath}"
 for arg in "$@"; do
   printf '%s\\n' "$arg" >> "${argsPath}"
 done
@@ -151,16 +155,18 @@ exit 1
     await chmod(fakeCodexPath, 0o755);
     process.env.CODIFF_CODEX_PATH = fakeCodexPath;
 
-    await expect(runCodex('/repo', 'prompt', {}, 'walkthrough.json', 'Timed out.')).resolves.toBe(
+    await expect(runCodex(repoPath, 'prompt', {}, 'walkthrough.json', 'Timed out.')).resolves.toBe(
       '{"version":1}',
     );
 
     const args = (await readFile(argsPath, 'utf8')).trim().split('\n');
     expect(args).toContain('--ephemeral');
     expect(args).toContain('--cd');
-    expect(args).toContain('/repo');
+    expect(args).toContain(repoPath);
+    expect(args).toContain('--skip-git-repo-check');
     expect(args).toContain('model_reasoning_effort="high"');
     expect(args).not.toContain('resume');
+    await expect(readFile(cwdPath, 'utf8')).resolves.toBe(`${await realpath(repoPath)}\n`);
   } finally {
     if (previousCodexPath == null) {
       delete process.env.CODIFF_CODEX_PATH;
@@ -178,6 +184,8 @@ test('forwards per-call Codex reasoning effort overrides', async () => {
   const previousCodexPath = process.env.CODIFF_CODEX_PATH;
 
   try {
+    const repoPath = join(directory, 'repo');
+    await mkdir(repoPath);
     await writeFile(
       fakeCodexPath,
       `#!/bin/sh
@@ -199,7 +207,7 @@ exit 1
     process.env.CODIFF_CODEX_PATH = fakeCodexPath;
 
     await expect(
-      runCodex('/repo', 'prompt', {}, 'walkthrough.json', 'Timed out.', {
+      runCodex(repoPath, 'prompt', {}, 'walkthrough.json', 'Timed out.', {
         reasoningEffort: 'low',
       }),
     ).resolves.toBe('{"version":1}');
@@ -222,6 +230,8 @@ test('supports per-call Codex timeouts', async () => {
   const previousCodexPath = process.env.CODIFF_CODEX_PATH;
 
   try {
+    const repoPath = join(directory, 'repo');
+    await mkdir(repoPath);
     await writeFile(
       fakeCodexPath,
       `#!/usr/bin/env node
@@ -233,7 +243,7 @@ setInterval(() => {}, 1_000);
     process.env.CODIFF_CODEX_PATH = fakeCodexPath;
 
     await expect(
-      runCodex('/repo', 'prompt', {}, 'walkthrough.json', 'Timed out.', { timeoutMs: 10 }),
+      runCodex(repoPath, 'prompt', {}, 'walkthrough.json', 'Timed out.', { timeoutMs: 10 }),
     ).rejects.toThrow('Timed out.');
   } finally {
     if (previousCodexPath == null) {
@@ -251,6 +261,8 @@ test('surfaces structured Codex CLI errors without the full prompt stream', asyn
   const previousCodexPath = process.env.CODIFF_CODEX_PATH;
 
   try {
+    const repoPath = join(directory, 'repo');
+    await mkdir(repoPath);
     await writeFile(
       fakeCodexPath,
       `#!/bin/sh
@@ -264,7 +276,7 @@ exit 1
 
     let message = '';
     try {
-      await runCodex('/repo', 'prompt', {}, 'walkthrough.json', 'Timed out.');
+      await runCodex(repoPath, 'prompt', {}, 'walkthrough.json', 'Timed out.');
     } catch (error) {
       message = error instanceof Error ? error.message : String(error);
     }

--- a/electron/__tests__/command-line.test.ts
+++ b/electron/__tests__/command-line.test.ts
@@ -17,6 +17,11 @@ const { getInitialRepositoryPath, parseCommandLineArguments, parseGitHubRemoteUr
         planResultFile?: string;
         repositoryPathProvided: boolean;
         source?:
+          | { type: 'arc-working-tree' }
+          | { base: string; type: 'arc-branch' }
+          | { ref: string; type: 'arc-commit' }
+          | { number: number; type: 'arc-pull-request' }
+          | { base: string; head: string; symmetric: boolean; type: 'arc-range' }
           | { ref: string; type: 'branch' }
           | { ref: string; type: 'commit' }
           | { base: string; head: string; symmetric: boolean; type: 'range' }
@@ -34,6 +39,11 @@ const { getInitialRepositoryPath, parseCommandLineArguments, parseGitHubRemoteUr
         planResultFile?: string;
         repositoryPathProvided: boolean;
         source?:
+          | { type: 'arc-working-tree' }
+          | { base: string; type: 'arc-branch' }
+          | { ref: string; type: 'arc-commit' }
+          | { number: number; type: 'arc-pull-request' }
+          | { base: string; head: string; symmetric: boolean; type: 'arc-range' }
           | { ref: string; type: 'branch' }
           | { ref: string; type: 'commit' }
           | { base: string; head: string; symmetric: boolean; type: 'range' }
@@ -50,7 +60,11 @@ const { getInitialRepositoryPath, parseCommandLineArguments, parseGitHubRemoteUr
 const execFileAsync = promisify(execFile);
 
 const git = async (repo: string, args: ReadonlyArray<string>) => {
-  await execFileAsync('git', ['-C', repo, ...args], { encoding: 'utf8' });
+  await execFileAsync(
+    'git',
+    ['-c', 'commit.gpgsign=false', '-c', 'tag.gpgsign=false', '-C', repo, ...args],
+    { encoding: 'utf8' },
+  );
 };
 
 const defaultLaunchOptions = {
@@ -122,6 +136,115 @@ test('parses commit and walkthrough command-line options', () => {
     pullRequestNumber: null,
     repositoryPath: '/repo',
   });
+});
+
+test('parses Arc command-line options', () => {
+  expect(parseCommandLineArguments(['codiff', '--arc', '/arcadia'])).toEqual({
+    launchOptions: {
+      repositoryPathProvided: true,
+      source: {
+        type: 'arc-working-tree',
+      },
+      walkthrough: false,
+    },
+    pullRequestNumber: null,
+    repositoryPath: '/arcadia',
+  });
+
+  expect(parseCommandLineArguments(['codiff', '--arc-base', 'trunk', '/arcadia'])).toEqual({
+    launchOptions: {
+      repositoryPathProvided: true,
+      source: {
+        base: 'trunk',
+        type: 'arc-branch',
+      },
+      walkthrough: false,
+    },
+    pullRequestNumber: null,
+    repositoryPath: '/arcadia',
+  });
+});
+
+test.sequential('auto-detects Arc command-line sources', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-arc-command-line-'));
+  const fakeBin = join(directory, 'bin');
+  const workspace = join(directory, 'workspace');
+  const previousPath = process.env.PATH;
+  const previousCwd = process.cwd();
+
+  try {
+    await mkdir(fakeBin);
+    await mkdir(workspace);
+    await writeFile(
+      join(fakeBin, 'arc'),
+      '#!/bin/sh\nif [ "$1" = "root" ]; then pwd; exit 0; fi\nexit 1\n',
+    );
+    await chmod(join(fakeBin, 'arc'), 0o755);
+    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+    await git(workspace, ['init']);
+    process.chdir(workspace);
+
+    expect(parseCommandLineArguments(['codiff'])).toMatchObject({
+      launchOptions: {
+        repositoryPathProvided: false,
+        source: {
+          type: 'arc-working-tree',
+        },
+      },
+      repositoryPath: null,
+    });
+    expect(parseCommandLineArguments(['codiff', 'trunk'])).toMatchObject({
+      launchOptions: {
+        source: {
+          base: 'trunk',
+          type: 'arc-branch',
+        },
+      },
+    });
+    expect(parseCommandLineArguments(['codiff', 'base...head'])).toMatchObject({
+      launchOptions: {
+        source: {
+          base: 'base',
+          head: 'head',
+          symmetric: true,
+          type: 'arc-range',
+        },
+      },
+    });
+    expect(parseCommandLineArguments(['codiff', '--commit', 'HEAD'])).toMatchObject({
+      launchOptions: {
+        source: {
+          ref: 'HEAD',
+          type: 'arc-commit',
+        },
+      },
+    });
+    expect(parseCommandLineArguments(['codiff', 'pr', '123'])).toMatchObject({
+      launchOptions: {
+        source: {
+          number: 123,
+          type: 'arc-pull-request',
+        },
+      },
+      pullRequestNumber: null,
+    });
+    expect(
+      parseCommandLineArguments(['codiff', 'https://a.yandex-team.ru/review/456/files']),
+    ).toMatchObject({
+      launchOptions: {
+        source: {
+          number: 456,
+          type: 'arc-pull-request',
+          url: 'https://a.yandex-team.ru/review/456',
+        },
+      },
+      pullRequestNumber: null,
+    });
+  } finally {
+    process.chdir(previousCwd);
+    process.env.PATH = previousPath;
+    await rm(directory, { force: true, recursive: true });
+  }
 });
 
 test('parses plan handoff command-line options', () => {

--- a/electron/__tests__/git-identity.test.ts
+++ b/electron/__tests__/git-identity.test.ts
@@ -27,6 +27,8 @@ test('prefers configured git identity and falls back to the current commit autho
       'user.name=Commit Author',
       '-c',
       'user.email=commit@example.com',
+      '-c',
+      'commit.gpgsign=false',
       'commit',
       '-m',
       'Initial commit',

--- a/electron/__tests__/narrative-walkthrough.test.ts
+++ b/electron/__tests__/narrative-walkthrough.test.ts
@@ -187,6 +187,7 @@ test('prompts generated walkthroughs to use deterministic hunk groups', () => {
   expect(prompt).toContain('Put hunkIds in the exact display order');
   expect(prompt).toContain('Use notes[] on a stop/support item');
   expect(prompt).not.toContain('comments[]');
+  expect(prompt).toContain('For Git or Arc working-tree sources');
   expect(prompt).toContain('include commit.title and commit.body by default');
 });
 
@@ -792,6 +793,23 @@ test('keeps the commit composer for a working-tree staging set', () => {
   expect(result.commit).toEqual({
     body: 'Hunk order is now collapse-independent.\n\nNavigation expands a collapsed target before scrolling.',
     title: 'Fix hunk nav',
+  });
+});
+
+test('keeps the commit composer for an Arc working-tree staging set', () => {
+  const input = baseInput() as any;
+  input.commit = {
+    body: 'Route Arc working-tree commits through arc.',
+    title: 'Support Arc commits',
+  };
+
+  const result = normalizeNarrativeWalkthrough(input, files, {
+    source: { type: 'arc-working-tree' },
+  });
+
+  expect(result.commit).toEqual({
+    body: 'Route Arc working-tree commits through arc.',
+    title: 'Support Arc commits',
   });
 });
 

--- a/electron/__tests__/walkthrough-commit.test.ts
+++ b/electron/__tests__/walkthrough-commit.test.ts
@@ -1,11 +1,19 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
 
 const require = createRequire(import.meta.url);
 const { createWalkthroughCommit } = require('../walkthrough-commit.cjs') as {
   createWalkthroughCommit: (
     repoPath: string,
-    request: { body?: string; paths?: ReadonlyArray<string>; subject?: string },
+    request: {
+      body?: string;
+      paths?: ReadonlyArray<string>;
+      source?: { type: 'arc-working-tree' | 'working-tree' };
+      subject?: string;
+    },
   ) => Promise<{ hash: string; status: 'committed' } | { reason: string; status: 'failed' }>;
 };
 
@@ -28,4 +36,55 @@ test('rejects a path that escapes the repository', async () => {
     subject: 'Fix it',
   });
   expect(result).toEqual({ reason: 'A selected file path is invalid.', status: 'failed' });
+});
+
+test.sequential('commits selected Arc working-tree paths with arc', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-walkthrough-commit-arc-'));
+  const fakeBin = join(directory, 'bin');
+  const repo = join(directory, 'repo');
+  const previousPath = process.env.PATH;
+
+  try {
+    await mkdir(fakeBin);
+    await mkdir(repo);
+    await writeFile(
+      join(fakeBin, 'arc'),
+      `#!/bin/sh
+printf '%s\\n' "$@" >> "${join(directory, 'arc-args.txt')}"
+if [ "$1" = "commit" ]; then
+  cp "$3" "${join(directory, 'commit-message.txt')}"
+  printf '%s\\n' "$3" > "${join(directory, 'commit-message-path.txt')}"
+  exit 0
+fi
+if [ "$1" = "log" ]; then
+  printf '[{"commit":"abc123","message":"Fix arc"}]'
+  exit 0
+fi
+exit 0
+`,
+    );
+    await chmod(join(fakeBin, 'arc'), 0o755);
+    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+
+    const result = await createWalkthroughCommit(repo, {
+      body: 'Body line',
+      paths: ['src/a.ts', 'src/b.ts'],
+      source: { type: 'arc-working-tree' },
+      subject: 'Fix arc',
+    });
+
+    expect(result).toEqual({ hash: 'abc123', status: 'committed' });
+    await expect(readFile(join(directory, 'commit-message.txt'), 'utf8')).resolves.toBe(
+      'Fix arc\n\nBody line\n',
+    );
+    const messagePath = (await readFile(join(directory, 'commit-message-path.txt'), 'utf8')).trim();
+    expect(messagePath).toContain('codiff-arc-commit-');
+    const arcArgs = await readFile(join(directory, 'arc-args.txt'), 'utf8');
+    expect(arcArgs).toBe(
+      `add\n--\nsrc/a.ts\nsrc/b.ts\ncommit\n-F\n${messagePath}\n--\nsrc/a.ts\nsrc/b.ts\nlog\n-n\n1\n--json\n`,
+    );
+  } finally {
+    process.env.PATH = previousPath;
+    await rm(directory, { force: true, recursive: true });
+  }
 });

--- a/electron/__tests__/walkthrough-diagnosis.test.ts
+++ b/electron/__tests__/walkthrough-diagnosis.test.ts
@@ -7,14 +7,22 @@ import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
 
 const require = createRequire(import.meta.url);
-const { collectWalkthroughPaths, diagnoseWalkthroughMismatch } =
+const { collectWalkthroughPaths, diagnoseWalkthroughMismatch, parseArcNewestCommit } =
   require('../walkthrough-diagnosis.cjs') as {
     collectWalkthroughPaths: (input: unknown) => Array<string>;
     diagnoseWalkthroughMismatch: (params: {
       hasFiles: boolean;
       input: unknown;
       repositoryRoot: string;
+      readNewestPathCommit?: (params: {
+        kind: 'arc-working-tree' | 'working-tree';
+        paths: Array<string>;
+        repositoryRoot: string;
+      }) => Promise<{ hash: string; isoDate: string; subject: string } | null>;
     }) => Promise<string | null>;
+    parseArcNewestCommit: (
+      raw: string,
+    ) => { hash: string; isoDate: string; subject: string } | null;
   };
 
 const execFileAsync = promisify(execFile);
@@ -26,6 +34,8 @@ const git = async (repo: string, args: ReadonlyArray<string>) => {
 const makeRepo = async () => {
   const repo = await mkdtemp(join(tmpdir(), 'codiff-diagnosis-'));
   await git(repo, ['init']);
+  await git(repo, ['config', 'commit.gpgSign', 'false']);
+  await git(repo, ['config', 'tag.gpgSign', 'false']);
   await git(repo, ['config', 'user.email', 'codiff@example.com']);
   await git(repo, ['config', 'user.name', 'Codiff Test']);
   return repo;
@@ -76,6 +86,33 @@ test('collects v4 hunk ids and normalized hunk paths from a walkthrough', () => 
   ]);
 });
 
+test('collects Arc v4 hunk ids from a walkthrough', () => {
+  const paths = collectWalkthroughPaths({
+    chapters: [{ stops: [{ hunkIds: ['src/a.ts:arc:h1', 'src/path:with:colon.ts:arc:h2'] }] }],
+    source: { type: 'arc-working-tree' },
+    version: 4,
+  });
+  expect([...paths].sort()).toEqual(['src/a.ts', 'src/path:with:colon.ts']);
+});
+
+test('parses newest Arc path commit from arc log JSON', () => {
+  expect(
+    parseArcNewestCommit(
+      JSON.stringify([
+        {
+          commit: '677c77892083d271094138885e41446323786113',
+          date: '2026-03-28T13:09:42+03:00',
+          message: 'VLG-4810: Speed up binary package install\n\nBody',
+        },
+      ]),
+    ),
+  ).toEqual({
+    hash: '677c77892083',
+    isoDate: '2026-03-28T13:09:42+03:00',
+    subject: 'VLG-4810: Speed up binary package install',
+  });
+});
+
 test('reports changes committed after the walkthrough was authored', async () => {
   const repo = await makeRepo();
   try {
@@ -115,6 +152,37 @@ test('reports v4 hunk-id changes committed after the walkthrough was authored', 
   } finally {
     await rm(repo, { force: true, recursive: true });
   }
+});
+
+test('reports Arc working-tree hunk-id changes committed after the walkthrough was authored', async () => {
+  const calls: Array<{
+    kind: 'arc-working-tree' | 'working-tree';
+    paths: Array<string>;
+    repositoryRoot: string;
+  }> = [];
+  const reason = await diagnoseWalkthroughMismatch({
+    hasFiles: false,
+    input: {
+      ...v4WalkthroughFor('feature.ts', { generatedAt: '2000-01-01T00:00:00.000Z' }),
+      chapters: [{ stops: [{ hunkIds: ['feature.ts:arc:h1'] }] }],
+      source: { type: 'arc-working-tree' },
+    },
+    readNewestPathCommit: async (params) => {
+      calls.push(params);
+      return {
+        hash: '677c77892083',
+        isoDate: '2026-03-28T13:09:42+03:00',
+        subject: 'Add the Arc v4 feature',
+      };
+    },
+    repositoryRoot: '/arcadia',
+  });
+
+  expect(calls).toEqual([
+    { kind: 'arc-working-tree', paths: ['feature.ts'], repositoryRoot: '/arcadia' },
+  ]);
+  expect(reason).toContain('committed since the walkthrough was authored');
+  expect(reason).toContain('Add the Arc v4 feature');
 });
 
 test('treats a commit that predates authoring as reverted, not committed', async () => {

--- a/electron/__tests__/window-identity.test.ts
+++ b/electron/__tests__/window-identity.test.ts
@@ -17,6 +17,11 @@ const { findMatchingWindowIdentity, getWindowIdentity, parseGitHubPullRequestUrl
       repositoryPath: string,
       launchOptions?: {
         source?:
+          | { type: 'arc-working-tree' }
+          | { base: string; type: 'arc-branch' }
+          | { ref: string; type: 'arc-commit' }
+          | { number: number; type: 'arc-pull-request' }
+          | { base: string; head: string; symmetric: boolean; type: 'arc-range' }
           | { type: 'working-tree' }
           | { ref: string; type: 'branch' }
           | { baseRef: string; headRef: string; ref: string; type: 'branch-diff' }
@@ -44,7 +49,11 @@ const { findMatchingWindowIdentity, getWindowIdentity, parseGitHubPullRequestUrl
 const execFileAsync = promisify(execFile);
 
 const git = async (repo: string, args: ReadonlyArray<string>) => {
-  const result = await execFileAsync('git', ['-C', repo, ...args], { encoding: 'utf8' });
+  const result = await execFileAsync(
+    'git',
+    ['-c', 'commit.gpgsign=false', '-c', 'tag.gpgsign=false', '-C', repo, ...args],
+    { encoding: 'utf8' },
+  );
   return result.stdout.trim();
 };
 
@@ -83,6 +92,52 @@ test.sequential('plan window identities do not invoke Git outside repositories',
       sourceKey: `plan:${realPlanFile}`,
     });
     expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
+  } finally {
+    process.env.PATH = previousPath;
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test.sequential('Arc window identities use Arc roots and source keys', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-arc-window-identity-'));
+  const fakeBin = join(directory, 'bin');
+  const workspace = join(directory, 'workspace');
+  const previousPath = process.env.PATH;
+
+  try {
+    await mkdir(fakeBin);
+    await mkdir(workspace);
+    await writeFile(
+      join(fakeBin, 'arc'),
+      '#!/bin/sh\nif [ "$1" = "root" ]; then pwd; exit 0; fi\nexit 1\n',
+    );
+    await chmod(join(fakeBin, 'arc'), 0o755);
+    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+    const realWorkspace = await realpath(workspace);
+
+    expect(getWindowIdentity(realWorkspace, { source: { type: 'arc-working-tree' } })).toEqual({
+      key: `${realWorkspace}\0arc-working-tree`,
+      repositoryRoot: realWorkspace,
+      sourceKey: 'arc-working-tree',
+    });
+    expect(
+      getWindowIdentity(realWorkspace, {
+        source: { base: 'HEAD~1', head: 'HEAD', symmetric: false, type: 'arc-range' },
+      }),
+    ).toEqual({
+      key: `${realWorkspace}\0arc-range:HEAD~1..HEAD`,
+      repositoryRoot: realWorkspace,
+      sourceKey: 'arc-range:HEAD~1..HEAD',
+    });
+    expect(
+      getWindowIdentity(realWorkspace, {
+        source: { number: 123, type: 'arc-pull-request' },
+      }),
+    ).toEqual({
+      key: `${realWorkspace}\0arc-pull-request:123`,
+      repositoryRoot: realWorkspace,
+      sourceKey: 'arc-pull-request:123',
+    });
   } finally {
     process.env.PATH = previousPath;
     await rm(directory, { force: true, recursive: true });

--- a/electron/arc-detection.cjs
+++ b/electron/arc-detection.cjs
@@ -1,0 +1,36 @@
+// @ts-check
+
+const { execFileSync } = require('node:child_process');
+
+/** @param {string} repositoryPath @param {ReadonlyArray<string>} args */
+const gitSucceeds = (repositoryPath, args) => {
+  try {
+    execFileSync('git', ['-C', repositoryPath, ...args], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** @param {string} repositoryPath @param {ReadonlyArray<string>} args */
+const arcSucceeds = (repositoryPath, args) => {
+  try {
+    execFileSync('arc', args, {
+      cwd: repositoryPath,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** @param {string} repositoryPath */
+const shouldUseArcRepository = (repositoryPath) => arcSucceeds(repositoryPath, ['root']);
+
+module.exports = {
+  arcSucceeds,
+  shouldUseArcRepository,
+};

--- a/electron/codex.cjs
+++ b/electron/codex.cjs
@@ -248,6 +248,7 @@ const runCodex = async (
           `model_reasoning_effort="${reasoningEffort}"`,
           '--cd',
           repoRoot,
+          '--skip-git-repo-check',
           '--sandbox',
           'read-only',
           '--ephemeral',
@@ -261,6 +262,7 @@ const runCodex = async (
           '-',
         ];
         const child = spawn(codexCommand, codexArgs, {
+          cwd: repoRoot,
           env: process.env,
           stdio: ['pipe', 'pipe', 'pipe'],
         });

--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -2,6 +2,17 @@
 
 const { gitOrEmpty, parseStatus, validateRepositoryPath } = require('./git-state/common.cjs');
 const {
+  listArcRepositoryHistory,
+  normalizeArcanumReviewComment,
+  parseArcNameStatus,
+  readArcImageContent,
+  readArcIdentity,
+  readArcRepositoryChangeSignature,
+  readArcSectionContent,
+  readArcState,
+  submitArcPullRequestComment,
+} = require('./git-state/arc.cjs');
+const {
   listRepositoryHistory,
   readBranchImageContent,
   readBranchSectionContent,
@@ -46,7 +57,7 @@ const {
   readDiffSectionContent: readWorkingTreeDiffSectionContent,
   readDiffImageContent: readWorkingTreeDiffImageContent,
   readGitIdentity,
-  readRepositoryChangeSignature,
+  readRepositoryChangeSignature: readGitRepositoryChangeSignature,
   readWorkingTreeState,
 } = require('./git-state/working-tree.cjs');
 
@@ -59,25 +70,56 @@ const {
  * @typedef {import('../core/types.ts').ReviewSource} ReviewSource
  */
 
+/** @param {unknown} error */
+const isNotGitRepositoryError = (error) =>
+  /not a git repository/i.test(error instanceof Error ? error.message : String(error));
+
+/** @param {ReviewSource | undefined} source */
+const isArcSource = (source) =>
+  source?.type === 'arc-working-tree' ||
+  source?.type === 'arc-branch' ||
+  source?.type === 'arc-range' ||
+  source?.type === 'arc-commit' ||
+  source?.type === 'arc-pull-request';
+
+/** @param {ReviewSource} source */
+const isWorkingTreeSource = (source) =>
+  source.type === 'working-tree' || source.type === 'arc-working-tree';
+
 /** @param {string} launchPath @param {ReviewSource} [source] @param {{showWhitespace?: boolean}} [options] @returns {Promise<RepositoryState>} */
-const readRepositoryState = async (launchPath, source = { type: 'working-tree' }, options = {}) => {
-  const state =
-    source.type === 'pull-request'
-      ? await (isGitLabReviewSource(source) ? readMergeRequestState : readPullRequestState)(
-          launchPath,
-          source,
-        )
-      : source.type === 'commit'
-        ? await readCommitState(launchPath, source.ref)
-        : source.type === 'range'
-          ? await readRangeState(launchPath, source.base, source.head, source.symmetric)
-          : source.type === 'branch' || source.type === 'branch-diff'
-            ? await readBranchState(launchPath, source)
-            : await readWorkingTreeState(launchPath, {
-                eagerContents: false,
-                showWhitespace: options.showWhitespace,
-              });
-  const branch = (await gitOrEmpty(state.root, ['symbolic-ref', '--short', 'HEAD'])).trim() || null;
+const readRepositoryState = async (launchPath, source, options = {}) => {
+  let state;
+  if (isArcSource(source)) {
+    state = await readArcState(launchPath, source, { showWhitespace: options.showWhitespace });
+  } else if (source?.type === 'pull-request') {
+    state = await (isGitLabReviewSource(source) ? readMergeRequestState : readPullRequestState)(
+      launchPath,
+      source,
+    );
+  } else if (source?.type === 'commit') {
+    state = await readCommitState(launchPath, source.ref);
+  } else if (source?.type === 'range') {
+    state = await readRangeState(launchPath, source.base, source.head, source.symmetric);
+  } else if (source?.type === 'branch' || source?.type === 'branch-diff') {
+    state = await readBranchState(launchPath, source);
+  } else {
+    state = await readWorkingTreeState(launchPath, {
+      eagerContents: false,
+      showWhitespace: options.showWhitespace,
+    }).catch(async (error) => {
+      if (isNotGitRepositoryError(error)) {
+        try {
+          return await readArcState(launchPath, { type: 'arc-working-tree' }, options);
+        } catch {
+          throw error;
+        }
+      }
+      throw error;
+    });
+  }
+
+  const branch =
+    (await gitOrEmpty(state.root, ['symbolic-ref', '--short', 'HEAD'])).trim() || state.branch;
   return { ...state, branch };
 };
 
@@ -92,8 +134,15 @@ const readRepositoryState = async (launchPath, source = { type: 'working-tree' }
  */
 const readWalkthroughRepositoryState = async (launchPath, source, options = {}) => {
   const state = await readRepositoryState(launchPath, source, options);
-  if (source || state.source.type !== 'working-tree' || state.files.length > 0) {
+  if (source || !isWorkingTreeSource(state.source) || state.files.length > 0) {
     return state;
+  }
+
+  if (state.source.type === 'arc-working-tree') {
+    const history = await listArcRepositoryHistory(state.root, 1, state.source);
+    return history.entries.length > 0
+      ? readRepositoryState(launchPath, { ref: 'HEAD', type: 'arc-commit' }, options)
+      : state;
   }
 
   const head = (await gitOrEmpty(state.root, ['rev-parse', '--verify', 'HEAD'])).trim();
@@ -110,60 +159,121 @@ const getBranchHistoryRef = (source) =>
 
 /** @param {string} launchPath @param {number} [limit] @param {ReviewSource} [source] @returns {Promise<RepositoryHistory>} */
 const readRepositoryHistory = (launchPath, limit, source) =>
-  source?.type === 'pull-request'
-    ? (isGitLabReviewSource(source) ? listMergeRequestHistory : listPullRequestHistory)(
-        launchPath,
-        source,
-        limit,
-      )
-    : listRepositoryHistory(
-        launchPath,
-        limit,
-        source?.type === 'branch' || source?.type === 'branch-diff'
-          ? getBranchHistoryRef(source)
-          : undefined,
-      );
+  isArcSource(source)
+    ? listArcRepositoryHistory(launchPath, limit, source)
+    : source?.type === 'pull-request'
+      ? (isGitLabReviewSource(source) ? listMergeRequestHistory : listPullRequestHistory)(
+          launchPath,
+          source,
+          limit,
+        )
+      : listRepositoryHistory(
+          launchPath,
+          limit,
+          source?.type === 'branch' || source?.type === 'branch-diff'
+            ? getBranchHistoryRef(source)
+            : undefined,
+        );
 
 /** @param {string} launchPath @param {DiffSectionContentRequest} request */
-const readDiffSectionContent = async (launchPath, request) =>
-  request.source?.type === 'range'
-    ? readRangeSectionContent(
-        launchPath,
-        request.source.base,
-        request.source.head,
-        request.source.symmetric,
-        request.path,
-        { force: request.force },
-      )
-    : request.source?.type === 'branch' || request.source?.type === 'branch-diff'
-      ? readBranchSectionContent(launchPath, request.source, request.path, {
-          force: request.force,
-        })
-      : request.kind === 'commit' || request.source?.type === 'commit'
-        ? readCommitSectionContent(launchPath, request.source?.ref || 'HEAD', request.path, {
-            force: request.force,
-          })
-        : readWorkingTreeDiffSectionContent(launchPath, request);
+const readDiffSectionContent = async (launchPath, request) => {
+  if (isArcSource(request.source)) {
+    return readArcSectionContent(launchPath, request);
+  }
+
+  if (request.source?.type === 'range') {
+    return readRangeSectionContent(
+      launchPath,
+      request.source.base,
+      request.source.head,
+      request.source.symmetric,
+      request.path,
+      { force: request.force },
+    );
+  }
+
+  if (request.source?.type === 'branch' || request.source?.type === 'branch-diff') {
+    return readBranchSectionContent(launchPath, request.source, request.path, {
+      force: request.force,
+    });
+  }
+
+  if (request.kind === 'commit' || request.source?.type === 'commit') {
+    return readCommitSectionContent(launchPath, request.source?.ref || 'HEAD', request.path, {
+      force: request.force,
+    });
+  }
+
+  return readWorkingTreeDiffSectionContent(launchPath, request);
+};
 
 /** @param {string} launchPath @param {DiffImageContentRequest} request @returns {Promise<DiffImageContentResult>} */
-const readDiffImageContent = (launchPath, request) =>
-  request.source?.type === 'pull-request'
-    ? (isGitLabReviewSource(request.source)
+const readDiffImageContent = (launchPath, request) => {
+  if (isArcSource(request.source)) {
+    return readArcImageContent(launchPath, request);
+  }
+
+  if (request.source?.type === 'pull-request') {
+    return (
+      isGitLabReviewSource(request.source)
         ? readMergeRequestImageContent
-        : readPullRequestImageContent)(launchPath, request.source, request.path)
-    : request.source?.type === 'range'
-      ? readRangeImageContent(
-          launchPath,
-          request.source.base,
-          request.source.head,
-          request.source.symmetric,
-          request.path,
-        )
-      : request.source?.type === 'branch' || request.source?.type === 'branch-diff'
-        ? readBranchImageContent(launchPath, request.source, request.path)
-        : request.kind === 'commit' || request.source?.type === 'commit'
-          ? readCommitImageContent(launchPath, request.source?.ref || 'HEAD', request.path)
-          : readWorkingTreeDiffImageContent(launchPath, request);
+        : readPullRequestImageContent
+    )(launchPath, request.source, request.path);
+  }
+
+  if (request.source?.type === 'range') {
+    return readRangeImageContent(
+      launchPath,
+      request.source.base,
+      request.source.head,
+      request.source.symmetric,
+      request.path,
+    );
+  }
+
+  if (request.source?.type === 'branch' || request.source?.type === 'branch-diff') {
+    return readBranchImageContent(launchPath, request.source, request.path);
+  }
+
+  if (request.kind === 'commit' || request.source?.type === 'commit') {
+    return readCommitImageContent(launchPath, request.source?.ref || 'HEAD', request.path);
+  }
+
+  return readWorkingTreeDiffImageContent(launchPath, request);
+};
+
+/** @param {string} launchPath @param {Iterable<string>} [additionalPaths] */
+const readRepositoryChangeSignature = async (launchPath, additionalPaths = []) => {
+  try {
+    return await readGitRepositoryChangeSignature(launchPath, additionalPaths);
+  } catch (error) {
+    if (!isNotGitRepositoryError(error)) {
+      throw error;
+    }
+    return readArcRepositoryChangeSignature(launchPath, additionalPaths);
+  }
+};
+
+/** @param {string} launchPath */
+const readLocalIdentity = async (launchPath) => {
+  try {
+    return await readArcIdentity(launchPath);
+  } catch {
+    // Fall through to Git/global identity when Arc is unavailable.
+  }
+
+  try {
+    const identity = await readGitIdentity(launchPath);
+    if (identity.name || identity.email) {
+      return identity;
+    }
+  } catch (error) {
+    if (!isNotGitRepositoryError(error)) {
+      throw error;
+    }
+  }
+  return readArcIdentity(launchPath);
+};
 
 module.exports = {
   collectResolvedReviewCommentIds,
@@ -175,8 +285,10 @@ module.exports = {
   listRepositoryHistory: readRepositoryHistory,
   normalizeGitHubPullRequestCommit,
   normalizeGitHubReviewComment,
+  normalizeArcanumReviewComment,
   normalizeGitLabReviewComment,
   normalizePullRequestComment,
+  parseArcNameStatus,
   parseStatus,
   parseGitHubPullRequestUrl,
   parseGitLabMergeRequestUrl,
@@ -184,7 +296,7 @@ module.exports = {
   readBranchState,
   readDiffSectionContent,
   readDiffImageContent,
-  readGitIdentity,
+  readGitIdentity: readLocalIdentity,
   readRepositoryChangeSignature,
   readCommitState,
   readPullRequestState,
@@ -193,14 +305,22 @@ module.exports = {
   readWorkingTreeState,
   resolvePullRequestContentRefs,
   submitPullRequestComment: (launchPath, request) =>
-    (isGitLabReviewSource(request.source) ? submitMergeRequestComment : submitPullRequestComment)(
-      launchPath,
-      request,
-    ),
-  submitPullRequestReview: (launchPath, request) =>
-    (isGitLabReviewSource(request.source) ? submitMergeRequestReview : submitPullRequestReview)(
-      launchPath,
-      request,
-    ),
+    request.source.type === 'arc-pull-request'
+      ? submitArcPullRequestComment(launchPath, request)
+      : (isGitLabReviewSource(request.source)
+          ? submitMergeRequestComment
+          : submitPullRequestComment)(launchPath, request),
+  submitPullRequestReview: (launchPath, request) => {
+    // TODO(arcadia): Replace this guard with a real Arcanum review-verdict call when
+    // Arcanum exposes Approve/Request changes through the available API/tooling.
+    if (request.source.type === 'arc-pull-request') {
+      throw new Error(
+        'Arcadia review verdicts are not supported yet. Add inline comments instead.',
+      );
+    }
+    return (
+      isGitLabReviewSource(request.source) ? submitMergeRequestReview : submitPullRequestReview
+    )(launchPath, request);
+  },
   validateRepositoryPath,
 };

--- a/electron/git-state/arc.cjs
+++ b/electron/git-state/arc.cjs
@@ -1,0 +1,1111 @@
+// @ts-check
+
+const { execFile } = require('node:child_process');
+const { lstat, readFile, readlink } = require('node:fs/promises');
+const { join } = require('node:path');
+const { promisify } = require('node:util');
+const {
+  bufferToTextFile,
+  bufferToImageRevision,
+  createSummary,
+  createPatchForNewFile,
+  fileSort,
+  getFingerprint,
+  getWhitespaceDiffArgs,
+  normalizeStatus,
+  readWorkingTreeImageFile,
+  validateRepositoryPath,
+} = require('./common.cjs');
+
+const execFileAsync = promisify(execFile);
+const ansiPattern = /\u001b\[[0-9;]*m/g;
+
+/**
+ * @typedef {import('../../core/types.ts').ChangedFile} ChangedFile
+ * @typedef {import('../../core/types.ts').CommitMetadata} CommitMetadata
+ * @typedef {import('../../core/types.ts').CommitMetadataFile} CommitMetadataFile
+ * @typedef {import('../../core/types.ts').DiffImageContentResult} DiffImageContentResult
+ * @typedef {import('../../core/types.ts').DiffSection} DiffSection
+ * @typedef {import('../../core/types.ts').DiffSectionContentRequest} DiffSectionContentRequest
+ * @typedef {import('../../core/types.ts').PullRequestExistingReviewComment} PullRequestExistingReviewComment
+ * @typedef {import('../../core/types.ts').PullRequestReviewComment} PullRequestReviewComment
+ * @typedef {import('../../core/types.ts').RepositoryState} RepositoryState
+ * @typedef {import('../../core/types.ts').RepositoryHistory} RepositoryHistory
+ * @typedef {import('../../core/types.ts').ReviewSource} ReviewSource
+ * @typedef {import('../../core/types.ts').SubmitPullRequestCommentRequest} SubmitPullRequestCommentRequest
+ * @typedef {import('./common.cjs').StatusItem} StatusItem
+ */
+
+/**
+ * @param {string} repoPath
+ * @param {ReadonlyArray<string>} args
+ * @returns {Promise<string>}
+ */
+const arc = async (repoPath, args) => {
+  try {
+    const { stdout } = await execFileAsync('arc', args, {
+      cwd: repoPath,
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024 * 64,
+    });
+    return stdout.replace(ansiPattern, '');
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      throw new Error('Arc support requires the `arc` command to be available on PATH.');
+    }
+    throw error;
+  }
+};
+
+/**
+ * @param {string} repoPath
+ * @param {ReadonlyArray<string>} args
+ * @returns {Promise<Buffer>}
+ */
+const arcBuffer = async (repoPath, args) => {
+  try {
+    const { stdout } = await execFileAsync('arc', args, {
+      cwd: repoPath,
+      maxBuffer: 1024 * 1024 * 64,
+    });
+    return Buffer.isBuffer(stdout) ? stdout : Buffer.from(stdout);
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      throw new Error('Arc support requires the `arc` command to be available on PATH.');
+    }
+    throw error;
+  }
+};
+
+/**
+ * @param {string} repoPath
+ * @param {string} tool
+ * @param {Record<string, unknown>} args
+ */
+const arcanum = async (repoPath, tool, args) => {
+  const toolArgs = ['tool', 'mcp', 'connect', 'devtools', '--tool', tool, '--raw'];
+  for (const [key, value] of Object.entries(args)) {
+    if (value == null) {
+      continue;
+    }
+    toolArgs.push('--arg', `${key}:${typeof value === 'object' ? JSON.stringify(value) : value}`);
+  }
+
+  try {
+    const { stdout } = await execFileAsync('ya', toolArgs, {
+      cwd: repoPath,
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024 * 64,
+    });
+    return stdout.replace(ansiPattern, '');
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(
+        'Arcadia pull request comments require `ya tool mcp connect devtools` to be available on PATH.',
+      );
+    }
+    throw error;
+  }
+};
+
+/** @param {string} raw */
+const parseMcpToolPayloads = (raw) => {
+  const parsed = JSON.parse(raw);
+  const content = parsed?.result?.content;
+  if (parsed?.result?.isError) {
+    const message = Array.isArray(content)
+      ? content
+          .map((item) => (typeof item?.text === 'string' ? item.text : ''))
+          .filter(Boolean)
+          .join('\n')
+      : '';
+    throw new Error(message || 'Arcanum returned an error.');
+  }
+
+  return Array.isArray(content)
+    ? content
+        .map((item) => {
+          if (typeof item?.text !== 'string') {
+            return null;
+          }
+          try {
+            return JSON.parse(item.text);
+          } catch {
+            return item.text;
+          }
+        })
+        .filter((item) => item != null)
+    : [];
+};
+
+/** @param {string} launchPath */
+const readArcRoot = async (launchPath) => {
+  try {
+    return (await arc(launchPath, ['root'])).trim();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Codiff was opened outside an Arc repository: ${detail}`);
+  }
+};
+
+/** @param {string} repoRoot */
+const readArcBranchName = async (repoRoot) => {
+  try {
+    const output = await arc(repoRoot, ['branch']);
+    const current = output
+      .split('\n')
+      .map((line) => line.trimEnd())
+      .find((line) => line.startsWith('* '));
+    return current ? current.slice(2).trim() || null : null;
+  } catch {
+    return null;
+  }
+};
+
+/** @param {string} raw @returns {Array<Pick<StatusItem, 'oldPath' | 'path' | 'status'>>} */
+const normalizeArcStatus = (statusCode) =>
+  statusCode === '?' || statusCode === '??' ? 'untracked' : normalizeStatus(statusCode[0] || 'M');
+
+/** @param {string} raw @returns {Array<Pick<StatusItem, 'oldPath' | 'path' | 'status'>>} */
+const parseArcNameStatus = (raw) =>
+  raw
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.includes('\t') ? line.split('\t') : line.trim().split(/\s+/);
+      const statusCode = parts[0] || 'M';
+      const statusType = statusCode[0] || 'M';
+      if ((statusType === 'R' || statusType === 'C') && parts.length >= 3) {
+        return {
+          oldPath: parts[1],
+          path: parts[2],
+          status: normalizeArcStatus(statusType),
+        };
+      }
+
+      return {
+        path: parts.slice(1).join(line.includes('\t') ? '\t' : ' '),
+        status: normalizeArcStatus(statusCode),
+      };
+    })
+    .filter((item) => item.path)
+    .sort(fileSort);
+
+/**
+ * @param {string} repoRoot
+ * @param {string} path
+ */
+const readArcWorkingTreePathSignature = async (repoRoot, path) => {
+  try {
+    const absolutePath = join(repoRoot, path);
+    const stat = await lstat(absolutePath);
+
+    if (stat.isDirectory()) {
+      return `${path}\0directory\0${stat.mode}\0${stat.size}\0${stat.mtimeMs}`;
+    }
+
+    if (stat.isSymbolicLink()) {
+      return `${path}\0symlink\0${stat.mode}\0${await readlink(absolutePath)}`;
+    }
+
+    if (!stat.isFile()) {
+      return `${path}\0other\0${stat.mode}\0${stat.size}\0${stat.mtimeMs}`;
+    }
+
+    const content =
+      stat.size <= 64 * 1024 * 1024
+        ? getFingerprint(await readFile(absolutePath))
+        : `${stat.size}\0${stat.mtimeMs}`;
+
+    return `${path}\0file\0${stat.mode}\0${stat.size}\0${content}`;
+  } catch {
+    return `${path}\0missing`;
+  }
+};
+
+/** @param {string} repoRoot @param {Iterable<string>} [additionalPaths] */
+const readArcWorkingTreeChangeSignatures = async (repoRoot, additionalPaths = []) => {
+  const status = parseArcNameStatus(await arc(repoRoot, ['status', '--short', '-u', 'all']));
+  const signatures = new Map();
+
+  for (const item of status) {
+    if (item.oldPath && item.oldPath !== item.path) {
+      try {
+        await lstat(join(repoRoot, item.oldPath));
+      } catch {
+        signatures.set(item.oldPath, `${item.oldPath}\0missing`);
+      }
+    }
+
+    signatures.set(item.path, await readArcWorkingTreePathSignature(repoRoot, item.path));
+  }
+  for (const path of additionalPaths) {
+    if (!signatures.has(path)) {
+      signatures.set(path, await readArcWorkingTreePathSignature(repoRoot, path));
+    }
+  }
+
+  return [...signatures.entries()].sort(([left], [right]) => left.localeCompare(right));
+};
+
+/** @param {string} patch */
+const splitGitPatch = (patch) =>
+  patch
+    .split(/(?=^diff --git )/m)
+    .map((part) => part.trimEnd())
+    .filter((part) => part.startsWith('diff --git '))
+    .map((part) => `${part}\n`);
+
+/** @param {string} path */
+const unquoteDiffPath = (path) => path.replace(/^"|"$/g, '');
+
+/** @param {string} path */
+const escapeRegExp = (path) => path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * @param {ReadonlyArray<string>} patches
+ * @param {Pick<StatusItem, 'oldPath' | 'path'>} item
+ */
+const findPatchForItem = (patches, item) => {
+  const pathPattern = escapeRegExp(item.path);
+  const oldPathPattern = item.oldPath ? escapeRegExp(item.oldPath) : pathPattern;
+  const headerPattern = new RegExp(
+    `^diff --git "?a/${oldPathPattern}"? "?b/${pathPattern}"?(?:\\n|$)`,
+  );
+  return patches.find((patch) => headerPattern.test(patch)) || '';
+};
+
+/** @param {string} patch */
+const parseArcPatchStatus = (patch) =>
+  splitGitPatch(patch)
+    .map((part) => {
+      const header = part.match(/^diff --git ("?a\/.+?"?) ("?b\/.+?"?)(?:\n|$)/);
+      if (!header) {
+        return null;
+      }
+      const oldPath = unquoteDiffPath(header[1]).replace(/^a\//, '');
+      const path = unquoteDiffPath(header[2]).replace(/^b\//, '');
+      return {
+        ...(oldPath !== path ? { oldPath } : {}),
+        path,
+        status: part.includes('\nnew file mode ')
+          ? 'added'
+          : part.includes('\ndeleted file mode ')
+            ? 'deleted'
+            : part.includes('\nrename from ')
+              ? 'renamed'
+              : 'modified',
+      };
+    })
+    .filter(Boolean)
+    .sort(fileSort);
+
+/** @param {Extract<ReviewSource, {type: 'arc-working-tree' | 'arc-branch' | 'arc-range' | 'arc-commit' | 'arc-pull-request'}>} source */
+const createArcDiffArgs = (source) => {
+  if (source.type === 'arc-pull-request') {
+    return ['pr', 'changes', String(source.number)];
+  }
+
+  const diffArgs =
+    source.type === 'arc-branch'
+      ? ['-B', source.base]
+      : source.type === 'arc-range'
+        ? source.symmetric
+          ? ['-B', source.base, source.head]
+          : [source.base, source.head]
+        : source.type === 'arc-commit'
+          ? [`${source.ref}^`, source.ref]
+          : [];
+
+  return ['diff', '--git', '--no-color', ...diffArgs];
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {Extract<ReviewSource, {type: 'arc-working-tree' | 'arc-branch' | 'arc-range' | 'arc-commit' | 'arc-pull-request'}>} source
+ * @param {ReadonlyArray<string>} [paths]
+ * @param {{showWhitespace?: boolean}} [options]
+ */
+const readArcPatch = (repoRoot, source, paths = [], options = {}) =>
+  source.type === 'arc-pull-request'
+    ? arc(repoRoot, createArcDiffArgs(source))
+    : arc(repoRoot, [
+        ...createArcDiffArgs(source),
+        ...getWhitespaceDiffArgs(options),
+        ...(paths.length > 0 ? ['--', ...paths] : []),
+      ]);
+
+/** @param {unknown} value @returns {value is Record<string, unknown>} */
+const isObject = (value) => typeof value === 'object' && value != null;
+
+/** @param {unknown} value */
+const optionalString = (value) => (typeof value === 'string' && value ? value : undefined);
+
+/** @param {unknown} value */
+const optionalNumber = (value) => {
+  const number = typeof value === 'number' || typeof value === 'string' ? Number(value) : NaN;
+  return Number.isFinite(number) ? number : undefined;
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {Extract<ReviewSource, {type: 'arc-pull-request'}>} source
+ */
+const readArcPullRequestSource = async (repoRoot, source) => {
+  try {
+    const parsed = JSON.parse(
+      await arc(repoRoot, ['pr', 'status', '--json', String(source.number)]),
+    );
+    if (!isObject(parsed)) {
+      return source;
+    }
+
+    return {
+      ...source,
+      author: optionalString(parsed.author),
+      fromBranch: optionalString(parsed.from_branch),
+      headSha: optionalString(parsed.from_id),
+      status: optionalString(parsed.status),
+      title: optionalString(parsed.summary),
+      toBranch: optionalString(parsed.to_branch),
+      url: optionalString(parsed.url),
+    };
+  } catch {
+    return source;
+  }
+};
+
+/**
+ * @param {unknown} raw
+ * @param {number} prNumber
+ * @param {string | undefined} prUrl
+ * @returns {PullRequestExistingReviewComment | null}
+ */
+const normalizeArcanumReviewComment = (raw, prNumber, prUrl) => {
+  if (!isObject(raw) || typeof raw.content !== 'string') {
+    return null;
+  }
+
+  const reviewRequest = isObject(raw.anchor) ? raw.anchor.review_request : undefined;
+  const diff = isObject(reviewRequest) ? reviewRequest.diff : undefined;
+  const file = isObject(diff) ? diff.file : undefined;
+  const position = isObject(file) ? file.position : undefined;
+  const entryId = isObject(file) ? file.entry_id : undefined;
+  const contentIdAfter = isObject(entryId) ? entryId.content_id_after : undefined;
+  const contentIdBefore = isObject(entryId) ? entryId.content_id_before : undefined;
+  const filePath =
+    (isObject(contentIdAfter) && optionalString(contentIdAfter.path)) ||
+    (isObject(contentIdBefore) && optionalString(contentIdBefore.path));
+  const line = isObject(position) ? optionalNumber(position.line) : undefined;
+  const size = isObject(position) ? optionalNumber(position.size) : undefined;
+  if (!filePath || line == null || line < 1) {
+    return null;
+  }
+
+  const rawSide = isObject(position) ? position.side : undefined;
+  const side = rawSide === 'old' ? 'deletions' : 'additions';
+  const lineCount = size != null && size > 1 ? Math.floor(size) : 1;
+  const lineNumber = Math.floor(line + lineCount - 1);
+  const user = isObject(raw.user) ? raw.user : undefined;
+  const id = optionalNumber(raw.id);
+
+  return {
+    author: {
+      login: (isObject(user) && optionalString(user.name)) || 'Arcanum user',
+    },
+    body: raw.content,
+    filePath,
+    id: `arcanum:${id ?? `${prNumber}:${filePath}:${lineNumber}`}`,
+    lineNumber,
+    side,
+    ...(lineCount > 1 ? { startLineNumber: Math.floor(line), startSide: side } : {}),
+    submittedAt: optionalString(raw.published_at) || optionalString(raw.created_at),
+    ...(prUrl && id != null ? { url: `${prUrl}#comment-${id}` } : {}),
+  };
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {number} prNumber
+ * @param {string | undefined} prUrl
+ */
+const readArcPullRequestComments = async (repoRoot, prNumber, prUrl) => {
+  try {
+    const payloads = parseMcpToolPayloads(
+      await arcanum(repoRoot, 'arcanum_pr_data', { pr_id: prNumber }),
+    );
+    return payloads
+      .flatMap((payload) => (isObject(payload) && Array.isArray(payload.data) ? payload.data : []))
+      .map((comment) => normalizeArcanumReviewComment(comment, prNumber, prUrl))
+      .filter(Boolean);
+  } catch (error) {
+    throw new Error(
+      `Could not load Arcanum comments for PR #${prNumber}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {Extract<ReviewSource, {type: 'arc-working-tree' | 'arc-branch' | 'arc-range' | 'arc-commit' | 'arc-pull-request'}>} source
+ */
+const readArcStatus = async (repoRoot, source) =>
+  source.type === 'arc-pull-request'
+    ? parseArcPatchStatus(await readArcPatch(repoRoot, source))
+    : source.type === 'arc-working-tree'
+      ? mergeArcStatusItems(
+          parseArcNameStatus(await arc(repoRoot, [...createArcDiffArgs(source), '--name-status'])),
+          parseArcNameStatus(await arc(repoRoot, ['status', '--short', '-u', 'all'])).filter(
+            (item) => item.status === 'untracked',
+          ),
+        )
+      : parseArcNameStatus(await arc(repoRoot, [...createArcDiffArgs(source), '--name-status']));
+
+/**
+ * @param {ReadonlyArray<Pick<StatusItem, 'oldPath' | 'path' | 'status'>>} primary
+ * @param {ReadonlyArray<Pick<StatusItem, 'oldPath' | 'path' | 'status'>>} extra
+ */
+const mergeArcStatusItems = (primary, extra) => {
+  const paths = new Set(primary.map((item) => item.path));
+  return [...primary, ...extra.filter((item) => !paths.has(item.path))].sort(fileSort);
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {Pick<StatusItem, 'path' | 'status'>} item
+ * @returns {Promise<DiffSection | null>}
+ */
+const createArcUntrackedSection = async (repoRoot, item) => {
+  if (item.status !== 'untracked') {
+    return null;
+  }
+
+  try {
+    const path = validateRepositoryPath(item.path);
+    const buffer = await readFile(join(repoRoot, path));
+    const contents = bufferToTextFile(path, buffer, `arc-working-tree:${path}:${buffer.length}`);
+    return {
+      binary: contents.binary,
+      id: `${item.path}:arc`,
+      kind: 'arc',
+      loadState: contents.binary ? 'binary' : 'ready',
+      newFile: contents.file,
+      patch: contents.file ? createPatchForNewFile(path, contents.file.contents) : '',
+      ...(contents.summary ? { summary: contents.summary } : {}),
+    };
+  } catch (error) {
+    return {
+      binary: false,
+      id: `${item.path}:arc`,
+      kind: 'arc',
+      loadState: 'error',
+      patch: '',
+      summary: createSummary(error instanceof Error ? error.message : String(error)),
+    };
+  }
+};
+
+/**
+ * @param {Extract<ReviewSource, {type: 'arc-working-tree' | 'arc-branch' | 'arc-range' | 'arc-commit' | 'arc-pull-request'}>} source
+ * @param {Pick<StatusItem, 'oldPath' | 'path' | 'status'>} item
+ * @param {string} patch
+ * @returns {Promise<ChangedFile>}
+ */
+const createArcFile = async (repoRoot, source, item, patch) => {
+  const untrackedSection = await createArcUntrackedSection(repoRoot, item);
+  /** @type {DiffSection} */
+  const section = untrackedSection ?? {
+    binary: /Binary files .* differ|GIT binary patch/.test(patch),
+    id: `${item.path}:arc`,
+    kind: 'arc',
+    loadState: patch ? 'ready' : 'error',
+    patch,
+    ...(patch
+      ? {}
+      : {
+          summary: createSummary('Codiff could not load this Arc diff.'),
+        }),
+  };
+
+  return {
+    fingerprint: getFingerprint(
+      `${JSON.stringify(source)}\n${item.status}\n${item.oldPath || ''}\n${item.path}\n${
+        section.patch
+      }`,
+    ),
+    oldPath: item.oldPath,
+    path: item.path,
+    sections: [section],
+    status: item.status,
+  };
+};
+
+/** @param {string} patch */
+const readArcPatchLineStats = (patch) => {
+  if (/Binary files .* differ|GIT binary patch/.test(patch)) {
+    return { binary: true };
+  }
+
+  let additions = 0;
+  let deletions = 0;
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('+++') || line.startsWith('---')) {
+      continue;
+    }
+    if (line.startsWith('+')) {
+      additions += 1;
+    } else if (line.startsWith('-')) {
+      deletions += 1;
+    }
+  }
+
+  return { additions, binary: false, deletions };
+};
+
+/**
+ * @param {ReadonlyArray<ChangedFile>} files
+ * @returns {Array<CommitMetadataFile>}
+ */
+const createArcCommitMetadataFiles = (files) =>
+  files
+    .map((file) => {
+      const patch = file.sections.map((section) => section.patch).join('\n');
+      const stats = readArcPatchLineStats(patch);
+      return {
+        binary: stats.binary,
+        oldPath: file.oldPath,
+        path: file.path,
+        status: file.status,
+        ...(stats.binary
+          ? {}
+          : {
+              additions: stats.additions,
+              deletions: stats.deletions,
+            }),
+      };
+    })
+    .sort(fileSort);
+
+/** @param {ReadonlyArray<CommitMetadataFile>} files */
+const createArcCommitMetadataStats = (files) => {
+  const stats = {
+    additions: 0,
+    binaryFiles: 0,
+    deletions: 0,
+    files: files.length,
+    renamedFiles: 0,
+  };
+
+  for (const file of files) {
+    stats.additions += file.additions ?? 0;
+    stats.binaryFiles += file.binary ? 1 : 0;
+    stats.deletions += file.deletions ?? 0;
+    stats.renamedFiles += file.oldPath ? 1 : 0;
+  }
+
+  return stats;
+};
+
+/** @param {string} message */
+const splitArcCommitMessage = (message) => {
+  const lines = message.split(/\r?\n/);
+  const subjectIndex = lines.findIndex((line) => line.trim());
+  if (subjectIndex === -1) {
+    return { body: '', subject: '(no subject)' };
+  }
+
+  return {
+    body: lines
+      .slice(subjectIndex + 1)
+      .join('\n')
+      .replace(/^\s*\n/, '')
+      .trimEnd(),
+    subject: lines[subjectIndex],
+  };
+};
+
+/** @param {string} raw */
+const parseArcCommitTrailers = (raw) =>
+  raw.split('\n').flatMap((line) => {
+    const separator = line.indexOf(':');
+    if (separator === -1) {
+      return [];
+    }
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    return key && value ? [{ key, value }] : [];
+  });
+
+/** @param {string} repoRoot @param {string} ref */
+const readArcCommitMessage = async (repoRoot, ref) => {
+  const parsed = JSON.parse(await arc(repoRoot, ['log', '-n', '1', '--json', ref]));
+  const entry = Array.isArray(parsed) ? parsed[0] : null;
+  return isObject(entry) && typeof entry.message === 'string' ? entry.message : '';
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {Extract<ReviewSource, {type: 'arc-commit'}>} source
+ * @param {ReadonlyArray<ChangedFile>} files
+ * @returns {Promise<CommitMetadata | undefined>}
+ */
+const readArcCommitMetadata = async (repoRoot, source, files) => {
+  const logEntry = parseArcLogJson(
+    await arc(repoRoot, ['log', '-n', '1', '--json', source.ref]),
+  )[0];
+  if (!logEntry) {
+    return undefined;
+  }
+
+  const message = await readArcCommitMessage(repoRoot, source.ref);
+  const messageParts = splitArcCommitMessage(message || logEntry.subject);
+  const metadataFiles = createArcCommitMetadataFiles(files);
+  const committedAt = logEntry.committedAt ? new Date(logEntry.committedAt).toISOString() : '';
+  const author = logEntry.author || '';
+
+  return {
+    author: {
+      date: committedAt,
+      email: '',
+      name: author,
+    },
+    body: messageParts.body,
+    committer: {
+      date: committedAt,
+      email: '',
+      name: author,
+    },
+    files: metadataFiles,
+    parents: logEntry.parents,
+    ref: logEntry.ref || source.ref,
+    refs: [],
+    shortRef: (logEntry.ref || source.ref).slice(0, 7),
+    signature: {
+      status: 'N',
+    },
+    stats: createArcCommitMetadataStats(metadataFiles),
+    subject: messageParts.subject,
+    trailers: parseArcCommitTrailers(messageParts.body),
+  };
+};
+
+/**
+ * @param {string} launchPath
+ * @param {Extract<ReviewSource, {type: 'arc-working-tree' | 'arc-branch' | 'arc-range' | 'arc-commit' | 'arc-pull-request'}>} source
+ * @param {{showWhitespace?: boolean}} [options]
+ * @returns {Promise<RepositoryState>}
+ */
+const readArcState = async (launchPath, source, options = {}) => {
+  const repoRoot = await readArcRoot(launchPath);
+  const [branch, rawPatch, resolvedSource] = await Promise.all([
+    readArcBranchName(repoRoot),
+    readArcPatch(repoRoot, source, [], options),
+    source.type === 'arc-pull-request' ? readArcPullRequestSource(repoRoot, source) : source,
+  ]);
+  const reviewComments =
+    resolvedSource.type === 'arc-pull-request'
+      ? await readArcPullRequestComments(repoRoot, resolvedSource.number, resolvedSource.url)
+      : undefined;
+  const status =
+    source.type === 'arc-pull-request'
+      ? parseArcPatchStatus(rawPatch)
+      : await readArcStatus(repoRoot, source);
+  const patches = splitGitPatch(rawPatch);
+  const files = await Promise.all(
+    status.map((item) => createArcFile(repoRoot, source, item, findPatchForItem(patches, item))),
+  );
+  const commitMetadata =
+    source.type === 'arc-commit' ? await readArcCommitMetadata(repoRoot, source, files) : undefined;
+
+  return {
+    branch,
+    ...(commitMetadata ? { commitMetadata } : {}),
+    files,
+    generatedAt: Date.now(),
+    launchPath,
+    ...(reviewComments ? { reviewComments } : {}),
+    root: repoRoot,
+    source:
+      source.type === 'arc-commit' && commitMetadata
+        ? { ref: commitMetadata.ref, type: 'arc-commit' }
+        : resolvedSource,
+  };
+};
+
+/** @param {PullRequestReviewComment['side']} side */
+const toArcanumDiffSide = (side) => (side === 'deletions' ? 'old' : 'new');
+
+/** @param {PullRequestReviewComment} comment */
+const getArcanumLineSpan = (comment) => {
+  const startSide = comment.startSide ?? comment.side;
+  if (
+    typeof comment.startLineNumber === 'number' &&
+    comment.startLineNumber !== comment.lineNumber &&
+    startSide === comment.side
+  ) {
+    const start = Math.min(comment.startLineNumber, comment.lineNumber);
+    const end = Math.max(comment.startLineNumber, comment.lineNumber);
+    return { line: start, size: end - start + 1 };
+  }
+
+  return { line: comment.lineNumber, size: 1 };
+};
+
+/** @param {string} launchPath @param {SubmitPullRequestCommentRequest} request */
+const submitArcPullRequestComment = async (launchPath, request) => {
+  if (request.source.type !== 'arc-pull-request') {
+    throw new Error('Arcadia comment submission requires an Arc pull request source.');
+  }
+
+  const repoRoot = await readArcRoot(launchPath);
+  const span = getArcanumLineSpan(request.comment);
+  const payloads = parseMcpToolPayloads(
+    await arcanum(repoRoot, 'arcanum_post_comment', {
+      comment_data: {
+        content: request.comment.body,
+        draft: false,
+        issue_status: null,
+      },
+      diff_side: toArcanumDiffSide(request.comment.side),
+      file_line_number: span.line,
+      file_path: request.comment.filePath,
+      lines_to_highlight: span.size,
+      pr_id: request.source.number,
+    }),
+  );
+  const submitted = payloads
+    .flatMap((payload) => (isObject(payload) && 'data' in payload ? [payload.data] : [payload]))
+    .map((comment) =>
+      normalizeArcanumReviewComment(comment, request.source.number, request.source.url),
+    )
+    .find(Boolean);
+
+  return (
+    submitted ?? {
+      author: { login: 'Arcanum user' },
+      body: request.comment.body,
+      filePath: request.comment.filePath,
+      id: `arcanum:submitted:${Date.now()}`,
+      lineNumber: request.comment.lineNumber,
+      side: request.comment.side,
+      ...(typeof request.comment.startLineNumber === 'number'
+        ? {
+            startLineNumber: request.comment.startLineNumber,
+            startSide: request.comment.startSide ?? request.comment.side,
+          }
+        : {}),
+      submittedAt: new Date().toISOString(),
+      ...(request.source.url ? { url: request.source.url } : {}),
+    }
+  );
+};
+
+/** @param {string} launchPath @param {DiffSectionContentRequest} request */
+const readArcSectionContent = async (launchPath, request) => {
+  const source = request.source;
+  if (
+    source?.type !== 'arc-working-tree' &&
+    source?.type !== 'arc-branch' &&
+    source?.type !== 'arc-range' &&
+    source?.type !== 'arc-commit' &&
+    source?.type !== 'arc-pull-request'
+  ) {
+    throw new Error('Arc diff content requires an Arc source.');
+  }
+
+  const repoRoot = await readArcRoot(launchPath);
+  const path = validateRepositoryPath(request.path);
+  const rawPatch =
+    source.type === 'arc-pull-request'
+      ? await readArcPatch(repoRoot, source)
+      : await readArcPatch(repoRoot, source, [path], {
+          showWhitespace: request.showWhitespace,
+        });
+  const status =
+    source.type === 'arc-pull-request'
+      ? parseArcPatchStatus(rawPatch)
+      : await readArcStatus(repoRoot, source);
+  const item = status.find((candidate) => candidate.path === path);
+  if (!item) {
+    throw new Error('File is not part of this Arc diff.');
+  }
+  const patch = findPatchForItem(splitGitPatch(rawPatch), item);
+  return (await createArcFile(repoRoot, source, item, patch)).sections[0];
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {Extract<ReviewSource, {type: 'arc-branch' | 'arc-range' | 'arc-commit' | 'arc-pull-request'}>} source
+ * @returns {Promise<{newRef: string; oldRef?: string}>}
+ */
+const resolveArcImageRefs = async (repoRoot, source) => {
+  if (source.type === 'arc-commit') {
+    return { newRef: source.ref, oldRef: `${source.ref}^` };
+  }
+
+  if (source.type === 'arc-pull-request') {
+    const resolved = await readArcPullRequestSource(repoRoot, source);
+    if (!resolved.headSha) {
+      throw new Error(`Arc PR #${source.number} did not report a head commit.`);
+    }
+    const base = resolved.toBranch || 'trunk';
+    return {
+      newRef: resolved.headSha,
+      oldRef: (await arc(repoRoot, ['merge-base', base, resolved.headSha])).trim(),
+    };
+  }
+
+  if (source.type === 'arc-range') {
+    return {
+      newRef: source.head,
+      oldRef: source.symmetric
+        ? (await arc(repoRoot, ['merge-base', source.base, source.head])).trim()
+        : source.base,
+    };
+  }
+
+  return {
+    newRef: 'HEAD',
+    oldRef: (await arc(repoRoot, ['merge-base', source.base, 'HEAD'])).trim(),
+  };
+};
+
+/** @param {string} repoRoot @param {string | undefined} ref @param {string} path */
+const readArcImageFile = async (repoRoot, ref, path) => {
+  if (!ref) {
+    return undefined;
+  }
+
+  try {
+    return bufferToImageRevision(path, await arcBuffer(repoRoot, ['show', `${ref}:${path}`]));
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * @param {string} launchPath
+ * @param {import('../../core/types.ts').DiffImageContentRequest} request
+ * @returns {Promise<DiffImageContentResult>}
+ */
+const readArcImageContent = async (launchPath, request) => {
+  const source = request.source;
+  if (
+    source?.type !== 'arc-working-tree' &&
+    source?.type !== 'arc-branch' &&
+    source?.type !== 'arc-range' &&
+    source?.type !== 'arc-commit' &&
+    source?.type !== 'arc-pull-request'
+  ) {
+    return {
+      reason: 'Image previews are not available for this Arc source.',
+      status: 'unavailable',
+    };
+  }
+
+  const repoRoot = await readArcRoot(launchPath);
+  const path = validateRepositoryPath(request.path);
+  if (source.type !== 'arc-working-tree') {
+    try {
+      const item = (await readArcStatus(repoRoot, source)).find(
+        (candidate) => candidate.path === path,
+      );
+      if (!item) {
+        return {
+          reason: 'Image file is not part of this Arc diff.',
+          status: 'unavailable',
+        };
+      }
+      const refs = await resolveArcImageRefs(repoRoot, source);
+      const [oldImage, newImage] = await Promise.all([
+        item.status === 'added'
+          ? undefined
+          : readArcImageFile(repoRoot, refs.oldRef, item.oldPath || item.path),
+        item.status === 'deleted' ? undefined : readArcImageFile(repoRoot, refs.newRef, item.path),
+      ]);
+      return oldImage || newImage
+        ? {
+            ...(oldImage ? { oldImage } : {}),
+            ...(newImage ? { newImage } : {}),
+            status: 'ready',
+          }
+        : {
+            reason: 'Image file is not available in this Arc diff.',
+            status: 'unavailable',
+          };
+    } catch (error) {
+      return {
+        reason: error instanceof Error ? error.message : String(error),
+        status: 'unavailable',
+      };
+    }
+  }
+
+  const item = (await readArcStatus(repoRoot, source)).find((candidate) => candidate.path === path);
+  if (item?.status !== 'added' && item?.status !== 'untracked') {
+    return {
+      reason: 'Arc image previews are only supported for added or untracked files.',
+      status: 'unavailable',
+    };
+  }
+
+  try {
+    const newImage = await readWorkingTreeImageFile(repoRoot, path);
+    return newImage
+      ? {
+          newImage,
+          status: 'ready',
+        }
+      : {
+          reason: 'Image file is not available in the Arc working tree.',
+          status: 'unavailable',
+        };
+  } catch (error) {
+    return {
+      reason: error instanceof Error ? error.message : String(error),
+      status: 'unavailable',
+    };
+  }
+};
+
+/** @param {string} message */
+const getArcLogSubject = (message) => message.split('\n').find(Boolean) || '(no subject)';
+
+/** @param {unknown} raw */
+const normalizeArcLogEntry = (raw) => {
+  if (!isObject(raw) || typeof raw.commit !== 'string') {
+    return null;
+  }
+
+  const parents = Array.isArray(raw.parents)
+    ? raw.parents.filter((parent) => typeof parent === 'string')
+    : [];
+  const message = typeof raw.message === 'string' ? raw.message : '';
+  const date = typeof raw.date === 'string' ? Date.parse(raw.date) : NaN;
+
+  return {
+    author: typeof raw.author === 'string' ? raw.author : '',
+    committedAt: Number.isFinite(date) ? date : 0,
+    parents,
+    ref: raw.commit,
+    subject: getArcLogSubject(message),
+  };
+};
+
+/** @param {string} raw */
+const parseArcLogJson = (raw) => {
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed.map(normalizeArcLogEntry).filter(Boolean) : [];
+};
+
+/** @param {string} repoRoot */
+const readArcHead = async (repoRoot) => {
+  try {
+    return parseArcLogJson(await arc(repoRoot, ['log', '-n', '1', '--json']))[0]?.ref ?? '';
+  } catch {
+    return '';
+  }
+};
+
+/** @param {string} launchPath @param {Iterable<string>} [additionalPaths] */
+const readArcRepositoryChangeSignature = async (launchPath, additionalPaths = []) => {
+  const repoRoot = await readArcRoot(launchPath);
+  const [head, workingTreeSignatures] = await Promise.all([
+    readArcHead(repoRoot),
+    readArcWorkingTreeChangeSignatures(repoRoot, additionalPaths),
+  ]);
+  const workingTree = workingTreeSignatures.map(([, signature]) => signature).join('\0');
+
+  return {
+    head,
+    pathSignatures: Object.fromEntries(workingTreeSignatures),
+    root: repoRoot,
+    signature: getFingerprint([head, workingTree].join('\0')),
+  };
+};
+
+/** @param {string} launchPath */
+const readArcIdentity = async (launchPath) => {
+  const repoRoot = await readArcRoot(launchPath);
+  const parsed = JSON.parse(await arc(repoRoot, ['info', '--json']));
+  const info = isObject(parsed) ? parsed : {};
+  const login =
+    (typeof info.user_login === 'string' && info.user_login.trim()) ||
+    (typeof info.author === 'string' && info.author.trim()) ||
+    '';
+
+  return {
+    email: '',
+    name: login,
+  };
+};
+
+/** @param {string} raw */
+const parseArcPullRequestHistoryJson = (raw) => {
+  const parsed = JSON.parse(raw);
+  const iterations = isObject(parsed) && Array.isArray(parsed.iterations) ? parsed.iterations : [];
+  return iterations
+    .map((iteration) => {
+      if (!isObject(iteration) || typeof iteration.commit !== 'string') {
+        return null;
+      }
+      const timestamp =
+        typeof iteration.timestamp === 'string' ? Date.parse(iteration.timestamp) : NaN;
+      return {
+        author: '',
+        committedAt: Number.isFinite(timestamp) ? timestamp : 0,
+        parents: [],
+        ref: iteration.commit,
+        subject:
+          typeof iteration.message === 'string'
+            ? getArcLogSubject(iteration.message)
+            : '(no subject)',
+      };
+    })
+    .filter(Boolean);
+};
+
+/**
+ * @param {string} launchPath
+ * @param {number} [limit]
+ * @param {ReviewSource} [source]
+ * @returns {Promise<RepositoryHistory>}
+ */
+const listArcRepositoryHistory = async (launchPath, limit = 50, source) => {
+  const repoRoot = await readArcRoot(launchPath);
+  if (source?.type === 'arc-pull-request') {
+    const output = await arc(repoRoot, ['pr', 'history', '--json', String(source.number)]);
+    return {
+      entries: parseArcPullRequestHistoryJson(output).slice(0, limit),
+      root: repoRoot,
+    };
+  }
+
+  const range = source?.type === 'arc-branch' ? `${source.base}..HEAD` : '';
+  const output = await arc(repoRoot, [
+    'log',
+    '-n',
+    String(limit),
+    '--json',
+    ...(range ? [range] : []),
+  ]);
+  return {
+    entries: parseArcLogJson(output),
+    root: repoRoot,
+  };
+};
+
+module.exports = {
+  listArcRepositoryHistory,
+  normalizeArcanumReviewComment,
+  parseArcNameStatus,
+  readArcIdentity,
+  readArcImageContent,
+  readArcRepositoryChangeSignature,
+  readArcSectionContent,
+  readArcState,
+  submitArcPullRequestComment,
+};

--- a/electron/headless-walkthrough-share.cjs
+++ b/electron/headless-walkthrough-share.cjs
@@ -118,7 +118,10 @@ const uploadWalkthrough = async ({
       repository: {
         root: state.root,
         source: state.source,
-        title: state.source.type === 'commit' ? state.commitMetadata?.subject : undefined,
+        title:
+          state.source.type === 'commit' || state.source.type === 'arc-commit'
+            ? state.commitMetadata?.subject
+            : undefined,
       },
       reviewComments: state.reviewComments,
       version: 1,

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -990,10 +990,18 @@ const createWindow = (
   if (initialRepositoryState) {
     windowInitialRepositoryStates.set(webContentsId, initialRepositoryState);
   }
-  if (!launchOptions.planFile && !launchOptions.source) {
+  if (
+    !launchOptions.planFile &&
+    (!launchOptions.source ||
+      launchOptions.source.type === 'working-tree' ||
+      launchOptions.source.type === 'arc-working-tree')
+  ) {
     void initialRepositoryState
       .then((state) => {
-        if (state.source.type === 'working-tree' && !window.isDestroyed()) {
+        if (
+          (state.source.type === 'working-tree' || state.source.type === 'arc-working-tree') &&
+          !window.isDestroyed()
+        ) {
           startRepositoryWatcher(window, repositoryPath);
         }
       })

--- a/electron/main/command-line.cjs
+++ b/electron/main/command-line.cjs
@@ -4,13 +4,14 @@ const { execFileSync } = require('node:child_process');
 const { existsSync } = require('node:fs');
 const { resolve } = require('node:path');
 const { parseArgs } = require('node:util');
+const { shouldUseArcRepository } = require('../arc-detection.cjs');
 const { readWalkthroughContext } = require('../walkthrough-context.cjs');
-const { parseReviewUrl, resolveReviewUrl } = require('../review-source.cjs');
+const { parseArcReviewUrl, parseReviewUrl, resolveReviewUrl } = require('../review-source.cjs');
 
 /**
  * @typedef {import('../../core/types.ts').CodiffLaunchOptions} CodiffLaunchOptions
  * @typedef {{direction: string; name: string; owner: string; repo: string}} GitHubRemote
- * @typedef {{launchOptions: CodiffLaunchOptions; pullRequestNumber: number | null; repositoryPath: string | null}} ParsedCommandLineArguments
+ * @typedef {{launchOptions: CodiffLaunchOptions; pullRequestNumber: number | null; pullRequestProvider?: 'github' | 'gitlab'; repositoryPath: string | null}} ParsedCommandLineArguments
  */
 
 const commitHashPattern = /^[0-9a-f]{4,64}$/i;
@@ -123,7 +124,7 @@ const parseGitHubRemoteUrl = (value) => {
   }
 };
 
-/** @param {string} repositoryPath @param {number} number */
+/** @param {string} repositoryPath @param {number} number @param {'github' | 'gitlab'} [provider] */
 const resolvePullRequestUrl = (repositoryPath, number, provider) =>
   resolveReviewUrl(repositoryPath, number, provider);
 
@@ -146,6 +147,12 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
         type: 'boolean',
       },
       agent: {
+        type: 'string',
+      },
+      arc: {
+        type: 'boolean',
+      },
+      'arc-base': {
         type: 'string',
       },
       'claude-session': {
@@ -178,6 +185,12 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
 
   let commitRef = typeof values.commit === 'string' ? values.commit : null;
   let branchRef = typeof values.branch === 'string' ? values.branch : null;
+  let arcBase = typeof values['arc-base'] === 'string' ? values['arc-base'] : null;
+  let arc = values.arc === true || arcBase != null;
+  let arcCommitRef = null;
+  let arcPullRequestNumber = null;
+  let arcPullRequestUrl = null;
+  let arcRange = null;
   let pullRequestNumber = null;
   let pullRequestProvider = null;
   let pullRequestUrl = null;
@@ -193,6 +206,15 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
     if (requestedPlanFilePath) {
       repositoryPath ??= arg;
       continue;
+    }
+    if (arcPullRequestNumber == null) {
+      const arcReview = parseArcReviewUrl(arg);
+      if (arcReview) {
+        arc = true;
+        arcPullRequestNumber = arcReview.number;
+        arcPullRequestUrl = arcReview.url;
+        continue;
+      }
     }
     if (!pullRequestUrl && isPullRequestUrlArgument(arg)) {
       pullRequestUrl = arg;
@@ -234,29 +256,79 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
   }
 
   let range = null;
+  const commandRepositoryPath = resolve(repositoryPath || process.cwd());
+  const canUseArcRepository = !requestedPlanFilePath && !pullRequestUrl;
+  const canInferSource = canUseArcRepository && pullRequestNumber == null;
+  const useArcRepository =
+    canUseArcRepository && (arc || shouldUseArcRepository(commandRepositoryPath));
   if (rangeCandidate) {
-    const rangeRepo = resolve(repositoryPath || process.cwd());
     range =
-      isCommitRef(rangeRepo, rangeCandidate.base) && isCommitRef(rangeRepo, rangeCandidate.head)
+      isCommitRef(commandRepositoryPath, rangeCandidate.base) &&
+      isCommitRef(commandRepositoryPath, rangeCandidate.head)
         ? rangeCandidate
         : null;
+    if (!range && useArcRepository) {
+      arc = true;
+      arcRange = rangeCandidate;
+    }
   }
 
   if (!range && !commitRef && !branchRef && sourceCandidate) {
-    const source = resolveSourceCandidate(
-      resolve(repositoryPath || process.cwd()),
-      sourceCandidate,
-    );
+    const source = resolveSourceCandidate(commandRepositoryPath, sourceCandidate);
     if (source?.branchRef) {
       branchRef = source.branchRef;
     } else if (source?.commitRef) {
       commitRef = source.commitRef;
+    } else if (
+      useArcRepository &&
+      !existsSync(resolve(sourceCandidate)) &&
+      !isExplicitPathArgument(sourceCandidate)
+    ) {
+      arc = true;
+      if (isCommitRefArgument(sourceCandidate)) {
+        arcCommitRef = sourceCandidate;
+      } else {
+        arcBase ??= sourceCandidate;
+      }
     } else if (repositoryPath == null) {
       repositoryPath = sourceCandidate;
     }
   }
+  if (useArcRepository && commitRef && !branchRef && !range && !arcRange) {
+    arc = true;
+    arcCommitRef = commitRef;
+    commitRef = null;
+  }
+  if (useArcRepository && pullRequestNumber != null && !pullRequestUrl) {
+    arc = true;
+    arcPullRequestNumber = pullRequestNumber;
+    pullRequestNumber = null;
+    pullRequestProvider = null;
+  }
+  if (
+    canInferSource &&
+    !arc &&
+    !arcBase &&
+    !range &&
+    !commitRef &&
+    !branchRef &&
+    !sourceCandidate &&
+    shouldUseArcRepository(commandRepositoryPath)
+  ) {
+    arc = true;
+  }
 
   const envCommitRef = useEnvironment ? process.env.CODIFF_COMMIT_REF || '' : '';
+  const envArc = useEnvironment ? process.env.CODIFF_ARC === '1' : false;
+  const envArcBase = useEnvironment ? process.env.CODIFF_ARC_BASE || '' : '';
+  const envArcCommitRef = useEnvironment ? process.env.CODIFF_ARC_COMMIT_REF || '' : '';
+  const envArcPullRequestNumber = useEnvironment
+    ? parsePullRequestNumberValue(process.env.CODIFF_ARC_PULL_REQUEST_NUMBER || '')
+    : null;
+  const envArcPullRequestUrl = useEnvironment ? process.env.CODIFF_ARC_PULL_REQUEST_URL || '' : '';
+  const envArcRange = useEnvironment
+    ? parseRangeArgument(process.env.CODIFF_ARC_RANGE || '')
+    : null;
   const envBranchRef = useEnvironment ? process.env.CODIFF_BRANCH_REF || '' : '';
   const envRange = useEnvironment ? parseRangeArgument(process.env.CODIFF_RANGE || '') : null;
   const envPullRequestNumber = useEnvironment
@@ -319,9 +391,20 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
       ? envReviewProvider
       : pullRequestProvider;
   const sourceRef = envCommitRef || commitRef;
+  const sourceArcBase = envArcBase || arcBase;
+  const sourceArcCommitRef = envArcCommitRef || arcCommitRef;
+  const sourceArcPullRequestNumber = envArcPullRequestNumber ?? arcPullRequestNumber;
+  const sourceArcPullRequestUrl = envArcPullRequestUrl || arcPullRequestUrl;
+  const sourceArcRange = envArcRange || arcRange;
+  const sourceArc =
+    envArc ||
+    arc ||
+    Boolean(sourceArcBase || sourceArcCommitRef || sourceArcRange) ||
+    sourceArcPullRequestNumber != null;
   const sourceBranchRef = envBranchRef || branchRef;
   const sourceRange = envRange || range;
   const sourcePullRequestUrl = envPullRequestUrl || pullRequestUrl;
+  const parsedPullRequest = sourcePullRequestUrl ? parseReviewUrl(sourcePullRequestUrl) : null;
   const repositoryPathProvided = Boolean(
     repositoryPath || (useEnvironment && process.env.CODIFF_REPOSITORY_PATH),
   );
@@ -335,8 +418,34 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
       ...(planFilePath ? { planFile: resolve(planFilePath) } : {}),
       ...(planResultFilePath ? { planResultFile: resolve(planResultFilePath) } : {}),
       repositoryPathProvided,
-      source:
-        sourceRange && sourcePullRequestNumber == null
+      source: sourceArc
+        ? sourceArcRange
+          ? {
+              base: sourceArcRange.base,
+              head: sourceArcRange.head,
+              symmetric: sourceArcRange.symmetric,
+              type: 'arc-range',
+            }
+          : sourceArcCommitRef
+            ? {
+                ref: sourceArcCommitRef,
+                type: 'arc-commit',
+              }
+            : sourceArcPullRequestNumber != null
+              ? {
+                  number: sourceArcPullRequestNumber,
+                  type: 'arc-pull-request',
+                  ...(sourceArcPullRequestUrl ? { url: sourceArcPullRequestUrl } : {}),
+                }
+              : sourceArcBase
+                ? {
+                    base: sourceArcBase,
+                    type: 'arc-branch',
+                  }
+                : {
+                    type: 'arc-working-tree',
+                  }
+        : sourceRange && sourcePullRequestNumber == null
           ? {
               base: sourceRange.base,
               head: sourceRange.head,
@@ -345,9 +454,7 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
             }
           : sourcePullRequestUrl
             ? {
-                ...(parseReviewUrl(sourcePullRequestUrl)?.provider
-                  ? { provider: parseReviewUrl(sourcePullRequestUrl).provider }
-                  : {}),
+                ...(parsedPullRequest?.provider ? { provider: parsedPullRequest.provider } : {}),
                 type: 'pull-request',
                 url: sourcePullRequestUrl,
               }

--- a/electron/narrative-walkthrough.cjs
+++ b/electron/narrative-walkthrough.cjs
@@ -113,6 +113,13 @@ const normalizeGeneratedAt = (value) => {
   return '';
 };
 
+/** @param {unknown} source */
+const isWorkingTreeSource = (source) => {
+  const type =
+    source && typeof source === 'object' ? /** @type {{type?: unknown}} */ (source).type : null;
+  return type === 'working-tree' || type === 'arc-working-tree';
+};
+
 /** @param {any} input */
 const isLegacyV3Walkthrough = (input) =>
   input?.version === 3 ||
@@ -463,7 +470,7 @@ const normalizeNarrativeWalkthrough = (input, files, facts = {}) => {
   // commit, branch, or pull request. For working trees, always expose the
   // composer even when the agent did not draft a message, so the reviewer can
   // complete the whole workflow in Codiff.
-  if (/** @type {{type?: string}} */ (result.source).type === 'working-tree') {
+  if (isWorkingTreeSource(result.source)) {
     /** @type {Record<string, unknown>} */
     const commit = {};
     const inputCommit = input.commit && typeof input.commit === 'object' ? input.commit : {};
@@ -684,7 +691,7 @@ Grouping contract:
 - Use notes[] on a stop/support item for short per-hunk header notes: each note is { hunkId, body } and hunkId must be one of that item's hunkIds.
 - Do not provide added/deleted counts, status, oldPath, section ids, display labels, path, repo, source, generatedAt, agent, or meta; Codiff computes those.
 - Put secondary, mechanical, docs-only, or repeated-pattern hunks in support[], grouped by reason.
-- For working-tree sources, include commit.title and commit.body by default unless there are no commit-worthy files. Put the subject line in commit.title, not as the first line of commit.body.
+- For Git or Arc working-tree sources, include commit.title and commit.body by default unless there are no commit-worthy files. Put the subject line in commit.title, not as the first line of commit.body.
 `;
 };
 

--- a/electron/review-source.cjs
+++ b/electron/review-source.cjs
@@ -5,6 +5,24 @@ const { execFileSync } = require('node:child_process');
 /** @typedef {'github' | 'gitlab'} ReviewProvider */
 
 /** @param {string} value */
+const parseArcReviewUrl = (value) => {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+
+  const match = url.pathname.match(/(?:^|\/)review\/([1-9]\d*)(?:\/.*)?$/);
+  return url.hostname.toLowerCase() === 'a.yandex-team.ru' && match
+    ? {
+        number: Number(match[1]),
+        url: `${url.protocol}//${url.host}/review/${match[1]}`,
+      }
+    : null;
+};
+
+/** @param {string} value */
 const parseReviewUrl = (value) => {
   let url;
   try {
@@ -134,6 +152,7 @@ const resolveReviewUrl = (repositoryPath, number, provider) => {
 };
 
 module.exports = {
+  parseArcReviewUrl,
   parseRemoteUrl,
   parseReviewUrl,
   readReviewRemotes,

--- a/electron/walkthrough-commit.cjs
+++ b/electron/walkthrough-commit.cjs
@@ -1,11 +1,74 @@
 // @ts-check
 
-// Create a git commit from a walkthrough's staging set. The renderer hands in the
+// Create a commit from a walkthrough's staging set. The renderer hands in the
 // human-written subject, the agent-drafted body, and the repo-relative paths the
 // reviewer chose to include. Only those paths are committed — any other staged
 // changes are left untouched — so a reviewer can land part of a working tree.
 
+const { execFile } = require('node:child_process');
+const { mkdtemp, rm, writeFile } = require('node:fs/promises');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { promisify } = require('node:util');
 const { git, gitBufferWithInput, validateRepositoryPath } = require('./git-state/common.cjs');
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * @param {string} repoPath
+ * @param {ReadonlyArray<string>} args
+ * @returns {Promise<string>}
+ */
+const arc = async (repoPath, args) => {
+  const { stdout } = await execFileAsync('arc', args, {
+    cwd: repoPath,
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024 * 64,
+  });
+  return stdout;
+};
+
+/** @param {string} raw */
+const parseArcHead = (raw) => {
+  const parsed = JSON.parse(raw);
+  const first = Array.isArray(parsed) ? parsed[0] : undefined;
+  return typeof first?.commit === 'string' ? first.commit : '';
+};
+
+/**
+ * @param {string} repoPath
+ * @param {ReadonlyArray<string>} paths
+ * @param {string} message
+ * @returns {Promise<WalkthroughCommitResult>}
+ */
+const createArcWalkthroughCommit = async (repoPath, paths, message) => {
+  const messageDirectory = await mkdtemp(join(tmpdir(), 'codiff-arc-commit-'));
+  const messagePath = join(messageDirectory, 'message.txt');
+  try {
+    await writeFile(messagePath, message, 'utf8');
+    await arc(repoPath, ['add', '--', ...paths]);
+    await arc(repoPath, ['commit', '-F', messagePath, '--', ...paths]);
+    const hash = parseArcHead(await arc(repoPath, ['log', '-n', '1', '--json']));
+    return hash
+      ? { hash, status: 'committed' }
+      : { reason: 'Arc committed the change but did not return a commit hash.', status: 'failed' };
+  } finally {
+    await rm(messageDirectory, { force: true, recursive: true });
+  }
+};
+
+/**
+ * @param {string} repoPath
+ * @param {ReadonlyArray<string>} paths
+ * @param {string} message
+ * @returns {Promise<WalkthroughCommitResult>}
+ */
+const createGitWalkthroughCommit = async (repoPath, paths, message) => {
+  await git(repoPath, ['add', '--', ...paths]);
+  await gitBufferWithInput(repoPath, ['commit', '-F', '-', '--', ...paths], message);
+  const hash = (await git(repoPath, ['rev-parse', 'HEAD'])).trim();
+  return { hash, status: 'committed' };
+};
 
 /**
  * @typedef {import('../core/types.ts').WalkthroughCommitRequest} WalkthroughCommitRequest
@@ -41,12 +104,11 @@ const createWalkthroughCommit = async (repoPath, request) => {
   const message = body ? `${subject}\n\n${body}\n` : `${subject}\n`;
 
   try {
-    // Stage exactly the chosen paths (covers untracked files too), then commit
-    // only those paths so previously-staged work on other files stays staged.
-    await git(repoPath, ['add', '--', ...paths]);
-    await gitBufferWithInput(repoPath, ['commit', '-F', '-', '--', ...paths], message);
-    const hash = (await git(repoPath, ['rev-parse', 'HEAD'])).trim();
-    return { hash, status: 'committed' };
+    if (request?.source?.type === 'arc-working-tree') {
+      return await createArcWalkthroughCommit(repoPath, paths, message);
+    }
+
+    return await createGitWalkthroughCommit(repoPath, paths, message);
   } catch (error) {
     return {
       reason: error instanceof Error ? error.message : String(error),

--- a/electron/walkthrough-diagnosis.cjs
+++ b/electron/walkthrough-diagnosis.cjs
@@ -1,16 +1,22 @@
 // @ts-check
 
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
 const { gitOrEmpty } = require('./git-state/common.cjs');
+
+const execFileAsync = promisify(execFile);
 
 /**
  * @typedef {{ kind?: string; type?: string }} WalkthroughSource
  * @typedef {{ generatedAt?: unknown; source?: WalkthroughSource; chapters?: unknown; support?: unknown }} WalkthroughInput
+ * @typedef {'arc-working-tree' | 'working-tree'} WorkingTreeWalkthroughKind
+ * @typedef {{hash: string; isoDate: string; subject: string}} NewestPathCommit
  */
 
 /** @param {unknown} value @returns {ReadonlyArray<any>} */
 const asArray = (value) => (Array.isArray(value) ? value : []);
 
-const WORKING_TREE_HUNK_ID = /^(.*):(staged|unstaged):h[1-9]\d*$/;
+const WORKING_TREE_HUNK_ID = /^(.*):(arc|staged|unstaged):h[1-9]\d*$/;
 
 /**
  * @param {unknown} value
@@ -85,33 +91,52 @@ const collectWalkthroughPaths = (input) => {
 const isWorkingTreeWalkthrough = (input) => {
   const kind = input?.source?.kind ?? input?.source?.type;
   // Working-tree is the implicit default the normalizer falls back to.
-  return kind == null || kind === 'working-tree';
+  return kind == null || kind === 'working-tree' || kind === 'arc-working-tree';
+};
+
+/** @param {WalkthroughInput} input @returns {WorkingTreeWalkthroughKind} */
+const getWorkingTreeWalkthroughKind = (input) =>
+  (input?.source?.kind ?? input?.source?.type) === 'arc-working-tree'
+    ? 'arc-working-tree'
+    : 'working-tree';
+
+/**
+ * @param {string} raw
+ * @returns {NewestPathCommit | null}
+ */
+const parseGitNewestCommit = (raw) => {
+  const unitSeparator = String.fromCharCode(0x1f);
+  const [hash, subject, isoDate] = raw.trim().split(unitSeparator);
+  return hash ? { hash, isoDate, subject: subject || '' } : null;
 };
 
 /**
- * When a working-tree walkthrough fails to anchor because the current diff is
- * empty, work out *why* so the modal can say something useful instead of a bare
- * "no changed files". The common cause: the staged/working changes were
- * committed since the walkthrough was authored, so `git diff` is now clean.
- *
- * Returns a human-readable reason, or null when nothing more specific than the
- * caller's default can be determined.
- *
- * @param {{ repositoryRoot: string; input: WalkthroughInput; hasFiles: boolean }} params
- * @returns {Promise<string | null>}
+ * @param {string} raw
+ * @returns {NewestPathCommit | null}
  */
-const diagnoseWalkthroughMismatch = async ({ repositoryRoot, input, hasFiles }) => {
-  // With files present, the mismatch is about anchors, not a vanished diff; the
-  // caller's existing detail message is more appropriate there.
-  if (hasFiles || !isWorkingTreeWalkthrough(input)) {
+const parseArcNewestCommit = (raw) => {
+  try {
+    const [commit] = JSON.parse(raw);
+    if (!commit || typeof commit !== 'object' || typeof commit.commit !== 'string') {
+      return null;
+    }
+    const message = typeof commit.message === 'string' ? commit.message : '';
+    return {
+      hash: commit.commit.slice(0, 12),
+      isoDate: typeof commit.date === 'string' ? commit.date : '',
+      subject: message.split('\n')[0] || '',
+    };
+  } catch {
     return null;
   }
+};
 
-  const paths = collectWalkthroughPaths(input);
-  if (!paths.length) {
-    return null;
-  }
-
+/**
+ * @param {string} repositoryRoot
+ * @param {Array<string>} paths
+ * @returns {Promise<NewestPathCommit | null>}
+ */
+const readGitNewestCommit = async (repositoryRoot, paths) => {
   // The newest commit touching any anchored path. Empty when those paths have
   // never been committed (e.g. untracked files that were since discarded).
   const log = await gitOrEmpty(repositoryRoot, [
@@ -124,10 +149,81 @@ const diagnoseWalkthroughMismatch = async ({ repositoryRoot, input, hasFiles }) 
   ]);
   // Fields are joined by the unit-separator byte (git's %x1f) so commit
   // subjects with arbitrary characters parse safely.
-  const unitSeparator = String.fromCharCode(0x1f);
-  const [hash, subject, isoDate] = log.trim().split(unitSeparator);
+  return parseGitNewestCommit(log);
+};
 
-  if (!hash) {
+/**
+ * @param {string} repositoryRoot
+ * @param {Array<string>} paths
+ * @returns {Promise<NewestPathCommit | null>}
+ */
+const readArcNewestCommit = async (repositoryRoot, paths) => {
+  try {
+    const { stdout } = await execFileAsync('arc', ['log', '-n', '1', '--json', '--', ...paths], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024 * 16,
+    });
+    return parseArcNewestCommit(stdout);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * @param {{
+ *   kind: WorkingTreeWalkthroughKind;
+ *   paths: Array<string>;
+ *   repositoryRoot: string;
+ * }} params
+ * @returns {Promise<NewestPathCommit | null>}
+ */
+const readNewestPathCommit = ({ kind, paths, repositoryRoot }) =>
+  kind === 'arc-working-tree'
+    ? readArcNewestCommit(repositoryRoot, paths)
+    : readGitNewestCommit(repositoryRoot, paths);
+
+/**
+ * When a working-tree walkthrough fails to anchor because the current diff is
+ * empty, work out *why* so the modal can say something useful instead of a bare
+ * "no changed files". The common cause: the staged/working changes were
+ * committed since the walkthrough was authored, so `git diff` is now clean.
+ *
+ * Returns a human-readable reason, or null when nothing more specific than the
+ * caller's default can be determined.
+ *
+ * @param {{
+ *   repositoryRoot: string;
+ *   input: WalkthroughInput;
+ *   hasFiles: boolean;
+ *   readNewestPathCommit?: typeof readNewestPathCommit;
+ * }} params
+ * @returns {Promise<string | null>}
+ */
+const diagnoseWalkthroughMismatch = async ({
+  repositoryRoot,
+  input,
+  hasFiles,
+  readNewestPathCommit: readNewestPathCommitOverride = readNewestPathCommit,
+}) => {
+  // With files present, the mismatch is about anchors, not a vanished diff; the
+  // caller's existing detail message is more appropriate there.
+  if (hasFiles || !isWorkingTreeWalkthrough(input)) {
+    return null;
+  }
+
+  const paths = collectWalkthroughPaths(input);
+  if (!paths.length) {
+    return null;
+  }
+
+  const commit = await readNewestPathCommitOverride({
+    kind: getWorkingTreeWalkthroughKind(input),
+    paths,
+    repositoryRoot,
+  });
+
+  if (!commit) {
     return 'This walkthrough was anchored to uncommitted changes, but the working tree is now clean — they appear to have been reverted or discarded, so the walkthrough no longer matches.';
   }
 
@@ -135,7 +231,7 @@ const diagnoseWalkthroughMismatch = async ({ repositoryRoot, input, hasFiles }) 
   // changes were never committed; they were stashed/reverted instead.
   const generatedAt =
     typeof input?.generatedAt === 'string' ? Date.parse(input.generatedAt) : Number.NaN;
-  const committedAt = Date.parse(isoDate);
+  const committedAt = Date.parse(commit.isoDate);
   const committedAfterAuthoring =
     Number.isNaN(generatedAt) || Number.isNaN(committedAt) || committedAt >= generatedAt - 60_000;
 
@@ -143,11 +239,13 @@ const diagnoseWalkthroughMismatch = async ({ repositoryRoot, input, hasFiles }) 
     return 'This walkthrough was anchored to uncommitted changes, but the working tree is now clean — they appear to have been stashed or reverted, so the walkthrough no longer matches.';
   }
 
-  const commitLabel = subject ? `“${subject}” (${hash})` : hash;
+  const commitLabel = commit.subject ? `“${commit.subject}” (${commit.hash})` : commit.hash;
   return `These changes were committed since the walkthrough was authored — most recently in ${commitLabel}. The walkthrough is anchored to uncommitted working-tree changes, which are now gone, so it no longer matches. Open that commit to review the changes.`;
 };
 
 module.exports = {
   collectWalkthroughPaths,
   diagnoseWalkthroughMismatch,
+  parseArcNewestCommit,
+  parseGitNewestCommit,
 };

--- a/electron/window-identity.cjs
+++ b/electron/window-identity.cjs
@@ -36,6 +36,22 @@ const resolveRepositoryRoot = (repositoryPath) => {
   }
 };
 
+/** @param {string} repositoryPath */
+const resolveArcRepositoryRoot = (repositoryPath) => {
+  const resolvedPath = resolve(repositoryPath);
+
+  try {
+    return getRealPath(
+      execFileSync('arc', ['root'], {
+        cwd: resolvedPath,
+        encoding: 'utf8',
+      }).trim(),
+    );
+  } catch {
+    return getRealPath(resolvedPath);
+  }
+};
+
 /** @param {string} repositoryRoot @param {string} ref */
 const resolveCommitRef = (repositoryRoot, ref) => {
   try {
@@ -124,6 +140,26 @@ const getPullRequestSourceKey = (source) => {
 
 /** @param {string} repositoryRoot @param {ReviewSource} [source] */
 const getSourceKey = (repositoryRoot, source = { type: 'working-tree' }) => {
+  if (source.type === 'arc-working-tree') {
+    return 'arc-working-tree';
+  }
+
+  if (source.type === 'arc-branch') {
+    return `arc-branch:${source.base}`;
+  }
+
+  if (source.type === 'arc-commit') {
+    return `arc-commit:${source.ref}`;
+  }
+
+  if (source.type === 'arc-pull-request') {
+    return `arc-pull-request:${source.number}`;
+  }
+
+  if (source.type === 'arc-range') {
+    return `arc-range:${source.base}${source.symmetric ? '...' : '..'}${source.head}`;
+  }
+
   if (source.type === 'working-tree') {
     return 'working-tree';
   }
@@ -166,7 +202,14 @@ const getWindowIdentity = (repositoryPath, launchOptions = {}) => {
       sourceKey: `plan:${planPath}`,
     };
   }
-  const repositoryRoot = resolveRepositoryRoot(repositoryPath);
+  const repositoryRoot =
+    launchOptions.source?.type === 'arc-working-tree' ||
+    launchOptions.source?.type === 'arc-branch' ||
+    launchOptions.source?.type === 'arc-commit' ||
+    launchOptions.source?.type === 'arc-pull-request' ||
+    launchOptions.source?.type === 'arc-range'
+      ? resolveArcRepositoryRoot(repositoryPath)
+      : resolveRepositoryRoot(repositoryPath);
   const implicitWalkthroughHead =
     launchOptions.walkthrough &&
     !launchOptions.walkthroughFile &&


### PR DESCRIPTION
## Summary

Adds Arcadia/Arc repository support alongside the existing Git/GitHub/GitLab flows.

- Detects Arcadia checkouts automatically and supports Arc working tree, branch, range, commit, and pull request sources.
- Adds Arc diff/state/history/identity/image/comment plumbing through `arc` and Arcanum devtools.
- Updates CLI, Electron command-line parsing, walkthrough/reload/source labels, shared walkthroughs, and review comment handling for Arc sources.
- Keeps Arc review verdict submission explicitly unsupported with a clear TODO/error while inline comments are supported.
- Fixes Codex walkthrough generation for Arcadia by launching with the repository cwd and `--skip-git-repo-check`.

## Validation

- `vp check --fix`
- `vp test` — 47 files, 476 tests passed
- `vp fmt --check .`
- `vp build`
- `git diff --check`
- Manual read-only smoke against `/Users/sergeigarin/arcadia` for Arc working tree, `HEAD` commit, walkthrough fallback, history, identity, diff section content, and Arcanum PR source `14096393`.
