### PR TITLE
Improve missing branch errors

### DIFF
--- a/bin/arguments.js
+++ b/bin/arguments.js
@@ -185,6 +185,9 @@ const gitSucceeds = (repositoryPath, args) => {
   }
 };
 
+const isGitRepository = (repositoryPath) =>
+  gitSucceeds(repositoryPath, ['rev-parse', '--show-toplevel']);
+
 const isBranchRef = (repositoryPath, ref) =>
   gitSucceeds(repositoryPath, ['show-ref', '--verify', '--quiet', `refs/heads/${ref}`]) ||
   gitSucceeds(repositoryPath, ['show-ref', '--verify', '--quiet', `refs/remotes/${ref}`]);
@@ -319,6 +322,10 @@ export const parseArguments = (args) => {
       branchRef = source.branchRef;
     } else if (source?.commitRef) {
       commitRef = source.commitRef;
+    } else if (requestedPath == null && existsSync(resolve(sourceCandidate))) {
+      requestedPath = sourceCandidate;
+    } else if (isGitRepository(repositoryPath)) {
+      branchRef = sourceCandidate;
     } else if (requestedPath == null) {
       requestedPath = sourceCandidate;
     }

--- a/bin/codiff-app
+++ b/bin/codiff-app
@@ -148,6 +148,10 @@ is_git_commit_ref() {
   git -C "$1" rev-parse --verify "$2^{commit}" >/dev/null 2>&1
 }
 
+is_git_repository() {
+  git -C "$1" rev-parse --show-toplevel >/dev/null 2>&1
+}
+
 for arg in "$@"; do
   if [ "$expect_codex_session" -eq 1 ]; then
     codex_session_id="$arg"
@@ -361,6 +365,10 @@ if [ -n "$source_ref" ] && [ -z "$commit_ref" ] && [ -z "$branch_ref" ]; then
     branch_ref="$source_ref"
   elif is_git_commit_ref "$repository_context" "$source_ref" || is_commit_ref_arg "$source_ref"; then
     commit_ref="$source_ref"
+  elif [ -z "$repository_path" ] && [ -e "$source_ref" ]; then
+    repository_path="$source_ref"
+  elif is_git_repository "$repository_context"; then
+    branch_ref="$source_ref"
   elif [ -z "$repository_path" ]; then
     repository_path="$source_ref"
   fi

--- a/core/__tests__/codiff-cli.test.ts
+++ b/core/__tests__/codiff-cli.test.ts
@@ -115,6 +115,22 @@ test('parseArguments treats plain branch refs as branch refs', async () => {
   });
 });
 
+test('parseArguments treats missing plain refs in Git repositories as branch refs', async () => {
+  await withCwd(refRepositoryPath, () => {
+    expect(parseArguments(['definitely-missing-branch'])).toMatchObject({
+      branchRef: 'definitely-missing-branch',
+      commitRef: null,
+      requestedPath: refRepositoryPath,
+    });
+
+    expect(parseArguments(['definitely-missing-branch', refRepositoryPath])).toMatchObject({
+      branchRef: 'definitely-missing-branch',
+      commitRef: null,
+      requestedPath: refRepositoryPath,
+    });
+  });
+});
+
 test('parseArguments treats hex-like refs as commits before branches', async () => {
   await withCwd(refRepositoryPath, () => {
     expect(parseArguments([refRepositoryShortHash])).toMatchObject({
@@ -454,6 +470,28 @@ test('packaged terminal helper forwards branch names to Electron as branches', a
       '--args',
       '--branch',
       'feature',
+      refRepositoryPath,
+    ]);
+  } finally {
+    await logger.cleanup();
+  }
+});
+
+test('packaged terminal helper forwards missing branch names to Electron as branches', async () => {
+  const logger = await createFakeOpenLogger();
+
+  try {
+    await execFileAsync(resolve('bin/codiff-app'), ['definitely-missing-branch'], {
+      cwd: refRepositoryPath,
+      env: logger.env,
+    });
+
+    expect(await logger.readArgs()).toEqual([
+      '-n',
+      resolve('bin/../../../..'),
+      '--args',
+      '--branch',
+      'definitely-missing-branch',
       refRepositoryPath,
     ]);
   } finally {

--- a/core/__tests__/git-state.test.ts
+++ b/core/__tests__/git-state.test.ts
@@ -906,6 +906,57 @@ test('readRepositoryState opens branch refs as current branch diffs against the 
   });
 });
 
+test('readRepositoryState reports missing branch refs clearly', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(repo, 'file.txt', 'base\n');
+    await commitAll(repo, 'initial commit');
+
+    await expect(
+      readRepositoryState(repo, { ref: 'definitely-missing-branch', type: 'branch' }),
+    ).rejects.toThrow('Branch "definitely-missing-branch" does not exist in this repository.');
+  });
+});
+
+test('readRepositoryState suggests nearby branch refs', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(repo, 'file.txt', 'base\n');
+    await commitAll(repo, 'initial commit');
+    await git(repo, ['branch', 'feature/login']);
+
+    await expect(
+      readRepositoryState(repo, { ref: 'feature/logn', type: 'branch' }),
+    ).rejects.toThrow(
+      'Branch "feature/logn" does not exist in this repository. Did you mean "feature/login"?',
+    );
+  });
+});
+
+test('readRepositoryState suggests master when main is missing', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(repo, 'file.txt', 'base\n');
+    await commitAll(repo, 'initial commit');
+    await git(repo, ['checkout', '-B', 'master']);
+    await git(repo, ['branch', '-D', 'main']).catch(() => undefined);
+
+    await expect(readRepositoryState(repo, { ref: 'main', type: 'branch' })).rejects.toThrow(
+      'Branch "main" does not exist in this repository. Did you mean "master"?',
+    );
+  });
+});
+
+test('readRepositoryState suggests main when master is missing', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(repo, 'file.txt', 'base\n');
+    await commitAll(repo, 'initial commit');
+    await git(repo, ['checkout', '-B', 'main']);
+    await git(repo, ['branch', '-D', 'master']).catch(() => undefined);
+
+    await expect(readRepositoryState(repo, { ref: 'master', type: 'branch' })).rejects.toThrow(
+      'Branch "master" does not exist in this repository. Did you mean "main"?',
+    );
+  });
+});
+
 test('readWorkingTreeState reports staged pure renames with old and new paths', async () => {
   await withRepo(async (repo) => {
     await writeRepoFile(repo, 'old.txt', 'same contents\n');

--- a/electron/__tests__/command-line.test.ts
+++ b/electron/__tests__/command-line.test.ts
@@ -216,6 +216,50 @@ test('parses plain refs as branch sources', async () => {
   }
 });
 
+test('parses missing plain refs in Git repositories as branch sources', async () => {
+  const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-missing-branch-ref-'));
+  const previousCwd = process.cwd();
+
+  try {
+    await git(repositoryPath, ['init']);
+    await git(repositoryPath, ['config', 'user.email', 'codiff@example.com']);
+    await git(repositoryPath, ['config', 'user.name', 'Codiff Test']);
+    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'initial commit']);
+    process.chdir(repositoryPath);
+
+    expect(parseCommandLineArguments(['codiff', 'definitely-missing-branch'])).toEqual({
+      launchOptions: {
+        repositoryPathProvided: false,
+        source: {
+          ref: 'definitely-missing-branch',
+          type: 'branch',
+        },
+        walkthrough: false,
+      },
+      pullRequestNumber: null,
+      repositoryPath: null,
+    });
+
+    expect(
+      parseCommandLineArguments(['codiff', 'definitely-missing-branch', repositoryPath]),
+    ).toEqual({
+      launchOptions: {
+        repositoryPathProvided: true,
+        source: {
+          ref: 'definitely-missing-branch',
+          type: 'branch',
+        },
+        walkthrough: false,
+      },
+      pullRequestNumber: null,
+      repositoryPath,
+    });
+  } finally {
+    process.chdir(previousCwd);
+    await rm(repositoryPath, { force: true, recursive: true });
+  }
+});
+
 test('parses hex-like refs as commits before branches', async () => {
   const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-hex-ref-'));
   const previousCwd = process.cwd();

--- a/electron/git-state/commit.cjs
+++ b/electron/git-state/commit.cjs
@@ -118,6 +118,79 @@ const resolveRangeRefs = async (repoRoot, base, head, symmetric) => {
   return { newRef, oldRef };
 };
 
+/** @param {string} left @param {string} right */
+const getEditDistance = (left, right) => {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+
+  for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
+    const current = [leftIndex + 1];
+    for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
+      current[rightIndex + 1] =
+        left[leftIndex] === right[rightIndex]
+          ? previous[rightIndex]
+          : Math.min(previous[rightIndex], previous[rightIndex + 1], current[rightIndex]) + 1;
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+
+  return previous[right.length];
+};
+
+/** @param {string} requested @param {string} candidate */
+const getBranchSuggestionScore = (requested, candidate) => {
+  const requestedLower = requested.toLowerCase();
+  const aliases = [candidate.toLowerCase()];
+  const slashIndex = candidate.indexOf('/');
+  if (slashIndex !== -1) {
+    aliases.push(candidate.slice(slashIndex + 1).toLowerCase());
+  }
+
+  return Math.min(
+    ...aliases.map((alias) => {
+      if (
+        (requestedLower === 'main' && alias === 'master') ||
+        (requestedLower === 'master' && alias === 'main')
+      ) {
+        return 1;
+      }
+
+      return alias.startsWith(requestedLower) && requestedLower.length >= 3
+        ? 1
+        : getEditDistance(requestedLower, alias);
+    }),
+  );
+};
+
+/** @param {string} ref */
+const getBranchSuggestionThreshold = (ref) =>
+  ref.length <= 4 ? 1 : ref.length <= 8 ? 2 : Math.floor(ref.length / 3);
+
+/** @param {string} repoRoot @param {string} ref @returns {Promise<string | null>} */
+const getBranchSuggestion = async (repoRoot, ref) => {
+  const raw = await git(repoRoot, [
+    'for-each-ref',
+    '--format=%(refname:short)',
+    'refs/heads',
+    'refs/remotes',
+  ]);
+  const candidates = [
+    ...new Set(
+      raw
+        .split('\n')
+        .map((branch) => branch.trim())
+        .filter((branch) => branch && !branch.endsWith('/HEAD') && branch !== ref),
+    ),
+  ];
+  const [best] = candidates
+    .map((branch) => ({
+      branch,
+      score: getBranchSuggestionScore(ref, branch),
+    }))
+    .sort((left, right) => left.score - right.score || left.branch.localeCompare(right.branch));
+
+  return best && best.score <= getBranchSuggestionThreshold(ref) ? best.branch : null;
+};
+
 /** @param {string | BranchSource | BranchDiffSource} input @returns {BranchSource | BranchDiffSource} */
 const normalizeBranchSourceInput = (input) =>
   typeof input === 'string' ? { ref: input, type: 'branch' } : input;
@@ -137,7 +210,19 @@ const resolveBranchComparison = async (repoRoot, source) => {
     };
   }
 
-  const { newRef, oldRef } = await resolveRangeRefs(repoRoot, source.ref, 'HEAD', true);
+  const newRef = await resolveRangeEndpoint(repoRoot, 'HEAD');
+  let branchRef;
+  try {
+    branchRef = await resolveRangeEndpoint(repoRoot, source.ref);
+  } catch {
+    const suggestion = await getBranchSuggestion(repoRoot, source.ref);
+    throw new Error(
+      `Branch "${source.ref}" does not exist in this repository.${
+        suggestion ? ` Did you mean "${suggestion}"?` : ''
+      }`,
+    );
+  }
+  const oldRef = (await git(repoRoot, ['merge-base', branchRef, newRef])).trim();
   return {
     newRef,
     oldRef,

--- a/electron/main/command-line.cjs
+++ b/electron/main/command-line.cjs
@@ -52,6 +52,10 @@ const gitSucceeds = (repositoryPath, args) => {
   }
 };
 
+/** @param {string} repositoryPath */
+const isGitRepository = (repositoryPath) =>
+  gitSucceeds(repositoryPath, ['rev-parse', '--show-toplevel']);
+
 /** @param {string} repositoryPath @param {string} ref */
 const isBranchRef = (repositoryPath, ref) =>
   gitSucceeds(repositoryPath, ['show-ref', '--verify', '--quiet', `refs/heads/${ref}`]) ||
@@ -251,6 +255,10 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
       branchRef = source.branchRef;
     } else if (source?.commitRef) {
       commitRef = source.commitRef;
+    } else if (repositoryPath == null && existsSync(resolve(sourceCandidate))) {
+      repositoryPath = sourceCandidate;
+    } else if (isGitRepository(resolve(repositoryPath || process.cwd()))) {
+      branchRef = sourceCandidate;
     } else if (repositoryPath == null) {
       repositoryPath = sourceCandidate;
     }


### PR DESCRIPTION
Resolves #93 

This PR gives a better error message when you run `codiff <branch>` and the branch does not exists. It even suggests an alternative branch in case of typos or a classic master<>main problem 😄 