### PR TITLE
Fix packaged app crash: include core/lib CJS modules

### DIFF
--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -107,28 +107,38 @@ module.exports = {
     },
     executableName: 'codiff',
     ...(iconPath ? { icon: iconPath } : {}),
-    ignore: [
-      /^\/\.DS_Store$/,
-      /^\/\.cache(?:$|\/)/,
-      /^\/\.enum_manifest\.json$/,
-      /^\/\.env(?:$|[.])/,
-      /^\/\.git(?:$|\/)/,
-      /^\/\.gitignore$/,
-      /^\/\.github(?:$|\/)/,
-      /^\/\.vite-hooks(?:$|\/)/,
-      /^\/\.vscode(?:$|\/)/,
-      /^\/README\.md$/,
-      /^\/coverage(?:$|\/)/,
-      /^\/docs(?:$|\/)/,
-      /^\/forge\.config\.cjs$/,
-      /^\/index\.html$/,
-      /^\/out(?:$|\/)/,
-      /^\/pnpm-workspace\.yaml$/,
-      /^\/public(?:$|\/)/,
-      /^\/core(?:$|\/)/,
-      /^\/tsconfig/,
-      /^\/vite\.config\./,
-    ],
+    ignore: (filePath) => {
+      if (
+        filePath === '/core' ||
+        filePath === '/core/lib' ||
+        /^\/core\/lib\/.*\.cjs$/.test(filePath)
+      ) {
+        return false;
+      }
+
+      return [
+        /^\/\.DS_Store$/,
+        /^\/\.cache(?:$|\/)/,
+        /^\/\.enum_manifest\.json$/,
+        /^\/\.env(?:$|[.])/,
+        /^\/\.git(?:$|\/)/,
+        /^\/\.gitignore$/,
+        /^\/\.github(?:$|\/)/,
+        /^\/\.vite-hooks(?:$|\/)/,
+        /^\/\.vscode(?:$|\/)/,
+        /^\/README\.md$/,
+        /^\/coverage(?:$|\/)/,
+        /^\/docs(?:$|\/)/,
+        /^\/forge\.config\.cjs$/,
+        /^\/index\.html$/,
+        /^\/out(?:$|\/)/,
+        /^\/pnpm-workspace\.yaml$/,
+        /^\/public(?:$|\/)/,
+        /^\/core(?:$|\/)/,
+        /^\/tsconfig/,
+        /^\/vite\.config\./,
+      ].some((pattern) => pattern.test(filePath));
+    },
     name: 'Codiff',
     ...(osxNotarize ? { osxNotarize } : {}),
     osxSign: {


### PR DESCRIPTION
Fixes #100

I had [Claude](https://claude.ai/code) fix this. The `ignore` list in `forge.config.cjs` blanket-excludes `/core`, but `electron/narrative-walkthrough.cjs` requires `../core/lib/narrative-walkthrough-diff.cjs` at runtime. This converts `ignore` from an array to a function that whitelists `core/lib/*.cjs` while still excluding the rest of `core/` (React/TS source compiled into `dist/` by Vite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)