### PR TITLE
Resolve the glab binary like other CLI integrations

### DIFF
--- a/core/__tests__/gitlab.test.ts
+++ b/core/__tests__/gitlab.test.ts
@@ -1,4 +1,7 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, test } from 'vite-plus/test';
 
 const require = createRequire(import.meta.url);
@@ -15,6 +18,9 @@ const {
   createMergeRequestFetchRefspecs,
   createMergeRequestSource,
   getGitLabReviewQuickAction,
+  getGlabCommand,
+  GLAB_NOT_FOUND_CODE,
+  GLAB_NOT_FOUND_MESSAGE,
   normalizeGitLabReviewComment,
   parseGitLabMergeRequestUrl,
   parseGlabJsonPages,
@@ -39,6 +45,9 @@ const {
     metadata: Record<string, unknown>,
   ) => Record<string, unknown>;
   getGitLabReviewQuickAction: (event: 'APPROVE' | 'REQUEST_CHANGES') => string;
+  getGlabCommand: () => string;
+  GLAB_NOT_FOUND_CODE: string;
+  GLAB_NOT_FOUND_MESSAGE: string;
   normalizeGitLabReviewComment: (
     note: Record<string, unknown>,
     url: string,
@@ -70,6 +79,55 @@ describe('GitLab merge requests', () => {
       '-',
       'projects/1/merge_requests/2/discussions',
     ]);
+  });
+
+  test('resolves glab from the CODIFF_GLAB_PATH override', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'codiff-glab-'));
+    const fakeGlabPath = join(directory, 'glab');
+    const previousGlabPath = process.env.CODIFF_GLAB_PATH;
+
+    try {
+      await writeFile(fakeGlabPath, '#!/usr/bin/env node\n');
+      await chmod(fakeGlabPath, 0o755);
+      process.env.CODIFF_GLAB_PATH = fakeGlabPath;
+
+      expect(getGlabCommand()).toBe(fakeGlabPath);
+    } finally {
+      if (previousGlabPath == null) {
+        delete process.env.CODIFF_GLAB_PATH;
+      } else {
+        process.env.CODIFF_GLAB_PATH = previousGlabPath;
+      }
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects invalid explicit glab CLI overrides', () => {
+    const previousGlabPath = process.env.CODIFF_GLAB_PATH;
+    process.env.CODIFF_GLAB_PATH = '/tmp/codiff-missing-glab';
+
+    try {
+      expect(() => getGlabCommand()).toThrow('CODIFF_GLAB_PATH');
+      try {
+        getGlabCommand();
+      } catch (error) {
+        expect(error).toMatchObject({ code: GLAB_NOT_FOUND_CODE });
+      }
+    } finally {
+      if (previousGlabPath == null) {
+        delete process.env.CODIFF_GLAB_PATH;
+      } else {
+        process.env.CODIFF_GLAB_PATH = previousGlabPath;
+      }
+    }
+  });
+
+  test('explains where Codiff searches for glab when it is missing', () => {
+    expect(GLAB_NOT_FOUND_MESSAGE).toContain('PATH');
+    expect(GLAB_NOT_FOUND_MESSAGE).toContain('~/.local/bin/glab');
+    expect(GLAB_NOT_FOUND_MESSAGE).toContain('/opt/homebrew/bin/glab');
+    expect(GLAB_NOT_FOUND_MESSAGE).toContain('/usr/local/bin/glab');
+    expect(GLAB_NOT_FOUND_MESSAGE).toContain('CODIFF_GLAB_PATH=/absolute/path/to/glab');
   });
 
   test('parses arbitrary hosts and nested project paths', () => {

--- a/electron/git-state/merge-request.cjs
+++ b/electron/git-state/merge-request.cjs
@@ -2,6 +2,9 @@
 
 const { createHash } = require('node:crypto');
 const { spawn } = require('node:child_process');
+const { homedir } = require('node:os');
+const { join } = require('node:path');
+const { findExecutableOnPath, isExecutableFile } = require('../agent-shared.cjs');
 const {
   getFingerprint,
   git,
@@ -22,6 +25,49 @@ const { parseReviewUrl, readReviewRemotes } = require('../review-source.cjs');
  * @typedef {import('../../core/types.ts').PullRequestReviewComment} PullRequestReviewComment
  * @typedef {import('../../core/types.ts').ReviewSource} ReviewSource
  */
+
+const GLAB_NOT_FOUND_CODE = 'GLAB_NOT_FOUND';
+const GLAB_NOT_FOUND_MESSAGE =
+  'GitLab support requires glab. Install glab, authenticate it, and verify `glab --version` works in Terminal. Codiff searches PATH, ~/.local/bin/glab, /opt/homebrew/bin/glab, and /usr/local/bin/glab. If glab is installed somewhere else, launch Codiff with `CODIFF_GLAB_PATH=/absolute/path/to/glab codiff -w`.';
+
+/** @param {string} [detail] */
+const createGlabNotFoundError = (detail) =>
+  Object.assign(
+    new Error(detail ? `${GLAB_NOT_FOUND_MESSAGE} ${detail}` : GLAB_NOT_FOUND_MESSAGE),
+    {
+      code: GLAB_NOT_FOUND_CODE,
+    },
+  );
+
+const getGlabCommand = () => {
+  const glabPath = process.env.CODIFF_GLAB_PATH?.trim();
+  if (glabPath) {
+    if (isExecutableFile(glabPath)) {
+      return glabPath;
+    }
+
+    throw createGlabNotFoundError(
+      `CODIFF_GLAB_PATH is set to ${JSON.stringify(glabPath)}, but that file is not executable.`,
+    );
+  }
+
+  const pathCommand = findExecutableOnPath('glab');
+  if (pathCommand) {
+    return pathCommand;
+  }
+
+  for (const path of [
+    join(homedir(), '.local/bin/glab'),
+    '/opt/homebrew/bin/glab',
+    '/usr/local/bin/glab',
+  ]) {
+    if (isExecutableFile(path)) {
+      return path;
+    }
+  }
+
+  throw createGlabNotFoundError();
+};
 
 /** @param {string} value */
 const parseGitLabMergeRequestUrl = (value) => {
@@ -56,7 +102,15 @@ const createGlabApiArgs = (mergeRequest, args, input) => [
  */
 const glabApi = (repoRoot, mergeRequest, args, input) =>
   new Promise((resolve, reject) => {
-    const child = spawn('glab', createGlabApiArgs(mergeRequest, args, input), {
+    let command;
+    try {
+      command = getGlabCommand();
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const child = spawn(command, createGlabApiArgs(mergeRequest, args, input), {
       cwd: repoRoot,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -65,11 +119,7 @@ const glabApi = (repoRoot, mergeRequest, args, input) =>
     child.stdout.on('data', (chunk) => stdout.push(chunk));
     child.stderr.on('data', (chunk) => stderr.push(chunk));
     child.on('error', (error) => {
-      reject(
-        error.code === 'ENOENT'
-          ? new Error('GitLab support requires glab. Install glab and authenticate it first.')
-          : error,
-      );
+      reject(error.code === 'ENOENT' ? createGlabNotFoundError() : error);
     });
     child.on('close', (code) => {
       if (code === 0) {
@@ -605,12 +655,15 @@ const readMergeRequestImageContent = async (launchPath, source, requestedPath) =
 };
 
 module.exports = {
+  GLAB_NOT_FOUND_CODE,
+  GLAB_NOT_FOUND_MESSAGE,
   createGlabApiArgs,
   createGitLabPosition,
   createGitLabDiffLineMap,
   createMergeRequestSource,
   createMergeRequestFetchRefspecs,
   getGitLabReviewQuickAction,
+  getGlabCommand,
   listMergeRequestHistory,
   normalizeGitLabReviewComment,
   parseGlabJsonPages,


### PR DESCRIPTION
## Summary

- resolve the `glab` binary in `electron/git-state/merge-request.cjs` the same way the Claude, Codex, OpenCode, Pi, and cloudflared integrations do: PATH lookup via the shared `agent-shared.cjs` helpers, with fallbacks to `~/.local/bin/glab`, `/opt/homebrew/bin/glab`, and `/usr/local/bin/glab`
- support a `CODIFF_GLAB_PATH` override, including a clear error when it points at a non-executable file
- expand the glab-not-found error to explain the searched locations and the override, matching the phrasing of the Claude/OpenCode messages
- add tests for the override, the invalid-override error code, and the guidance in the not-found message

The packaged `codiff` wrapper launches the app via `open -n`, so the GUI process inherits launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) and the previous bare `spawn('glab', ...)` failed with ENOENT even when glab was installed via Homebrew and authenticated, causing MR reviews to fall back to local changes.

Fixes #104.

## Validation

- `vp check --fix`
- `vp test core/__tests__/gitlab.test.ts` (14 passed)
- `vp build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)