### PR TITLE
Refresh instead of hard reload

### DIFF
--- a/core/App.tsx
+++ b/core/App.tsx
@@ -69,8 +69,10 @@ import { isNativeInputTarget } from './lib/keyboard.ts';
 import { buildCommitModel, buildGenericCommitModel } from './lib/narrative-walkthrough.ts';
 import {
   consumeReloadSelection,
+  getChangedPaths,
   getReloadDeltaPaths,
   getReloadHistorySource,
+  getReloadMainMode,
   getReloadSelectionPath,
   writeReloadSelection,
 } from './lib/reload-selection.ts';
@@ -650,6 +652,17 @@ export default function App() {
         : {};
       const reloadSelectedPath = getReloadSelectionPath(reloadSelection, orderedState);
       const nextReloadDeltaPaths = getReloadDeltaPaths(reloadSelection, orderedState);
+      // Reopen the commit view after a reload, but only while it would still be
+      // openable (same conditions as openCommitView); e.g. once the commit
+      // lands the working tree may be empty and we fall back to the review.
+      const restoreCommitView =
+        getReloadMainMode(reloadSelection, orderedState) === 'commit' &&
+        orderedState.source.type === 'working-tree' &&
+        orderedState.files.length > 0;
+      if (restoreCommitView) {
+        setSidebarMode('tree');
+        setMainMode('commit');
+      }
 
       setHistoryEntries(history.entries);
       setHistoryHasMore(history.entries.length >= HISTORY_PAGE_SIZE);
@@ -1352,9 +1365,63 @@ export default function App() {
     [scrollPathIntoReview],
   );
 
-  const reloadWindow = useCallback(() => {
-    window.location.reload();
-  }, []);
+  // Refresh the repository state in place after the working tree changed.
+  // Unlike a window reload, this keeps all review UI state (selection, scroll,
+  // search, walkthrough navigation, commit drafts, pending comments) and only
+  // re-renders the files whose fingerprints actually moved.
+  const refreshRepository = useCallback(() => {
+    const previousState = stateRef.current;
+    if (!previousState || pendingSource) {
+      return;
+    }
+
+    const request = sourceRequestRef.current + 1;
+    sourceRequestRef.current = request;
+
+    Promise.all([
+      window.codiff.getRepositoryState(previousState.source),
+      window.codiff.getRepositoryHistory(historyLimit, historySourceRef.current ?? undefined),
+    ])
+      .then(([nextState, history]) => {
+        if (sourceRequestRef.current !== request) {
+          return;
+        }
+
+        const orderedState = {
+          ...nextState,
+          files: sortFiles(nextState.files),
+        };
+        const changedPaths = getChangedPaths(previousState.files, orderedState.files);
+
+        stateGenerationRef.current += 1;
+        setState(orderedState);
+        setReloadDeltaPaths(changedPaths);
+        for (const path of changedPaths) {
+          bumpItemVersion(path);
+        }
+        setHistoryEntries(history.entries);
+        setHistoryHasMore(history.entries.length >= historyLimit);
+        setSelectedPath((current) =>
+          current != null && orderedState.files.some((file) => file.path === current)
+            ? current
+            : (orderedState.files[0]?.path ?? null),
+        );
+        if (
+          mainModeRef.current === 'commit' &&
+          (orderedState.source.type !== 'working-tree' || orderedState.files.length === 0)
+        ) {
+          setMainMode('review');
+        }
+        setLocalChangesDetected(false);
+      })
+      .catch(() => {
+        // Keep the current state; the banner stays up as a retry affordance.
+      });
+  }, [bumpItemVersion, historyLimit, pendingSource]);
+
+  // ⌘R / the View menu's "Refresh Changes" item route here from the main
+  // process instead of reloading the window.
+  useEffect(() => window.codiff.onRefreshRequest(refreshRepository), [refreshRepository]);
 
   // Commit the files a reviewer chose from the walkthrough's staging set. The
   // working-tree watcher surfaces a "reload to see changes" banner afterwards.
@@ -1380,7 +1447,12 @@ export default function App() {
 
   useEffect(() => {
     const writeCurrentReloadSelection = () => {
-      writeReloadSelection(stateRef.current, selectedPathRef.current, historySourceRef.current);
+      writeReloadSelection(
+        stateRef.current,
+        selectedPathRef.current,
+        historySourceRef.current,
+        mainModeRef.current,
+      );
     };
 
     window.addEventListener('beforeunload', writeCurrentReloadSelection);
@@ -1514,6 +1586,58 @@ export default function App() {
     handle.addEventListener('pointercancel', handleEnd);
   }, []);
 
+  // Ask the connected agent for a narrative walkthrough of the given source.
+  // Results are dropped if the reviewer switched sources while it was running.
+  const loadNarrativeWalkthrough = useCallback((source: ReviewSource) => {
+    const sourceKey = getSourceKey(source);
+    setWalkthroughLoading(true);
+    setWalkthroughError(null);
+    window.codiff
+      .getNarrativeWalkthrough(source)
+      .then((result) => {
+        if (getSourceKey(stateRef.current?.source ?? source) !== sourceKey) {
+          return;
+        }
+
+        if (result.status === 'ready') {
+          setNarrativeWalkthrough(result.walkthrough);
+          if (sidebarModeRef.current === 'walkthrough') {
+            setSidebarMode('walkthrough');
+          } else {
+            setWalkthroughUnread(true);
+          }
+        } else {
+          setWalkthroughError(result);
+        }
+      })
+      .catch((error: unknown) => {
+        if (getSourceKey(stateRef.current?.source ?? source) !== sourceKey) {
+          return;
+        }
+
+        setWalkthroughError({
+          reason: error instanceof Error ? error.message : String(error),
+          status: 'unavailable',
+        });
+      })
+      .finally(() => {
+        if (getSourceKey(stateRef.current?.source ?? source) === sourceKey) {
+          setWalkthroughLoading(false);
+        }
+      });
+  }, []);
+
+  // Regenerate the walkthrough on demand, e.g. after an in-place refresh
+  // surfaced changes the current walkthrough doesn't narrate. The existing
+  // walkthrough stays visible until the new one arrives.
+  const regenerateWalkthrough = useCallback(() => {
+    const currentState = stateRef.current;
+    if (!currentState || currentState.files.length === 0 || walkthroughLoading) {
+      return;
+    }
+    loadNarrativeWalkthrough(currentState.source);
+  }, [loadNarrativeWalkthrough, walkthroughLoading]);
+
   const changeSidebarMode = useCallback(
     (mode: SidebarMode) => {
       setMainMode('review');
@@ -1539,44 +1663,9 @@ export default function App() {
         return;
       }
 
-      const sourceKey = getSourceKey(state.source);
-      setWalkthroughLoading(true);
-      setWalkthroughError(null);
-      window.codiff
-        .getNarrativeWalkthrough(state.source)
-        .then((result) => {
-          if (getSourceKey(stateRef.current?.source ?? state.source) !== sourceKey) {
-            return;
-          }
-
-          if (result.status === 'ready') {
-            setNarrativeWalkthrough(result.walkthrough);
-            if (sidebarModeRef.current === 'walkthrough') {
-              setSidebarMode('walkthrough');
-            } else {
-              setWalkthroughUnread(true);
-            }
-          } else {
-            setWalkthroughError(result);
-          }
-        })
-        .catch((error: unknown) => {
-          if (getSourceKey(stateRef.current?.source ?? state.source) !== sourceKey) {
-            return;
-          }
-
-          setWalkthroughError({
-            reason: error instanceof Error ? error.message : String(error),
-            status: 'unavailable',
-          });
-        })
-        .finally(() => {
-          if (getSourceKey(stateRef.current?.source ?? state.source) === sourceKey) {
-            setWalkthroughLoading(false);
-          }
-        });
+      loadNarrativeWalkthrough(state.source);
     },
-    [narrativeWalkthrough, state, walkthroughError, walkthroughLoading],
+    [loadNarrativeWalkthrough, narrativeWalkthrough, state, walkthroughError, walkthroughLoading],
   );
 
   const openCommitView = useCallback(() => {
@@ -1798,9 +1887,9 @@ export default function App() {
         title: 'Open Config File',
       }),
       registry.register({
-        execute: reloadWindow,
+        execute: refreshRepository,
         id: 'reload',
-        title: 'Reload Window',
+        title: 'Refresh Changes',
       }),
     ];
     setCommandBarCommands(registry.commands);
@@ -1816,7 +1905,7 @@ export default function App() {
     getReviewCommandTarget,
     openDiffSearch,
     openSelectedFile,
-    reloadWindow,
+    refreshRepository,
     setFileViewedState,
     toggleSidebar,
     toggleViewed,
@@ -2431,7 +2520,7 @@ export default function App() {
         </div>
       ) : null}
       <RepositoryChangeBanner
-        onReload={reloadWindow}
+        onRefresh={refreshRepository}
         visible={localChangesDetected && (pendingSource ?? state.source).type === 'working-tree'}
       />
       <WalkthroughOutdatedBanner
@@ -2546,12 +2635,15 @@ export default function App() {
           />
         ) : showNarrativeWalkthrough && narrativeWalkthrough ? (
           <NarrativeWalkthroughView
+            changedPaths={reloadDeltaPaths}
             files={state.files}
             navigation={narrativeNavigation}
             onActiveReviewTargetChange={updateActiveWalkthroughReviewTarget}
             onCommit={commitWalkthrough}
+            onRegenerateWalkthrough={regenerateWalkthrough}
             onShareWalkthrough={enabledShareWalkthrough}
             onUpdateCommitMessage={updateWalkthroughCommitMessage}
+            regenerateDisabled={walkthroughLoading}
             renderDiffBlocks={renderWalkthroughDiffBlocks}
             shareWalkthroughDisabled={walkthroughSharing}
             showWhitespace={showWhitespace}

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -180,6 +180,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
   onFindInDiffs: vi.fn(() => () => {}),
   onMarkdownDocumentChanged: vi.fn(() => () => {}),
   onPlanCloseRequested: vi.fn(() => () => {}),
+  onRefreshRequest: vi.fn(() => () => {}),
   onRepositoryChanged: vi.fn(() => () => {}),
   onWindowFullScreenChanged: vi.fn(() => () => {}),
   openConfigFile: vi.fn(async () => {}),
@@ -2471,6 +2472,115 @@ test('repository changes show the update banner without refreshing the working t
 
     expect(container.querySelector('.repository-change-banner.visible')).not.toBeNull();
     expect(getRepositoryState).toHaveBeenCalledTimes(1);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('clicking the change banner refreshes the repository in place', async () => {
+  const initialFile = {
+    fingerprint: 'src/app.ts:1',
+    path: 'src/app.ts',
+    sections: [
+      {
+        binary: false,
+        id: 'src/app.ts:unstaged',
+        kind: 'unstaged',
+        patch: 'diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n',
+      },
+    ],
+    status: 'modified',
+  } satisfies ChangedFile;
+  const addedFile = {
+    fingerprint: 'src/added.ts:1',
+    path: 'src/added.ts',
+    sections: [
+      {
+        binary: false,
+        id: 'src/added.ts:unstaged',
+        kind: 'unstaged',
+        patch: 'diff --git a/src/added.ts b/src/added.ts\n@@ -0,0 +1 @@\n+created\n',
+      },
+    ],
+    status: 'added',
+  } satisfies ChangedFile;
+
+  let onRepositoryChanged: ((change: { root: string }) => void) | null = null;
+  let stateRequests = 0;
+  const getRepositoryState = vi.fn<Window['codiff']['getRepositoryState']>(async () => {
+    stateRequests += 1;
+    return stateRequests === 1
+      ? { ...repositoryState, files: [initialFile] }
+      : {
+          ...repositoryState,
+          files: [
+            addedFile,
+            {
+              ...initialFile,
+              fingerprint: 'src/app.ts:2',
+              sections: [
+                {
+                  binary: false,
+                  id: 'src/app.ts:unstaged',
+                  kind: 'unstaged',
+                  patch: 'diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+newer\n',
+                },
+              ],
+            },
+          ],
+        };
+  });
+
+  window.codiff = createCodiffMock({
+    getRepositoryState,
+    onRepositoryChanged: vi.fn((callback) => {
+      onRepositoryChanged = callback;
+      return () => {
+        onRepositoryChanged = null;
+      };
+    }),
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.loading')).toBeNull();
+      expect(onRepositoryChanged).not.toBeNull();
+    });
+    expect(container.textContent).not.toContain('added.ts');
+
+    await act(async () => {
+      onRepositoryChanged?.({ root: '/repo' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const refreshButton = container.querySelector<HTMLButtonElement>('.repository-change-reload');
+    expect(refreshButton).not.toBeNull();
+    await act(async () => {
+      refreshButton?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // New file appears without a window reload, and the banner clears.
+    expect(getRepositoryState).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain('added.ts');
+    expect(container.querySelector('.repository-change-banner.visible')).toBeNull();
+
+    // The changed file must not appear twice (old + new version).
+    const appOccurrences = container.textContent?.split('app.ts').length ?? 1;
+    expect(appOccurrences - 1).toBeLessThanOrEqual(2);
+    expect(container.textContent).not.toContain('-old\n+new\n');
   } finally {
     if (root) {
       await act(async () => root?.unmount());

--- a/core/__tests__/reload-selection.test.ts
+++ b/core/__tests__/reload-selection.test.ts
@@ -5,8 +5,10 @@
 import { beforeEach, expect, test } from 'vite-plus/test';
 import {
   consumeReloadSelection,
+  getChangedPaths,
   getReloadDeltaPaths,
   getReloadHistorySource,
+  getReloadMainMode,
   getReloadSelectionPath,
   writeReloadSelection,
 } from '../lib/reload-selection.ts';
@@ -88,6 +90,22 @@ test('reload selection preserves history source for the current source', () => {
   ).toBeNull();
 });
 
+test('reload selection preserves the commit view for the current source', () => {
+  const changedFile = file('src/app.ts');
+  const currentState = state([changedFile]);
+
+  writeReloadSelection(currentState, changedFile.path, null, 'commit');
+
+  const selection = consumeReloadSelection();
+  expect(getReloadMainMode(selection, currentState)).toBe('commit');
+  expect(
+    getReloadMainMode(selection, {
+      ...currentState,
+      source: { ref: 'abc1234', type: 'commit' },
+    }),
+  ).toBeNull();
+});
+
 test('reload delta paths include only current files changed since reload', () => {
   const unchangedFile = file('src/unchanged.ts', 'same');
   const changedFile = file('src/changed.ts', 'before');
@@ -103,6 +121,27 @@ test('reload delta paths include only current files changed since reload', () =>
       state([unchangedFile, file('src/changed.ts', 'after'), file('src/new.ts', 'new', 'added')]),
     ),
   ).toEqual(new Set(['src/changed.ts', 'src/new.ts']));
+});
+
+test('changed paths cover added, modified, and status-changed files', () => {
+  const unchangedFile = file('src/unchanged.ts', 'same');
+  const previous = [
+    unchangedFile,
+    file('src/changed.ts', 'before'),
+    file('src/status.ts', 'same-status', 'modified'),
+    file('src/removed.ts', 'old'),
+  ];
+  const next = [
+    unchangedFile,
+    file('src/changed.ts', 'after'),
+    file('src/status.ts', 'same-status', 'added'),
+    file('src/new.ts', 'new', 'added'),
+  ];
+
+  expect(getChangedPaths(previous, next)).toEqual(
+    new Set(['src/changed.ts', 'src/status.ts', 'src/new.ts']),
+  );
+  expect(getChangedPaths(previous, previous)).toEqual(new Set());
 });
 
 test('reload selection is ignored when it belongs to another repository source', () => {

--- a/core/app/components/Panels.tsx
+++ b/core/app/components/Panels.tsx
@@ -18,7 +18,6 @@ import {
 import { matchesShortcut } from '../../config/keymap.ts';
 import type { CodiffKeymap } from '../../config/types.ts';
 import type { RepositoryLoadError, ReviewComment } from '../../lib/app-types.ts';
-import { getReloadShortcutLabel } from '../../lib/keyboard.ts';
 import { buildReviewCommentsMarkdown } from '../../lib/review-comments.ts';
 import type {
   ChangedFile,
@@ -45,21 +44,26 @@ export function ReviewSourceLoading() {
 }
 
 export function RepositoryChangeBanner({
-  onReload,
+  onRefresh,
   visible,
 }: {
-  onReload: () => void;
+  onRefresh: () => void;
   visible: boolean;
 }) {
   const [dismissed, setDismissed] = useState(false);
+  // Re-arm the dismiss latch once the current change is refreshed away, so the
+  // banner comes back for the next change instead of staying dismissed forever.
+  if (!visible && dismissed) {
+    setDismissed(false);
+  }
   const isVisible = visible && !dismissed;
 
   return (
     <div aria-live="polite" className={`repository-change-banner${isVisible ? ' visible' : ''}`}>
       <span className="repository-change-banner-content">
         <span>Local changes detected,</span>
-        <button className="repository-change-reload" onClick={onReload} type="button">
-          {getReloadShortcutLabel()} to reload.
+        <button className="repository-change-reload" onClick={onRefresh} type="button">
+          refresh to see them.
         </button>
       </span>
       <button

--- a/core/app/components/Sidebar.tsx
+++ b/core/app/components/Sidebar.tsx
@@ -351,6 +351,7 @@ export function Sidebar({
         />
       ) : mode === 'walkthrough' && narrativeWalkthrough ? (
         <NarrativeSidebar
+          changedPaths={reloadDeltaPaths}
           files={commitFiles}
           navigation={narrativeNavigation}
           onShareWalkthrough={onShareWalkthrough}

--- a/core/app/components/walkthrough/NarrativeSidebar.tsx
+++ b/core/app/components/walkthrough/NarrativeSidebar.tsx
@@ -10,7 +10,7 @@ import {
   type WalkthroughStopView,
 } from '../../../lib/narrative-walkthrough.ts';
 import type { ChangedFile, NarrativeWalkthrough } from '../../../types.ts';
-import { Check, GitBranch, Path, ShareNetwork } from './icons.tsx';
+import { ArrowsClockwise, Check, GitBranch, Path, ShareNetwork } from './icons.tsx';
 import { ChapterIcon } from './parts.tsx';
 import type { NarrativeNavigation } from './useNarrativeNavigation.ts';
 
@@ -88,11 +88,13 @@ function TocStop({
 }
 
 function SupportingFilesStop({
+  changedPaths,
   files,
   navigation,
   showWhitespace,
   walkthroughView,
 }: {
+  changedPaths?: ReadonlySet<string>;
   files: ReadonlyArray<ChangedFile>;
   navigation: NarrativeNavigation;
   showWhitespace: boolean;
@@ -102,7 +104,7 @@ function SupportingFilesStop({
     files,
     walkthroughView,
     showWhitespace,
-  );
+  ).filter((file) => !changedPaths?.has(file.path));
   if (walkthroughView.support.length === 0 && uncoveredFiles.length === 0) {
     return null;
   }
@@ -147,8 +149,58 @@ function SupportingFilesStop({
   );
 }
 
+function ChangedFilesStop({
+  changedPaths,
+  files,
+  navigation,
+  showWhitespace,
+  walkthroughView,
+}: {
+  changedPaths?: ReadonlySet<string>;
+  files: ReadonlyArray<ChangedFile>;
+  navigation: NarrativeNavigation;
+  showWhitespace: boolean;
+  walkthroughView: WalkthroughView;
+}) {
+  const changedFiles = getUncoveredWalkthroughFileLineItems(
+    files,
+    walkthroughView,
+    showWhitespace,
+  ).filter((file) => changedPaths?.has(file.path));
+  if (changedFiles.length === 0) {
+    return null;
+  }
+  const fileRows = formatWalkthroughFileLineRows(changedFiles);
+  return (
+    <div className="wt-toc-chapter">
+      <div className="wt-toc-chapter-head">
+        <span className="wt-toc-chapter-icon">
+          <ArrowsClockwise size={15} />
+        </span>
+        <span className="wt-toc-chapter-title">Changed</span>
+      </div>
+      <div className="wt-toc-stops">
+        <button
+          className="wt-toc-stop"
+          onClick={navigation.openSupport}
+          title="Changed after the walkthrough was generated"
+          type="button"
+        >
+          <span className="wt-toc-rail">
+            <span className="wt-toc-node" />
+          </span>
+          <span className="wt-toc-main">
+            <TocFileRows files={fileRows} />
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function NarrativeSidebar({
   allowCommit = true,
+  changedPaths,
   files,
   navigation,
   onShareWalkthrough,
@@ -157,6 +209,7 @@ export function NarrativeSidebar({
   walkthrough,
 }: {
   allowCommit?: boolean;
+  changedPaths?: ReadonlySet<string>;
   files: ReadonlyArray<ChangedFile>;
   navigation: NarrativeNavigation;
   onShareWalkthrough?: () => void;
@@ -210,6 +263,14 @@ export function NarrativeSidebar({
           </div>
         ))}
         <SupportingFilesStop
+          changedPaths={changedPaths}
+          files={files}
+          navigation={navigation}
+          showWhitespace={showWhitespace}
+          walkthroughView={walkthroughView}
+        />
+        <ChangedFilesStop
+          changedPaths={changedPaths}
           files={files}
           navigation={navigation}
           showWhitespace={showWhitespace}

--- a/core/app/components/walkthrough/NarrativeWalkthroughView.tsx
+++ b/core/app/components/walkthrough/NarrativeWalkthroughView.tsx
@@ -21,6 +21,7 @@ import { CommitView, type CommitHandler, type CommitMessageHandler } from './Com
 import {
   ArrowLeft,
   ArrowRight,
+  ArrowsClockwise,
   CaretLeft,
   CaretRight,
   Check,
@@ -139,6 +140,36 @@ function SupportHeader({ current }: { current: boolean }) {
   );
 }
 
+function ChangedHeader({
+  current,
+  onRegenerate,
+  regenerateDisabled = false,
+}: {
+  current: boolean;
+  onRegenerate?: () => void;
+  regenerateDisabled?: boolean;
+}) {
+  return (
+    <div className={`wt-stop-block wt-stop-block-header${current ? ' current' : ''}`}>
+      <div className="wt-stage-title-row">
+        <h2 className="wt-stage-title">Changed</h2>
+        {onRegenerate ? (
+          <button
+            className="wt-regenerate"
+            disabled={regenerateDisabled}
+            onClick={onRegenerate}
+            type="button"
+          >
+            <ArrowsClockwise size={13} weight="bold" />
+            {regenerateDisabled ? 'Regenerating…' : 'Regenerate walkthrough'}
+          </button>
+        ) : null}
+      </div>
+      <Narration prose="These changes arrived after the walkthrough was generated and are not part of its narrative yet." />
+    </div>
+  );
+}
+
 const createWalkthroughBlocks = (
   files: ReadonlyArray<ChangedFile>,
   walkthroughView: WalkthroughView,
@@ -201,6 +232,9 @@ const createSupportBlocks = (
   selected: boolean,
   walkthroughView: WalkthroughView,
   showWhitespace: boolean,
+  changedPaths?: ReadonlySet<string>,
+  onRegenerateWalkthrough?: () => void,
+  regenerateDisabled?: boolean,
 ): ReadonlyArray<ReviewDiffBlock> => {
   const blocks: Array<ReviewDiffBlock> = [];
   for (const group of walkthroughView.supportByReason) {
@@ -221,7 +255,14 @@ const createSupportBlocks = (
     }
   }
 
-  for (const file of getUncoveredWalkthroughFiles(files, walkthroughView, showWhitespace)) {
+  const uncoveredFiles = getUncoveredWalkthroughFiles(files, walkthroughView, showWhitespace);
+  // Changes that arrived after the walkthrough was generated (e.g. via an
+  // in-place refresh) get their own "Changed" section; other uncovered hunks
+  // stay under "Support" as before.
+  const changedFiles = uncoveredFiles.filter((file) => changedPaths?.has(file.path));
+  const uncoveredSupportFiles = uncoveredFiles.filter((file) => !changedPaths?.has(file.path));
+
+  for (const file of uncoveredSupportFiles) {
     const blockId = `walkthrough:uncovered:${file.path}`;
     const isFirstBlock = blocks.length === 0;
     blocks.push({
@@ -237,6 +278,29 @@ const createSupportBlocks = (
       },
     });
   }
+
+  changedFiles.forEach((file, fileIndex) => {
+    const blockId = `walkthrough:changed:${file.path}`;
+    blocks.push({
+      file,
+      header:
+        fileIndex === 0 ? (
+          <ChangedHeader
+            current={selected}
+            onRegenerate={onRegenerateWalkthrough}
+            regenerateDisabled={regenerateDisabled}
+          />
+        ) : null,
+      headerSelected: selected,
+      id: blockId,
+      itemIdPrefix: blockId,
+      note: 'Changed after the walkthrough was generated.',
+      reviewIdentity: {
+        fingerprint: file.fingerprint,
+        key: blockId,
+      },
+    });
+  });
 
   return blocks;
 };
@@ -466,24 +530,30 @@ function Arc({
 
 export function NarrativeWalkthroughView({
   allowCommit = true,
+  changedPaths,
   files,
   navigation,
   onActiveReviewTargetChange,
   onCommit,
+  onRegenerateWalkthrough,
   onShareWalkthrough,
   onUpdateCommitMessage,
+  regenerateDisabled,
   renderDiffBlocks,
   shareWalkthroughDisabled,
   showWhitespace,
   walkthrough,
 }: {
   allowCommit?: boolean;
+  changedPaths?: ReadonlySet<string>;
   files: ReadonlyArray<ChangedFile>;
   navigation: NarrativeNavigation;
   onActiveReviewTargetChange: (target: WalkthroughReviewTarget | null) => void;
   onCommit: CommitHandler;
+  onRegenerateWalkthrough?: () => void;
   onShareWalkthrough?: () => void;
   onUpdateCommitMessage: CommitMessageHandler;
+  regenerateDisabled?: boolean;
   renderDiffBlocks: RenderWalkthroughDiffBlocks;
   shareWalkthroughDisabled?: boolean;
   showWhitespace: boolean;
@@ -501,9 +571,25 @@ export function NarrativeWalkthroughView({
   const supportBlocks = useMemo(
     () =>
       walkthroughView
-        ? createSupportBlocks(files, navigation.mode === 'support', walkthroughView, showWhitespace)
+        ? createSupportBlocks(
+            files,
+            navigation.mode === 'support',
+            walkthroughView,
+            showWhitespace,
+            changedPaths,
+            onRegenerateWalkthrough,
+            regenerateDisabled,
+          )
         : [],
-    [files, navigation.mode, showWhitespace, walkthroughView],
+    [
+      changedPaths,
+      files,
+      navigation.mode,
+      onRegenerateWalkthrough,
+      regenerateDisabled,
+      showWhitespace,
+      walkthroughView,
+    ],
   );
   const supportAvailable = supportBlocks.length > 0;
   const firstSupportBlockId = supportBlocks[0]?.id ?? null;

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -77,6 +77,7 @@ declare global {
         ) => void,
       ) => () => void;
       onPlanCloseRequested: (callback: () => void) => () => void;
+      onRefreshRequest: (callback: () => void) => () => void;
       onRepositoryChanged: (callback: (change: { root: string }) => void) => () => void;
       onWindowFullScreenChanged: (callback: (isFullScreen: boolean) => void) => () => void;
       openConfigFile: () => Promise<void>;

--- a/core/lib/reload-selection.ts
+++ b/core/lib/reload-selection.ts
@@ -9,9 +9,12 @@ type ReloadSelectionFile = {
   status: GitFileStatus;
 };
 
+export type ReloadMainMode = 'commit' | 'review';
+
 type ReloadSelection = {
   files: ReadonlyArray<ReloadSelectionFile>;
   historySource?: ReviewSource | null;
+  mainMode?: ReloadMainMode;
   root: string;
   selectedPath: string | null;
   source: ReviewSource;
@@ -92,6 +95,7 @@ const isReloadSelection = (value: unknown): value is ReloadSelection =>
   Array.isArray(value.files) &&
   value.files.every(isReloadSelectionFile) &&
   (value.historySource == null || isReviewSource(value.historySource)) &&
+  (value.mainMode == null || value.mainMode === 'commit' || value.mainMode === 'review') &&
   typeof value.root === 'string' &&
   (value.selectedPath == null || typeof value.selectedPath === 'string') &&
   isReviewSource(value.source);
@@ -140,6 +144,26 @@ export const getReloadSelectionPath = (
     : null;
 };
 
+export const getChangedPaths = (
+  previousFiles: ReadonlyArray<ReloadSelectionFile>,
+  nextFiles: ReadonlyArray<ReloadSelectionFile>,
+): ReadonlySet<string> => {
+  const previousByPath = new Map(previousFiles.map((file) => [file.path, file]));
+  const changedPaths = new Set<string>();
+  for (const file of nextFiles) {
+    const previousFile = previousByPath.get(file.path);
+    if (
+      !previousFile ||
+      previousFile.fingerprint !== file.fingerprint ||
+      previousFile.status !== file.status
+    ) {
+      changedPaths.add(file.path);
+    }
+  }
+
+  return changedPaths;
+};
+
 export const getReloadDeltaPaths = (
   selection: ReloadSelection | null,
   state: RepositoryState,
@@ -149,20 +173,7 @@ export const getReloadDeltaPaths = (
     return new Set();
   }
 
-  const previousFiles = new Map(matchedSelection.files.map((file) => [file.path, file]));
-  const deltaPaths = new Set<string>();
-  for (const file of state.files) {
-    const previousFile = previousFiles.get(file.path);
-    if (
-      !previousFile ||
-      previousFile.fingerprint !== file.fingerprint ||
-      previousFile.status !== file.status
-    ) {
-      deltaPaths.add(file.path);
-    }
-  }
-
-  return deltaPaths;
+  return getChangedPaths(matchedSelection.files, state.files);
 };
 
 export const getReloadHistorySource = (
@@ -170,10 +181,16 @@ export const getReloadHistorySource = (
   state: RepositoryState,
 ): ReviewSource | null => getMatchingSelection(selection, state)?.historySource ?? null;
 
+export const getReloadMainMode = (
+  selection: ReloadSelection | null,
+  state: RepositoryState,
+): ReloadMainMode | null => getMatchingSelection(selection, state)?.mainMode ?? null;
+
 export const writeReloadSelection = (
   state: RepositoryState | null,
   selectedPath: string | null,
   historySource: ReviewSource | null = null,
+  mainMode: ReloadMainMode = 'review',
 ) => {
   const storage = getStorage();
   if (!storage || !state) {
@@ -190,6 +207,7 @@ export const writeReloadSelection = (
           status: file.status,
         })),
         historySource,
+        mainMode,
         root: state.root,
         selectedPath,
         source: state.source,

--- a/core/walkthrough.css
+++ b/core/walkthrough.css
@@ -329,6 +329,24 @@
   gap: 12px;
   margin: 0 0 12px;
 }
+.wt-regenerate {
+  align-items: center;
+  background: color-mix(in srgb, var(--tree-selection-focus) 13%, transparent);
+  border: 0;
+  border-radius: 14px;
+  color: var(--tree-selection-focus);
+  corner-shape: squircle;
+  cursor: pointer;
+  display: inline-flex;
+  flex: none;
+  font: 600 12px/1 var(--font-sans);
+  gap: 6px;
+  padding: 7px 12px;
+}
+.wt-regenerate:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
 /* ---- Variation C — hybrid arc timeline ------------------------------------ */
 .wt-hybrid {
   display: flex;

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -895,7 +895,18 @@ const buildApplicationMenu = () =>
           },
           { type: 'separator' },
           { role: 'togglefullscreen' },
-          { role: 'reload' },
+          {
+            // In-place refresh handled by the renderer; the window itself is
+            // only reloaded via Force Reload below.
+            accelerator: 'CommandOrControl+R',
+            click: (_menuItem, browserWindow) => {
+              if (browserWindow instanceof BrowserWindow) {
+                browserWindow.webContents.send('codiff:refreshRequest');
+              }
+            },
+            label: 'Refresh Changes',
+          },
+          { role: 'forceReload' },
           {
             accelerator: 'CommandOrControl+Alt+J',
             click: (_menuItem, browserWindow) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -93,6 +93,11 @@ const codiff = {
     ipcRenderer.on('codiff:repositoryChanged', listener);
     return () => ipcRenderer.removeListener('codiff:repositoryChanged', listener);
   },
+  onRefreshRequest: (callback) => {
+    const listener = () => callback();
+    ipcRenderer.on('codiff:refreshRequest', listener);
+    return () => ipcRenderer.removeListener('codiff:refreshRequest', listener);
+  },
   openConfigFile: () => ipcRenderer.invoke('codiff:openConfigFile'),
   openFile: (path) => ipcRenderer.invoke('codiff:openFile', path),
   setDiffStyle: (value) => ipcRenderer.invoke('codiff:setDiffStyle', value),


### PR DESCRIPTION
Controversial perhaps, but hard reloading the whole app on any change is annoying, it loses all state (which view I'm on, etc). It feels like a hack that worked to some point, but a proper refresh that only changes what's needed is the way to go?

Code is mostly by Fable, I just checked it works.