### PR TITLE
Read result event from newer Claude Code stream-array output

### DIFF
--- a/electron/__tests__/claude.test.ts
+++ b/electron/__tests__/claude.test.ts
@@ -8,6 +8,7 @@ const require = createRequire(import.meta.url);
 const {
   CLAUDE_NOT_FOUND_CODE,
   DEFAULT_CLAUDE_MODEL,
+  extractResultEnvelope,
   getClaudeCommand,
   isClaudeModelAvailabilityError,
   isClaudeNotLoggedInError,
@@ -16,6 +17,7 @@ const {
 } = require('../claude.cjs') as {
   CLAUDE_NOT_FOUND_CODE: string;
   DEFAULT_CLAUDE_MODEL: string;
+  extractResultEnvelope: (parsed: unknown) => any;
   getClaudeCommand: () => string;
   isClaudeModelAvailabilityError: (value: string) => boolean;
   isClaudeNotLoggedInError: (value: string) => boolean;
@@ -29,6 +31,31 @@ const {
     options?: { model?: string; timeoutMs?: number },
   ) => Promise<string>;
 };
+
+test('extracts the terminal result event from stream-array output', () => {
+  // v2.1+ CLIs emit `--output-format json` as an array of stream events.
+  const envelope = extractResultEnvelope([
+    { type: 'system' },
+    { type: 'assistant' },
+    {
+      type: 'result',
+      is_error: false,
+      result: '{"answer":"4"}',
+      structured_output: { answer: '4' },
+    },
+  ]);
+  expect(envelope).toMatchObject({ is_error: false, structured_output: { answer: '4' } });
+});
+
+test('passes a single result object through unchanged', () => {
+  // Older CLIs emit a single result envelope.
+  const single = { is_error: false, result: '{"answer":"4"}' };
+  expect(extractResultEnvelope(single)).toBe(single);
+});
+
+test('falls back to an empty envelope when no result event is present', () => {
+  expect(extractResultEnvelope([{ type: 'system' }, { type: 'assistant' }])).toEqual({});
+});
 
 test('normalizes Claude Code model preferences to known models', () => {
   expect(normalizeClaudeModel('claude-opus-4-8')).toBe('claude-opus-4-8');
@@ -101,6 +128,39 @@ process.stdin.on('end', () => {
     expect(args).toContain('--add-dir');
     expect(args).toContain(directory);
     expect(args).toContain('--no-session-persistence');
+  } finally {
+    if (previousClaudePath == null) {
+      delete process.env.CODIFF_CLAUDE_PATH;
+    } else {
+      process.env.CODIFF_CLAUDE_PATH = previousClaudePath;
+    }
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test('reads the result event from newer stream-array output', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-claude-array-'));
+  const fakeClaudePath = join(directory, 'claude');
+  const previousClaudePath = process.env.CODIFF_CLAUDE_PATH;
+
+  try {
+    await writeFile(
+      fakeClaudePath,
+      `#!/usr/bin/env node
+process.stdin.resume();
+process.stdin.on('end', () => {
+  process.stdout.write(${JSON.stringify(
+    '[{"type":"system"},{"type":"assistant"},{"type":"result","is_error":false,"result":"{\\"version\\":1}","structured_output":{"version":1}}]',
+  )});
+});
+`,
+    );
+    await chmod(fakeClaudePath, 0o755);
+    process.env.CODIFF_CLAUDE_PATH = fakeClaudePath;
+
+    await expect(
+      runClaude(directory, 'prompt', { type: 'object' }, 'walkthrough.json', 'Timed out.'),
+    ).resolves.toBe('{"version":1}');
   } finally {
     if (previousClaudePath == null) {
       delete process.env.CODIFF_CLAUDE_PATH;

--- a/electron/claude.cjs
+++ b/electron/claude.cjs
@@ -116,6 +116,19 @@ const isClaudeModelAvailabilityError = (value) =>
   );
 
 /**
+ * Extract the terminal result envelope from Claude Code's `--output-format json`
+ * output. Older CLIs emit a single result object; v2.1+ emit an array of stream
+ * events (`system`, `assistant`, …, `result`) whose last `result` event carries
+ * `result` and `structured_output`. Returns the parsed value unchanged when it
+ * is already an object.
+ *
+ * @param {unknown} parsed
+ * @returns {any}
+ */
+const extractResultEnvelope = (parsed) =>
+  Array.isArray(parsed) ? (parsed.findLast((event) => event?.type === 'result') ?? {}) : parsed;
+
+/**
  * @param {unknown} error
  */
 const getClaudeLaunchError = (error) => {
@@ -230,7 +243,7 @@ const runClaude = async (
           /** @type {any} */
           let envelope;
           try {
-            envelope = JSON.parse(stdout);
+            envelope = extractResultEnvelope(JSON.parse(stdout));
           } catch {
             reject(new Error(oneLine(stdout, 'Claude Code did not return JSON.')));
             return;
@@ -280,6 +293,7 @@ module.exports = {
   CLAUDE_NOT_FOUND_MESSAGE,
   CLAUDE_TIMEOUT_MS,
   DEFAULT_CLAUDE_MODEL,
+  extractResultEnvelope,
   FALLBACK_CLAUDE_MODEL,
   getClaudeCommand,
   isClaudeModelAvailabilityError,


### PR DESCRIPTION
## Problem

Codiff's Claude Code integration fails for everyone on Claude Code **v2.1+** (repro'd on `2.1.202`): walkthrough generation and every "Ask" fail with **"Claude Code did not return JSON."**

`runClaude` spawns `claude -p --output-format json …` and then reads `envelope.result` / `envelope.structured_output`. That assumes `--output-format json` returns a single result envelope. Newer CLIs instead return a **JSON array of stream events**:

```jsonc
[
  { "type": "system", ... },
  { "type": "assistant", ... },
  { "type": "result", "is_error": false, "result": "{…}", "structured_output": {…} }
]
```

`JSON.parse(stdout)` still succeeds (an array is valid JSON), so the code silently fell through: `envelope.result` and `envelope.structured_output` were both `undefined`, `runClaude` resolved an empty string, and the caller threw the "did not return JSON" error.

Notably `claude --help` still documents `json` as *"single result"*, so this looks like an upstream CLI regression — this change is defensive and backward-compatible either way.

## Fix

Add `extractResultEnvelope(parsed)`, which collapses an array of stream events to its terminal `result` event (`findLast(type === 'result')`) and returns older single-object output unchanged. Apply it at the parse site in `runClaude`.

- **Old single-object output** → returned as-is (identical behavior).
- **New array output** → the terminal `result` event (with `result` + `structured_output`) is used.
- **Array-with-error** → `is_error: true` on the result event still rejects with the correct message (including the not-logged-in path).
- **Resultless array** → falls back to `{}`, matching prior behavior; genuine process failures still hit the non-zero-exit path before parsing.

## Tests

- Unit tests for `extractResultEnvelope`: array shape, single-object passthrough, and the empty-envelope fallback.
- A headless integration test driving `runClaude` with a fake `claude` that emits the array shape.

`vp check` (format + lint + typecheck) and `vp test` pass.