### PR TITLE
Respect (linguist|gitlab)-generated in .gitattributes

### DIFF
--- a/bin/walkthrough-guide.md
+++ b/bin/walkthrough-guide.md
@@ -39,8 +39,10 @@ choose.
 - **`support[]`** — changed hunks that should stay off the main path. Use it for generated files,
   lockfiles, snapshots, docs-only changes, and repeated mechanical edits unless they are essential
   to review. Codiff adds any omitted live-diff hunks to support. Generated-like files are one
-  synthetic hunk per changed section; never split them, but keep behavior-relevant snapshots or
-  artifacts on the main path.
+  synthetic hunk per changed section; never split them, use `reason: "Generated files"` for
+  generated-only support items so they render together, but keep behavior-relevant snapshots or
+  artifacts on the main path. Codiff also recognizes `linguist-generated` and `gitlab-generated`
+  attributes from `.gitattributes`.
 - **`changeType?` / `commitNote?`** — optional commit composer metadata for committable
   walkthroughs.
 - **`commit?`** — for working-tree walkthroughs, include `title` and `body` when there is enough

--- a/core/App.css
+++ b/core/App.css
@@ -2713,6 +2713,7 @@ html[data-codiff-platform='darwin'] .sidebar {
 
 .codiff-status-badge,
 .codiff-section-badge,
+.codiff-generated-badge,
 .codiff-line-count,
 .codiff-file-comment-button,
 .codiff-load-button,
@@ -2726,11 +2727,17 @@ html[data-codiff-platform='darwin'] .sidebar {
 
 .codiff-status-badge,
 .codiff-section-badge,
+.codiff-generated-badge,
 .codiff-line-count {
   background: rgb(127 127 127 / 0.11);
   color: var(--muted);
   padding: 5px 9px;
   white-space: nowrap;
+}
+
+.codiff-generated-badge {
+  background: color-mix(in srgb, var(--sidebar-ref) 15%, transparent);
+  color: var(--sidebar-ref);
 }
 
 .codiff-line-count {

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -70,6 +70,7 @@ import {
 } from './lib/diff.ts';
 import { compactPath, fuzzyMatches, sortFiles } from './lib/files.ts';
 import { isNativeInputTarget } from './lib/keyboard.ts';
+import { isGeneratedWalkthroughFile } from './lib/narrative-walkthrough-diff.js';
 import { buildCommitModel, buildGenericCommitModel } from './lib/narrative-walkthrough.ts';
 import {
   consumeReloadSelection,
@@ -228,6 +229,7 @@ const getReloadSourceForLaunch = (
 
 export default function App() {
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+  const [expandedGenerated, setExpandedGenerated] = useState<Set<string>>(() => new Set());
   const [activeDiffSearchMatchIndex, setActiveDiffSearchMatchIndex] = useState(0);
   const [diffSearchFocusRequest, setDiffSearchFocusRequest] = useState(0);
   const [diffSearchQuery, setDiffSearchQuery] = useState('');
@@ -301,6 +303,7 @@ export default function App() {
   const stateRef = useRef<RepositoryState | null>(null);
   const activeReviewCommandTargetRef = useRef<ReviewCommandTarget | null>(null);
   const collapsedRef = useRef<Set<string>>(new Set());
+  const expandedGeneratedRef = useRef<Set<string>>(new Set());
   const preferencesRef = useRef<CodiffPreferences>(defaultPreferences);
   const reviewCommentsRef = useRef<ReadonlyArray<ReviewComment>>([]);
   const selectedPathRef = useRef<string | null>(null);
@@ -558,6 +561,13 @@ export default function App() {
         }
         return next;
       });
+      if (nextViewed) {
+        setExpandedGenerated((current) => {
+          const next = new Set(current);
+          next.delete(file.path);
+          return next;
+        });
+      }
       bumpItemVersion(file.path);
     },
     [bumpItemVersion],
@@ -571,6 +581,7 @@ export default function App() {
 
     sourceSessionsRef.current.set(getSourceKey(currentState.source), {
       collapsed: new Set(collapsedRef.current),
+      expandedGenerated: new Set(expandedGeneratedRef.current),
       narrativeWalkthrough: narrativeWalkthroughRef.current,
       reviewComments: reviewCommentsRef.current,
       selectedPath: selectedPathRef.current,
@@ -733,6 +744,7 @@ export default function App() {
       setState(orderedState);
       setLoadError(null);
       setCollapsed(getCollapsedViewedPaths(orderedState.files, nextViewed));
+      setExpandedGenerated(new Set());
       setItemVersionByKey({});
       setFocusCommentId(null);
       setFocusCommentRequest(0);
@@ -1026,6 +1038,7 @@ export default function App() {
           setReviewComments(getReviewCommentsFromState(orderedState));
           setViewed(nextViewed);
           setCollapsed(getCollapsedViewedPaths(orderedState.files, nextViewed));
+          setExpandedGenerated(new Set());
           setLoadError(null);
         })
         .catch((error: unknown) => {
@@ -1096,6 +1109,10 @@ export default function App() {
   useEffect(() => {
     collapsedRef.current = collapsed;
   }, [collapsed]);
+
+  useEffect(() => {
+    expandedGeneratedRef.current = expandedGenerated;
+  }, [expandedGenerated]);
 
   useEffect(() => {
     reviewCommentsRef.current = reviewComments;
@@ -1601,11 +1618,13 @@ export default function App() {
               : (orderedState.files[0]?.path ?? null);
           const nextCollapsed =
             session?.collapsed ?? getCollapsedViewedPaths(orderedState.files, nextViewed);
+          const nextExpandedGenerated = session?.expandedGenerated ?? new Set<string>();
 
           stateGenerationRef.current += 1;
           setState(orderedState);
           setHistorySource(getHistorySource(orderedState.source) ?? historySource);
           setCollapsed(new Set(nextCollapsed));
+          setExpandedGenerated(new Set(nextExpandedGenerated));
           setItemVersionByKey({});
           setReviewComments(session?.reviewComments ?? getReviewCommentsFromState(orderedState));
           setReloadDeltaPaths(new Set());
@@ -1814,6 +1833,13 @@ export default function App() {
       });
 
       setCollapsed((current) => updateReviewIdentityCollapsed(current, reviewIdentity, isViewed));
+      if (!isViewed) {
+        setExpandedGenerated((current) => {
+          const next = new Set(current);
+          next.delete(reviewIdentity.key);
+          return next;
+        });
+      }
       bumpItemVersion(reviewIdentity.key);
     },
     [bumpItemVersion],
@@ -2025,6 +2051,15 @@ export default function App() {
           next.delete(reviewKey);
         } else {
           next.add(reviewKey);
+        }
+        return next;
+      });
+      setExpandedGenerated((current) => {
+        const next = new Set(current);
+        if (isCollapsed && isGeneratedWalkthroughFile(file)) {
+          next.add(reviewKey);
+        } else {
+          next.delete(reviewKey);
         }
         return next;
       });
@@ -2542,6 +2577,7 @@ export default function App() {
     commitMetadata,
     diffLineHeight,
     diffStyle,
+    expandedGenerated,
     focusCommentId,
     focusCommentRequest,
     gitIdentity,

--- a/core/SharedWalkthroughApp.tsx
+++ b/core/SharedWalkthroughApp.tsx
@@ -62,7 +62,7 @@ import {
 } from './lib/diff.ts';
 import { compactPath, fileTreeSort, fuzzyMatches, sortFiles, statusForTree } from './lib/files.ts';
 import { isNativeInputTarget } from './lib/keyboard.ts';
-import { isGeneratedWalkthroughPath } from './lib/narrative-walkthrough-diff.js';
+import { isGeneratedWalkthroughFile } from './lib/narrative-walkthrough-diff.js';
 import {
   getCommentKey,
   getReviewCommentsFromState,
@@ -1051,6 +1051,7 @@ function ReviewSurface({
   );
   const keymap = useMemo(() => createDefaultConfig().keymap, []);
   const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(() => new Set());
+  const [expandedGenerated, setExpandedGenerated] = useState<ReadonlySet<string>>(() => new Set());
   const [fileSearchQuery, setFileSearchQuery] = useState('');
   const [itemVersionByKey, setItemVersionByKey] = useState<Record<string, number>>({});
   const [selectedPath, setSelectedPath] = useState<string | null>(
@@ -1140,9 +1141,7 @@ function ReviewSurface({
       ? selectedPath
       : (visibleFiles[0]?.path ?? null);
   const initialMarkdownPreviewSectionIds = useMemo(() => {
-    const nonGeneratedFiles = snapshot.files.filter(
-      (file) => !isGeneratedWalkthroughPath(file.path),
-    );
+    const nonGeneratedFiles = snapshot.files.filter((file) => !isGeneratedWalkthroughFile(file));
     if (
       nonGeneratedFiles.length === 0 ||
       !nonGeneratedFiles.every((file) => isMarkdownFilePath(file.path))
@@ -1611,13 +1610,22 @@ function ReviewSurface({
   }, []);
 
   const toggleCollapsed = useCallback(
-    (_file: ChangedFile, isCollapsed: boolean, reviewKey: string) => {
+    (file: ChangedFile, isCollapsed: boolean, reviewKey: string) => {
       setCollapsed((current) => {
         const next = new Set(current);
         if (isCollapsed) {
           next.delete(reviewKey);
         } else {
           next.add(reviewKey);
+        }
+        return next;
+      });
+      setExpandedGenerated((current) => {
+        const next = new Set(current);
+        if (isCollapsed && isGeneratedWalkthroughFile(file)) {
+          next.add(reviewKey);
+        } else {
+          next.delete(reviewKey);
         }
         return next;
       });
@@ -1629,6 +1637,13 @@ function ReviewSurface({
     (_file: ChangedFile, isViewed: boolean, reviewIdentity: ReviewIdentity) => {
       setViewed((current) => updateReviewIdentityViewed(current, reviewIdentity, isViewed));
       setCollapsed((current) => updateReviewIdentityCollapsed(current, reviewIdentity, isViewed));
+      if (!isViewed) {
+        setExpandedGenerated((current) => {
+          const next = new Set(current);
+          next.delete(reviewIdentity.key);
+          return next;
+        });
+      }
       bumpItemVersion(reviewIdentity.key);
     },
     [bumpItemVersion],
@@ -1685,6 +1700,7 @@ function ReviewSurface({
     diffLineHeight,
     diffStyle: snapshot.preferences.diffStyle,
     disableWorkerPool: true,
+    expandedGenerated,
     focusCommentId,
     focusCommentRequest,
     gitIdentity,

--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -125,6 +125,53 @@ const createLoadedMarkdownFile = (contents: string, fingerprint: string) => {
   };
 };
 
+test('generated files are collapsed by default and can be explicitly expanded per review', async () => {
+  const file = createChangedFile('src/__generated__/api.ts');
+  const reviewKey = 'walkthrough:generated-api';
+  const blocks: ReadonlyArray<ReviewDiffBlock> = [
+    {
+      file,
+      id: reviewKey,
+      reviewIdentity: {
+        fingerprint: file.fingerprint,
+        key: reviewKey,
+      },
+    },
+  ];
+  const view = await renderReact(<ReviewCodeViewHarness blocks={blocks} files={[]} />);
+
+  try {
+    await waitFor(() => {
+      expect(
+        view.container.querySelector('[aria-label="Expand file"]')?.getAttribute('aria-expanded'),
+      ).toBe('false');
+      expect(view.container.querySelector('.codiff-generated-badge')?.textContent).toBe(
+        'Generated',
+      );
+    });
+
+    await view.rerender(
+      <ReviewCodeViewHarness
+        blocks={blocks}
+        expandedGenerated={new Set([reviewKey])}
+        files={[]}
+        itemVersionByKey={{ [reviewKey]: 1 }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        view.container.querySelector('[aria-label="Collapse file"]')?.getAttribute('aria-expanded'),
+      ).toBe('true');
+      expect(view.container.querySelector('.codiff-generated-badge')?.textContent).toBe(
+        'Generated',
+      );
+    });
+  } finally {
+    await view.cleanup();
+  }
+});
+
 test('switching edited Markdown back to a diff flushes and refreshes it first', async () => {
   const order: Array<string> = [];
   const initialFile = createLoadedMarkdownFile('# Edited\n', 'plan.md:initial');

--- a/core/__tests__/SharedWalkthroughApp.test.tsx
+++ b/core/__tests__/SharedWalkthroughApp.test.tsx
@@ -207,7 +207,10 @@ test('shared walkthroughs switch between walkthrough and tree review modes', asy
 
 test('shared walkthroughs initially preview Markdown when other files are generated', async () => {
   const file = createMarkdownFile();
-  const generatedFile = createChangedFile('src/__generated__/api.ts');
+  const generatedFile = {
+    ...createChangedFile('src/api.ts'),
+    generated: true,
+  };
   const source = { type: 'working-tree' } as const;
   const walkthrough = {
     agent: 'codex',

--- a/core/__tests__/git-state.test.ts
+++ b/core/__tests__/git-state.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -28,6 +28,14 @@ type PullRequestFileContent = {
   fingerprint?: string;
   loadState?: string;
   summary?: unknown;
+};
+
+type GeneratedFilesModule = {
+  readGeneratedAttributePaths: (
+    repoRoot: string,
+    paths: ReadonlyArray<string>,
+    source?: string,
+  ) => Promise<ReadonlySet<string>>;
 };
 
 type GitStateModule = {
@@ -117,6 +125,8 @@ type GitStateModule = {
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
+const { readGeneratedAttributePaths } =
+  require('../../electron/generated-files.cjs') as GeneratedFilesModule;
 const {
   collectResolvedReviewCommentIds,
   createPullRequestHistoryFetchRefspecs,
@@ -177,6 +187,91 @@ const withRepo = async (run: (repo: string) => Promise<void>) => {
     await rm(repo, { force: true, recursive: true });
   }
 };
+
+test('readRepositoryState marks generated files from gitattributes and path heuristics', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(
+      repo,
+      '.gitattributes',
+      '*.gen.yaml gitlab-generated\n*.generated.txt linguist-generated\nignored.txt -linguist-generated\n',
+    );
+    await writeRepoFile(repo, 'service.gen.yaml', 'generated\n');
+    await writeRepoFile(repo, 'schema.generated.txt', 'generated\n');
+    await writeRepoFile(repo, 'ignored.txt', 'source\n');
+    await writeRepoFile(repo, 'pnpm-lock.yaml', 'lockfileVersion: 9\n');
+
+    const state = await readRepositoryState(repo);
+    const generatedByPath = new Map(state.files.map((file) => [file.path, file.generated]));
+
+    expect(generatedByPath.get('service.gen.yaml')).toBe(true);
+    expect(generatedByPath.get('schema.generated.txt')).toBe(true);
+    expect(generatedByPath.get('pnpm-lock.yaml')).toBe(true);
+    expect(generatedByPath.get('ignored.txt')).toBeUndefined();
+  });
+});
+
+test('commit reviews evaluate generated attributes from the reviewed commit', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(repo, '.gitattributes', '*.api.ts linguist-generated\n');
+    await writeRepoFile(repo, 'client.api.ts', 'export const client = 1;\n');
+    await commitAll(repo, 'generated client');
+    const commit = (await git(repo, ['rev-parse', 'HEAD'])).trim();
+
+    await writeRepoFile(repo, '.gitattributes', '*.api.ts -linguist-generated\n');
+    const state = await readRepositoryState(repo, { ref: commit, type: 'commit' });
+
+    expect(state.files.find((file) => file.path === 'client.api.ts')?.generated).toBe(true);
+  });
+});
+
+test('historical generated attributes fall back to a temporary index without --source', async () => {
+  await withRepo(async (repo) => {
+    await writeRepoFile(repo, '.gitattributes', '*.api.ts linguist-generated\n');
+    await writeRepoFile(repo, 'client.api.ts', 'export const client = 1;\n');
+    await commitAll(repo, 'generated client');
+    const commit = (await git(repo, ['rev-parse', 'HEAD'])).trim();
+
+    await writeRepoFile(repo, '.gitattributes', '*.api.ts -linguist-generated\n');
+    const wrapperDirectory = await mkdtemp(join(tmpdir(), 'codiff-old-git-'));
+    const wrapperPath = join(wrapperDirectory, 'git');
+    await writeFile(
+      wrapperPath,
+      `#!/bin/sh
+for argument in "$@"; do
+  if [ "$argument" = "--source" ]; then
+    echo "error: unknown option 'source'" >&2
+    exit 129
+  fi
+done
+PATH="$CODIFF_TEST_ORIGINAL_PATH"
+export PATH
+exec git "$@"
+`,
+    );
+    await chmod(wrapperPath, 0o755);
+
+    const originalPath = process.env.PATH;
+    const originalGitPath = process.env.CODIFF_TEST_ORIGINAL_PATH;
+    process.env.CODIFF_TEST_ORIGINAL_PATH = originalPath ?? '';
+    process.env.PATH = `${wrapperDirectory}:${originalPath ?? ''}`;
+    try {
+      const generatedPaths = await readGeneratedAttributePaths(repo, ['client.api.ts'], commit);
+      expect(generatedPaths).toEqual(new Set(['client.api.ts']));
+    } finally {
+      if (originalPath == null) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+      if (originalGitPath == null) {
+        delete process.env.CODIFF_TEST_ORIGINAL_PATH;
+      } else {
+        process.env.CODIFF_TEST_ORIGINAL_PATH = originalGitPath;
+      }
+      await rm(wrapperDirectory, { force: true, recursive: true });
+    }
+  });
+});
 
 test('parseStatus reads staged rename paths in porcelain v1 -z order', () => {
   expect(parseStatus('R  new.txt\0old.txt\0')).toEqual([

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -80,6 +80,7 @@ import {
 import { getItemVersion } from '../../lib/item-version.ts';
 import { isNativeInputTarget } from '../../lib/keyboard.ts';
 import { sanitizeMarkdownImages } from '../../lib/markdown.tsx';
+import { isGeneratedWalkthroughFile } from '../../lib/narrative-walkthrough-diff.js';
 import {
   getCommentKey,
   getReviewCommentLineLabel,
@@ -115,6 +116,7 @@ import { DiffLineCountBadge } from './Sidebar.tsx';
 import { useCopiedState } from './useCopiedState.ts';
 
 const emptyMarkdownPreviewSectionIds = new Set<string>();
+const emptyExpandedGenerated = new Set<string>();
 const markdownPreviewPlugins = [
   frontmatterPlugin(),
   imagePlugin({
@@ -255,6 +257,11 @@ function CodeViewHeader({
         {sectionCount > 1 ? (
           <span className={`codiff-section-badge ${section.kind}`}>
             {sectionLabel[section.kind]}
+          </span>
+        ) : null}
+        {isGeneratedWalkthroughFile(file) ? (
+          <span className="codiff-generated-badge" title="Generated file">
+            Generated
           </span>
         ) : null}
       </div>
@@ -2368,6 +2375,7 @@ export function ReviewCodeView({
   diffLineHeight = DIFF_LINE_HEIGHT,
   diffStyle,
   disableWorkerPool = false,
+  expandedGenerated = emptyExpandedGenerated,
   files,
   focusCommentId,
   focusCommentRequest,
@@ -2425,6 +2433,7 @@ export function ReviewCodeView({
   diffLineHeight?: number;
   diffStyle: CodiffDiffStyle;
   disableWorkerPool?: boolean;
+  expandedGenerated?: ReadonlySet<string>;
   files: ReadonlyArray<ChangedFile>;
   focusCommentId: string | null;
   focusCommentRequest: number;
@@ -2718,7 +2727,10 @@ export function ReviewCodeView({
       const reviewIdentity = block.reviewIdentity ?? getReviewIdentity(file, reviewIdentityByPath);
       const reviewKey = reviewIdentity.key;
       const isViewed = isReviewIdentityViewed(viewed, reviewIdentity);
-      const isCollapsed = collapsed.has(reviewKey) && !forceExpandedPaths.has(file.path);
+      const isCollapsed =
+        !forceExpandedPaths.has(file.path) &&
+        !expandedGenerated.has(reviewKey) &&
+        (collapsed.has(reviewKey) || isGeneratedWalkthroughFile(file));
       const visibleSections = getVisibleDiffSections(file, showWhitespace);
       const lineCount = getDiffLineCountFromVisibleSections(visibleSections);
       const sections = isCollapsed ? visibleSections.slice(0, 1) : visibleSections;
@@ -2909,6 +2921,7 @@ export function ReviewCodeView({
     commentsBySection,
     diffLineHeight,
     diffStyle,
+    expandedGenerated,
     forceExpandedPaths,
     imagePreviewLayoutPassBySection,
     isReadOnly,

--- a/core/lib/app-types.ts
+++ b/core/lib/app-types.ts
@@ -128,6 +128,7 @@ export type WalkthroughNote = {
 
 export type SourceSession = {
   collapsed: Set<string>;
+  expandedGenerated: Set<string>;
   /** Populated by a generated or pre-authored narrative walkthrough document. */
   narrativeWalkthrough?: NarrativeWalkthrough | null;
   reviewComments: ReadonlyArray<ReviewComment>;

--- a/core/lib/narrative-walkthrough-diff.cjs
+++ b/core/lib/narrative-walkthrough-diff.cjs
@@ -80,6 +80,10 @@ const isGeneratedWalkthroughPath = (path) => {
   );
 };
 
+/** @param {{generated?: boolean; path: string}} file */
+const isGeneratedWalkthroughFile = (file) =>
+  file.generated === true || isGeneratedWalkthroughPath(file.path);
+
 /** @param {string} path */
 const getGeneratedWalkthroughSummary = (path) => {
   const parts = getPathParts(path).map((part) => part.toLowerCase());
@@ -231,7 +235,7 @@ const shouldCreateSyntheticHunk = (file, section) => {
 };
 
 /**
- * @param {{oldPath?: string; path: string; status: string}} file
+ * @param {{generated?: boolean; oldPath?: string; path: string; status: string}} file
  * @param {{binary?: boolean; id: string; kind: string; loadState?: string; patch?: string; summary?: {reason?: string}}} section
  */
 const createSyntheticSectionHunk = (file, section, lineCount = { added: 0, deleted: 0 }) => ({
@@ -247,7 +251,7 @@ const createSyntheticSectionHunk = (file, section, lineCount = { added: 0, delet
   status: file.status,
   summary:
     section.summary?.reason ??
-    (isGeneratedWalkthroughPath(file.path) ? getGeneratedWalkthroughSummary(file.path) : undefined),
+    (isGeneratedWalkthroughFile(file) ? getGeneratedWalkthroughSummary(file.path) : undefined),
 });
 
 /**
@@ -255,12 +259,12 @@ const createSyntheticSectionHunk = (file, section, lineCount = { added: 0, delet
  * Most are textual patch hunks; non-text or metadata-only sections get one
  * synthetic hunk so walkthroughs remain hunk-based for every visible change.
  *
- * @param {{oldPath?: string; path: string; status: string}} file
+ * @param {{generated?: boolean; oldPath?: string; path: string; status: string}} file
  * @param {{binary?: boolean; id: string; kind: string; loadState?: string; patch?: string; summary?: {reason?: string}}} section
  */
 const getSectionWalkthroughHunks = (file, section) => {
   const patchHunks = extractPatchHunks(section.patch || '');
-  if (patchHunks.length > 0 && isGeneratedWalkthroughPath(file.path)) {
+  if (patchHunks.length > 0 && isGeneratedWalkthroughFile(file)) {
     return [createSyntheticSectionHunk(file, section, sumHunkLineCounts(patchHunks))];
   }
 
@@ -363,6 +367,7 @@ module.exports = {
   HUNK_HEADER,
   hunkDisplayEnd,
   hunkDisplayStart,
+  isGeneratedWalkthroughFile,
   isGeneratedWalkthroughPath,
   isSyntheticWalkthroughHunk,
   parseHunkHeader,

--- a/core/lib/narrative-walkthrough-diff.js
+++ b/core/lib/narrative-walkthrough-diff.js
@@ -80,6 +80,10 @@ const isGeneratedWalkthroughPath = (path) => {
   );
 };
 
+/** @param {{generated?: boolean; path: string}} file */
+const isGeneratedWalkthroughFile = (file) =>
+  file.generated === true || isGeneratedWalkthroughPath(file.path);
+
 /** @param {string} path */
 const getGeneratedWalkthroughSummary = (path) => {
   const parts = getPathParts(path).map((part) => part.toLowerCase());
@@ -231,7 +235,7 @@ const shouldCreateSyntheticHunk = (file, section) => {
 };
 
 /**
- * @param {{oldPath?: string; path: string; status: string}} file
+ * @param {{generated?: boolean; oldPath?: string; path: string; status: string}} file
  * @param {{binary?: boolean; id: string; kind: string; loadState?: string; patch?: string; summary?: {reason?: string}}} section
  */
 const createSyntheticSectionHunk = (file, section, lineCount = { added: 0, deleted: 0 }) => ({
@@ -247,7 +251,7 @@ const createSyntheticSectionHunk = (file, section, lineCount = { added: 0, delet
   status: file.status,
   summary:
     section.summary?.reason ??
-    (isGeneratedWalkthroughPath(file.path) ? getGeneratedWalkthroughSummary(file.path) : undefined),
+    (isGeneratedWalkthroughFile(file) ? getGeneratedWalkthroughSummary(file.path) : undefined),
 });
 
 /**
@@ -255,12 +259,12 @@ const createSyntheticSectionHunk = (file, section, lineCount = { added: 0, delet
  * Most are textual patch hunks; non-text or metadata-only sections get one
  * synthetic hunk so walkthroughs remain hunk-based for every visible change.
  *
- * @param {{oldPath?: string; path: string; status: string}} file
+ * @param {{generated?: boolean; oldPath?: string; path: string; status: string}} file
  * @param {{binary?: boolean; id: string; kind: string; loadState?: string; patch?: string; summary?: {reason?: string}}} section
  */
 const getSectionWalkthroughHunks = (file, section) => {
   const patchHunks = extractPatchHunks(section.patch || '');
-  if (patchHunks.length > 0 && isGeneratedWalkthroughPath(file.path)) {
+  if (patchHunks.length > 0 && isGeneratedWalkthroughFile(file)) {
     return [createSyntheticSectionHunk(file, section, sumHunkLineCounts(patchHunks))];
   }
 
@@ -363,6 +367,7 @@ export {
   HUNK_HEADER,
   hunkDisplayEnd,
   hunkDisplayStart,
+  isGeneratedWalkthroughFile,
   isGeneratedWalkthroughPath,
   isSyntheticWalkthroughHunk,
   parseHunkHeader,

--- a/core/types.ts
+++ b/core/types.ts
@@ -31,6 +31,7 @@ export type GitFileStatus = 'added' | 'deleted' | 'modified' | 'renamed' | 'untr
 
 export type ChangedFile = {
   fingerprint: string;
+  generated?: boolean;
   oldPath?: string;
   path: string;
   sections: ReadonlyArray<DiffSection>;

--- a/electron/__tests__/narrative-walkthrough.test.ts
+++ b/electron/__tests__/narrative-walkthrough.test.ts
@@ -828,7 +828,7 @@ test('adds unreferenced live hunks to support so changed code remains visible', 
   const result = normalizeNarrativeWalkthrough(input, files);
 
   expect(result.support.map((item: any) => item.reason)).toEqual([
-    'Other changes',
+    'Generated files',
     'Other changes',
   ]);
   expect(result.support.map((item: any) => item.hunkIds)).toEqual([
@@ -856,7 +856,65 @@ test('adds unreferenced generated files to support as one review unit', () => {
     deleted: 18,
     hunkIds: ['src/__generated__/api.ts:staged:h1'],
     hunks: [{ kind: 'synthetic', path: 'src/__generated__/api.ts' }],
+    reason: 'Generated files',
   });
+});
+
+test('uses generated metadata for files without generated-looking paths', () => {
+  const input = baseInput();
+  input.support = [];
+  const generatedFile = {
+    generated: true,
+    path: 'api/client.ts',
+    sections: [{ id: 'api/client.ts:staged', kind: 'staged', patch: manyHunkPatch }],
+    status: 'modified',
+  };
+
+  const result = normalizeNarrativeWalkthrough(input, [...files, generatedFile]);
+  const generatedSupport = result.support.find(
+    (item: any) => item.hunks[0]?.path === 'api/client.ts',
+  );
+
+  expect(generatedSupport).toMatchObject({
+    hunkIds: ['api/client.ts:staged:h1'],
+    hunks: [{ kind: 'synthetic', path: 'api/client.ts' }],
+    reason: 'Generated files',
+  });
+});
+
+test('groups authored generated support under the generated-files reason', () => {
+  const input = baseInput();
+  input.support = [
+    {
+      hunkIds: ['pnpm-lock.yaml:staged:h1'],
+      id: 'lockfile',
+      reason: 'Dependency updates',
+    },
+  ];
+
+  const result = normalizeNarrativeWalkthrough(input, files);
+
+  expect(result.support.find((item: any) => item.id === 'lockfile')?.reason).toBe(
+    'Generated files',
+  );
+});
+
+test('keeps explicitly selected generated files in the main walkthrough path', () => {
+  const input = baseInput();
+  input.chapters[0].stops.push({
+    hunkIds: ['pnpm-lock.yaml:staged:h1'],
+    id: 'lockfile-stop',
+    importance: 'normal',
+    prose: 'The lockfile records the resolved dependency update.',
+  });
+  input.support = [];
+
+  const result = normalizeNarrativeWalkthrough(input, files);
+
+  expect(result.chapters[0].stops.map((stop: any) => stop.id)).toContain('lockfile-stop');
+  expect(
+    result.support.some((item: any) => item.hunkIds.includes('pnpm-lock.yaml:staged:h1')),
+  ).toBe(false);
 });
 
 test('normalizes ordered cross-file hunk groups under one stop', () => {

--- a/electron/generated-files.cjs
+++ b/electron/generated-files.cjs
@@ -1,0 +1,131 @@
+// @ts-check
+
+const { mkdtemp, rm } = require('node:fs/promises');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { gitBufferWithInput } = require('./git-state/common.cjs');
+const { isGeneratedWalkthroughPath } = require('../core/lib/narrative-walkthrough-diff.cjs');
+
+const GENERATED_ATTRIBUTES = ['linguist-generated', 'gitlab-generated'];
+
+/** @param {string} value */
+const isGeneratedAttributeValue = (value) =>
+  value !== 'unspecified' && value !== 'unset' && value !== 'false';
+
+/** @param {import('../core/types.ts').ReviewSource} source */
+const getGeneratedAttributeSource = (source) =>
+  source.type === 'commit'
+    ? source.ref
+    : source.type === 'range'
+      ? source.head
+      : source.type === 'branch-diff'
+        ? source.headRef
+        : source.type === 'pull-request'
+          ? source.headSha
+          : undefined;
+
+/** @param {Buffer} output */
+const parseGeneratedAttributePaths = (output) => {
+  const fields = output.toString('utf8').split('\0');
+  const generatedPaths = new Set();
+  for (let index = 0; index + 2 < fields.length; index += 3) {
+    const path = fields[index];
+    const value = fields[index + 2];
+    if (path && isGeneratedAttributeValue(value)) {
+      generatedPaths.add(path);
+    }
+  }
+  return generatedPaths;
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {ReadonlyArray<string>} paths
+ * @param {ReadonlyArray<string>} options
+ * @param {NodeJS.ProcessEnv} [env]
+ */
+const checkGeneratedAttributePaths = async (repoRoot, paths, options, env) =>
+  parseGeneratedAttributePaths(
+    await gitBufferWithInput(
+      repoRoot,
+      ['check-attr', ...options, '-z', '--stdin', ...GENERATED_ATTRIBUTES],
+      Buffer.from(`${paths.join('\0')}\0`),
+      { env },
+    ),
+  );
+
+/**
+ * Git before 2.40 cannot use `git check-attr --source`. Populate a temporary,
+ * isolated index from the reviewed tree and ask the older `--cached` mode to
+ * resolve attributes from that index instead.
+ *
+ * @param {string} repoRoot
+ * @param {ReadonlyArray<string>} paths
+ * @param {string} source
+ */
+const readGeneratedAttributePathsFromTree = async (repoRoot, paths, source) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'codiff-generated-files-'));
+  const env = {
+    ...process.env,
+    GIT_INDEX_FILE: join(temporaryDirectory, 'index'),
+  };
+
+  try {
+    await gitBufferWithInput(repoRoot, ['read-tree', source], Buffer.alloc(0), { env });
+    return await checkGeneratedAttributePaths(repoRoot, paths, ['--cached'], env);
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {ReadonlyArray<string>} paths
+ * @param {string | undefined} source
+ */
+const readGeneratedAttributePaths = async (repoRoot, paths, source) => {
+  if (paths.length === 0) {
+    return new Set();
+  }
+
+  try {
+    return await checkGeneratedAttributePaths(repoRoot, paths, source ? ['--source', source] : []);
+  } catch {
+    if (source) {
+      try {
+        // Git before 2.40 rejects `--source`; use its historical-tree fallback.
+        return await readGeneratedAttributePathsFromTree(repoRoot, paths, source);
+      } catch {
+        // Ignore invalid or unavailable historical sources.
+      }
+    }
+    return new Set();
+  }
+};
+
+/** @param {import('../core/types.ts').RepositoryState} state */
+const annotateGeneratedFiles = async (state) => {
+  const generatedAttributePaths = await readGeneratedAttributePaths(
+    state.root,
+    state.files.map((file) => file.path),
+    getGeneratedAttributeSource(state.source),
+  );
+  return {
+    ...state,
+    files: state.files.map((file) =>
+      file.generated ||
+      generatedAttributePaths.has(file.path) ||
+      isGeneratedWalkthroughPath(file.path)
+        ? { ...file, generated: true }
+        : file,
+    ),
+  };
+};
+
+module.exports = {
+  GENERATED_ATTRIBUTES,
+  annotateGeneratedFiles,
+  getGeneratedAttributeSource,
+  isGeneratedAttributeValue,
+  readGeneratedAttributePaths,
+};

--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -50,6 +50,7 @@ const {
   readRepositoryChangeSignature,
   readWorkingTreeState,
 } = require('./git-state/working-tree.cjs');
+const { annotateGeneratedFiles } = require('./generated-files.cjs');
 
 /**
  * @typedef {import('../core/types.ts').DiffSectionContentRequest} DiffSectionContentRequest
@@ -79,7 +80,7 @@ const readRepositoryState = async (launchPath, source = { type: 'working-tree' }
                 showWhitespace: options.showWhitespace,
               });
   const branch = (await gitOrEmpty(state.root, ['symbolic-ref', '--short', 'HEAD'])).trim() || null;
-  return { ...state, branch };
+  return annotateGeneratedFiles({ ...state, branch });
 };
 
 /**

--- a/electron/git-state/common.cjs
+++ b/electron/git-state/common.cjs
@@ -75,11 +75,13 @@ const gitBuffer = async (repoPath, args) => {
  * @param {string} repoPath
  * @param {ReadonlyArray<string>} args
  * @param {string | Buffer} input
+ * @param {{env?: NodeJS.ProcessEnv}} [options]
  * @returns {Promise<Buffer>}
  */
-const gitBufferWithInput = (repoPath, args, input) =>
+const gitBufferWithInput = (repoPath, args, input, options = {}) =>
   new Promise((resolve, reject) => {
     const child = spawn('git', ['-C', repoPath, ...args], {
+      env: options.env,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     /** @type {Array<Buffer>} */
@@ -89,6 +91,11 @@ const gitBufferWithInput = (repoPath, args, input) =>
 
     child.stdout.on('data', (chunk) => stdout.push(chunk));
     child.stderr.on('data', (chunk) => stderr.push(chunk));
+    child.stdin.on('error', (error) => {
+      if (/** @type {NodeJS.ErrnoException} */ (error).code !== 'EPIPE') {
+        reject(error);
+      }
+    });
     child.on('error', reject);
     child.on('close', (code) => {
       if (code === 0) {

--- a/electron/narrative-walkthrough.cjs
+++ b/electron/narrative-walkthrough.cjs
@@ -25,7 +25,7 @@ const {
   getSectionWalkthroughHunks,
   hunkDisplayEnd,
   hunkDisplayStart,
-  isGeneratedWalkthroughPath,
+  isGeneratedWalkthroughFile,
   isSyntheticWalkthroughHunk,
   sumHunkLineCounts,
 } = require('../core/lib/narrative-walkthrough-diff.cjs');
@@ -138,10 +138,14 @@ const defaultSideForStatus = (status) => {
  */
 const indexFiles = (files, hunkIdByAlias = new Map()) => {
   const hunkById = new Map();
+  const generatedHunkIds = new Set();
   for (const file of files) {
     for (const section of file.sections || []) {
       for (const hunk of getSectionWalkthroughHunks(file, section)) {
         hunkById.set(hunk.id, hunk);
+        if (isGeneratedWalkthroughFile(file)) {
+          generatedHunkIds.add(hunk.id);
+        }
       }
     }
   }
@@ -152,7 +156,7 @@ const indexFiles = (files, hunkIdByAlias = new Map()) => {
     }
   }
 
-  return { hunkById };
+  return { generatedHunkIds, hunkById };
 };
 
 const resolveHunks = (hunkIds, index) => {
@@ -371,7 +375,9 @@ const normalizeAuthoredSupport = (input, index, coveredHunkIds, itemIds) => {
       continue;
     }
 
-    group.reason = cleanText(item?.reason, 'Other changes');
+    group.reason = group.hunkIds.every((hunkId) => index.generatedHunkIds.has(hunkId))
+      ? 'Generated files'
+      : cleanText(item?.reason, 'Other changes');
     const note = cleanText(item?.note);
     if (note) {
       group.note = note;
@@ -415,7 +421,9 @@ const addUnreferencedSupport = (support, index, coveredHunkIds, itemIds) => {
         hunkIds: chunk.map((hunk) => hunk.id),
         hunks: chunk.map(normalizeHunk),
         id,
-        reason: 'Other changes',
+        reason: chunk.every((hunk) => index.generatedHunkIds.has(hunk.id))
+          ? 'Generated files'
+          : 'Other changes',
         title: path,
       });
       itemIds.add(id);
@@ -567,7 +575,7 @@ const buildPromptInput = (state) => {
   const input = {
     branch: state.branch,
     files: state.files.map((file) => {
-      const generated = isGeneratedWalkthroughPath(file.path);
+      const generated = isGeneratedWalkthroughFile(file);
       return {
         ...(generated
           ? {
@@ -712,7 +720,7 @@ Grouping contract:
 - Do not group a whole large file into one stop when its hunks implement distinct workflows, state transitions, or submission paths.
 - Put hunkIds in the exact display order you want Codiff to render. Out-of-line and cross-file order is allowed when it improves reviewer comprehension.
 - Do not provide added/deleted counts, status, oldPath, section ids, display labels, path, repo, source, generatedAt, agent, or meta; Codiff computes those.
-- Leave secondary, mechanical, docs-only, generated, styling, fixture, and repeated-pattern hunks out of chapters[]. Codiff automatically places every unreferenced hunk in support.
+- Leave secondary, mechanical, docs-only, generated, styling, fixture, and repeated-pattern hunks out of chapters[]. Codiff automatically places every unreferenced hunk in support. Use reason "Generated files" for generated-only support items so they render together.
 - For working-tree sources, include commit.title and commit.body by default unless there are no commit-worthy files. Put the subject line in commit.title, not as the first line of commit.body.
 `;
 };


### PR DESCRIPTION
This PR adds support for `.gitattributes` files being able to either consider a file as generated, or remove a typically generated file (i.e in folders such as `out`) from being considered as generated. This is complimentary to the existing path-based heuristics.

Both negation (`-linguist-generated`) and a `false` value (`linguist-generated=false`) are supported.

`git check-attr --source=` is used but if the Git version is older than 2.40, when [the `--source` option was introduced](https://github.blog/open-source/git/highlights-from-git-2-40/#:~:text=While%20we%E2%80%99re%20talking%20about%20scripting), it will fall-back to the previous method of generating an index first with `git read-tree`.

Files marked as generated are collapsed by default and given a small `Generated` badge:

<img width="3211" height="390" alt="image" src="https://github.com/user-attachments/assets/4224a9e1-5c81-4ee5-acd5-46cff95de674" />

The walkthrough agent will group these generated files in the final support section but if they are deemed to be behaviourally important, it may still be included in a named section.
