### PR TITLE
Update diffs to latest 1.3.0-beta.9

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -1560,6 +1560,22 @@ html[data-codiff-platform='darwin'] .sidebar {
   font-size: 14px;
 }
 
+/* The PR/commit description card renders in CodeView's non-virtualized header
+   region at the top of the scroll content; the host div inherits the
+   scroller's inline padding, so only vertical spacing is needed here. */
+.code-view [data-diffs-code-view-header] .codiff-code-view-source-description {
+  margin-top: 11px;
+}
+
+/* The title bar sticks to the top of the scroller while the card is in view
+   and unsticks naturally as the card scrolls past (sticky cannot escape the
+   panel; `overflow: clip` does not create a scroll container). */
+.code-view [data-diffs-code-view-header] .codiff-source-description-header {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+}
+
 .codiff-source-description-panel-body {
   background: var(--code-bg);
 }

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -1,3 +1,4 @@
+import type { FileDiffLoadedFiles } from '@pierre/diffs';
 import {
   useCallback,
   useEffect,
@@ -67,6 +68,7 @@ import {
   getItemId,
   isPatchOnlyDiffSection,
   shouldLoadDiffSectionContents,
+  shouldPreloadSectionContentsForSearch,
 } from './lib/diff.ts';
 import { compactPath, fuzzyMatches, sortFiles } from './lib/files.ts';
 import { isNativeInputTarget } from './lib/keyboard.ts';
@@ -437,6 +439,36 @@ export default function App() {
         });
     },
     [bumpItemVersion],
+  );
+
+  // Fetches full file contents for a patch-only section so the CodeView
+  // `loadDiffFiles` option can hydrate the rendered diff in place. Unlike
+  // `loadDiffSection`, this must not touch React state: replacing the section
+  // would reset the hydrated diff object's identity.
+  const loadDiffSectionContents = useCallback(
+    async (file: ChangedFile, section: DiffSection): Promise<FileDiffLoadedFiles> => {
+      const currentState = stateRef.current;
+      if (!currentState || !supportsLazyDiffContent(currentState.source)) {
+        throw new Error(`Cannot load diff contents for '${file.path}'.`);
+      }
+
+      const loadedSection = await window.codiff.getDiffSectionContent({
+        force: true,
+        kind: section.kind,
+        path: file.path,
+        showWhitespace: preferencesRef.current.showWhitespace,
+        source: currentState.source,
+      });
+      if (!loadedSection.newFile) {
+        throw new Error(`No file contents available for '${file.path}'.`);
+      }
+
+      return {
+        newFile: loadedSection.newFile,
+        oldFile: loadedSection.oldFile ?? null,
+      };
+    },
+    [],
   );
 
   const refreshMarkdownFile = useCallback(
@@ -842,7 +874,7 @@ export default function App() {
         fileHasVisibleDiff(file, preferences.showWhitespace),
     );
     const requests = searchableFiles.flatMap((file) =>
-      file.sections.filter(shouldLoadDiffSectionContents).map((section) => ({
+      file.sections.filter(shouldPreloadSectionContentsForSearch).map((section) => ({
         file,
         section,
       })),
@@ -2554,6 +2586,7 @@ export default function App() {
     onDeleteComment: deleteComment,
     onLoadImageContent: window.codiff.getDiffImageContent,
     onLoadSection: loadDiffSection,
+    onLoadSectionContents: loadDiffSectionContents,
     onOpenFile: openFile,
     onRefreshMarkdown: refreshMarkdownFile,
     onSaveCommentEdit: updateComment,

--- a/core/SharedWalkthroughApp.tsx
+++ b/core/SharedWalkthroughApp.tsx
@@ -154,7 +154,6 @@ export type MergeRequestReviewAppProps = {
   >;
   settingsBar?: ReactNode;
   sourceDescriptionFooterAside?: ReactNode;
-  sourceDescriptionFooterAsideKey?: string;
   state: RepositoryState;
   title: string;
   walkthrough: NarrativeWalkthrough | null;
@@ -877,7 +876,6 @@ type ReviewSurfaceProps = {
   settingsBar?: ReactNode;
   snapshot: SharedWalkthroughSnapshot;
   sourceDescriptionFooterAside?: ReactNode;
-  sourceDescriptionFooterAsideKey?: string;
   title?: string;
 };
 
@@ -890,7 +888,6 @@ function ReviewSurface({
   settingsBar,
   snapshot,
   sourceDescriptionFooterAside,
-  sourceDescriptionFooterAsideKey,
   title,
 }: ReviewSurfaceProps) {
   const sharedWalkthrough = useMemo(
@@ -1593,28 +1590,6 @@ function ReviewSurface({
     ) : (
       (sourceDescriptionFooterMain ?? sourceDescriptionFooterAside)
     );
-  const sourceDescriptionFooterKey =
-    interactive && sourceMergeState && !isTerminalMergeState
-      ? [
-          'merge',
-          pullRequestMergeSubmitting ? 'submitting' : 'idle',
-          sourceMergeState.sha,
-          String(sourceMergeState.autoMergeEnabled),
-          String(sourceMergeState.canCancelAutoMerge),
-          String(sourceMergeState.canMerge),
-          String(sourceMergeState.canSetAutoMerge),
-          sourceMergeState.status,
-          sourceMergeState.statusLabel,
-          String(sourceMergeState.options.removeSourceBranch),
-          String(sourceMergeState.options.squash),
-          ...sourceMergeState.checks.map(
-            (check) => `${check.status}:${check.label}:${check.detail ?? ''}:${check.url ?? ''}`,
-          ),
-          sourceDescriptionFooterAsideKey ? `aside:${sourceDescriptionFooterAsideKey}` : '',
-        ].join('|')
-      : sourceDescriptionFooter
-        ? (sourceDescriptionFooterAsideKey ?? 'custom')
-        : '';
   const sourceDescription =
     source.type === 'pull-request' ? (
       <PullRequestSourceDescription
@@ -1648,7 +1623,6 @@ function ReviewSurface({
           showSourceDescription
           sourceDescriptionActions={sourceDescriptionActions}
           sourceDescriptionFooter={sourceDescriptionFooter}
-          sourceDescriptionFooterKey={sourceDescriptionFooterKey}
           walkthroughNotes={emptyWalkthroughNotes}
         />
       </div>
@@ -1872,7 +1846,6 @@ function ReviewSurface({
               selectedPath={visibleSelectedPath}
               sourceDescriptionActions={sourceDescriptionActions}
               sourceDescriptionFooter={sourceDescriptionFooter}
-              sourceDescriptionFooterKey={sourceDescriptionFooterKey}
               walkthroughNotes={emptyWalkthroughNotes}
             />
           )
@@ -1946,7 +1919,6 @@ export function MergeRequestReviewApp({
   preferences,
   settingsBar,
   sourceDescriptionFooterAside,
-  sourceDescriptionFooterAsideKey,
   state,
   title,
   walkthrough,
@@ -2026,7 +1998,6 @@ export function MergeRequestReviewApp({
       settingsBar={settingsBar}
       snapshot={snapshot}
       sourceDescriptionFooterAside={sourceDescriptionFooterAside}
-      sourceDescriptionFooterAsideKey={sourceDescriptionFooterAsideKey}
       title={title}
     />
   );

--- a/core/__tests__/App.test.tsx
+++ b/core/__tests__/App.test.tsx
@@ -181,10 +181,15 @@ test('patch-only diffs are registered for lazy hydration and side-cached content
   expect(second).toBe(first);
   expect(third).toBe(first);
 
-  // A re-parse (here via the whitespace toggle) now produces a full diff from
-  // the cached contents instead of resetting to a partial patch parse.
-  const reparsed = getVisibleDiffSections(file, true)[0].fileDiff;
-  expect(reparsed.isPartial).toBe(false);
+  // Loading evicts the stale partial parse: any re-parse — same or different
+  // whitespace flag — now produces a full diff from the cached contents
+  // instead of the partial patch parse. (Inside CodeView the library hydrates
+  // a clone, so the app-side object must be upgraded on rebuild.)
+  const reparsedSameFlag = getVisibleDiffSections(file, false)[0].fileDiff;
+  expect(reparsedSameFlag.isPartial).toBe(false);
+  expect(reparsedSameFlag).not.toBe(fileDiff);
+  const reparsedFlippedFlag = getVisibleDiffSections(file, true)[0].fileDiff;
+  expect(reparsedFlippedFlag.isPartial).toBe(false);
 });
 
 test('non-loadable and placeholder diffs are not registered for hydration', () => {

--- a/core/__tests__/App.test.tsx
+++ b/core/__tests__/App.test.tsx
@@ -181,15 +181,15 @@ test('patch-only diffs are registered for lazy hydration and side-cached content
   expect(second).toBe(first);
   expect(third).toBe(first);
 
-  // Loading evicts the stale partial parse: any re-parse — same or different
-  // whitespace flag — now produces a full diff from the cached contents
-  // instead of the partial patch parse. (Inside CodeView the library hydrates
-  // a clone, so the app-side object must be upgraded on rebuild.)
-  const reparsedSameFlag = getVisibleDiffSections(file, false)[0].fileDiff;
-  expect(reparsedSameFlag.isPartial).toBe(false);
-  expect(reparsedSameFlag).not.toBe(fileDiff);
+  // CodeView hydrates the cached object in place (as of 1.3.0-beta.9), so a
+  // re-parse under the same cache key keeps returning the same object. A
+  // re-parse under a different key (e.g. the whitespace toggle) starts from a
+  // fresh patch parse and is hydrated from the cached contents instead of
+  // resetting to a partial diff.
+  expect(getVisibleDiffSections(file, false)[0].fileDiff).toBe(fileDiff);
   const reparsedFlippedFlag = getVisibleDiffSections(file, true)[0].fileDiff;
   expect(reparsedFlippedFlag.isPartial).toBe(false);
+  expect(reparsedFlippedFlag).not.toBe(fileDiff);
 });
 
 test('non-loadable and placeholder diffs are not registered for hydration', () => {

--- a/core/__tests__/App.test.tsx
+++ b/core/__tests__/App.test.tsx
@@ -5,10 +5,13 @@ import {
   canRenderImagePreview,
   getDiffLineCount,
   getMarkdownPreviewContents,
+  getSectionForFileDiff,
   getTotalDiffLineCount,
   getVisibleDiffSections,
   fileHasVisibleDiff,
+  loadSectionContents,
   shouldLoadDiffSectionContents,
+  shouldPreloadSectionContentsForSearch,
 } from '../lib/diff.ts';
 import { isDiffSearchShortcut } from '../lib/keyboard.ts';
 import { renderInlineMarkdown, sanitizeMarkdownImages } from '../lib/markdown.tsx';
@@ -70,16 +73,36 @@ test('pure renames are visible without content hunks', () => {
   expect(fileHasVisibleDiff(file, false)).toBe(true);
 });
 
-test('patch-only text sections are loadable for full context expansion', () => {
+test('patch-only text sections hydrate lazily instead of eager loading', () => {
+  const patchOnlySection = {
+    binary: false,
+    id: 'src/app.ts:unstaged',
+    kind: 'unstaged',
+    loadState: 'ready',
+    patch: 'diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n',
+  } as const;
+
+  // Patch-only sections expand via `loadDiffFiles` hydration, not the eager
+  // Load flow, but diff search still preloads their full contents.
+  expect(shouldLoadDiffSectionContents(patchOnlySection)).toBe(false);
+  expect(shouldPreloadSectionContentsForSearch(patchOnlySection)).toBe(true);
+
   expect(
     shouldLoadDiffSectionContents({
-      binary: false,
-      id: 'src/app.ts:unstaged',
-      kind: 'unstaged',
-      loadState: 'ready',
-      patch: 'diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n',
+      ...patchOnlySection,
+      loadState: 'deferred',
     }),
   ).toBe(true);
+
+  expect(
+    shouldPreloadSectionContentsForSearch({
+      ...patchOnlySection,
+      summary: {
+        canLoad: false,
+        reason: 'Codiff could not load full file context.',
+      },
+    }),
+  ).toBe(false);
 
   expect(
     shouldLoadDiffSectionContents({
@@ -112,6 +135,98 @@ test('patch-only text sections are loadable for full context expansion', () => {
       },
     }),
   ).toBe(false);
+});
+
+test('patch-only diffs are registered for lazy hydration and side-cached contents upgrade re-parses', async () => {
+  const section = {
+    binary: false,
+    id: 'src/lazy.ts:unstaged',
+    kind: 'unstaged',
+    loadState: 'ready',
+    patch:
+      'diff --git a/src/lazy.ts b/src/lazy.ts\n--- a/src/lazy.ts\n+++ b/src/lazy.ts\n@@ -2,3 +2,3 @@\n b\n-c\n+C\n d\n',
+  } as const;
+  const file = {
+    fingerprint: 'lazy-hydration',
+    path: 'src/lazy.ts',
+    sections: [section],
+    status: 'modified',
+  } satisfies ChangedFile;
+
+  const { fileDiff } = getVisibleDiffSections(file, false)[0];
+  expect(fileDiff.isPartial).toBe(true);
+  // Stable identity across re-parses: hydration mutates this object in place.
+  expect(getVisibleDiffSections(file, false)[0].fileDiff).toBe(fileDiff);
+
+  const target = getSectionForFileDiff(fileDiff);
+  expect(target?.file).toBe(file);
+  expect(target?.section).toBe(section);
+
+  let loadCount = 0;
+  const load = async () => {
+    loadCount += 1;
+    return {
+      newFile: { contents: 'a\nb\nC\nd\ne\n', name: 'src/lazy.ts' },
+      oldFile: { contents: 'a\nb\nc\nd\ne\n', name: 'src/lazy.ts' },
+    };
+  };
+
+  // Concurrent loads dedupe; later calls resolve from the cache.
+  const [first, second] = await Promise.all([
+    loadSectionContents(file, section, load),
+    loadSectionContents(file, section, load),
+  ]);
+  const third = await loadSectionContents(file, section, load);
+  expect(loadCount).toBe(1);
+  expect(second).toBe(first);
+  expect(third).toBe(first);
+
+  // A re-parse (here via the whitespace toggle) now produces a full diff from
+  // the cached contents instead of resetting to a partial patch parse.
+  const reparsed = getVisibleDiffSections(file, true)[0].fileDiff;
+  expect(reparsed.isPartial).toBe(false);
+});
+
+test('non-loadable and placeholder diffs are not registered for hydration', () => {
+  const nonLoadableFile = {
+    fingerprint: 'non-loadable',
+    path: 'src/locked.ts',
+    sections: [
+      {
+        binary: false,
+        id: 'src/locked.ts:unstaged',
+        kind: 'unstaged',
+        loadState: 'ready',
+        patch:
+          'diff --git a/src/locked.ts b/src/locked.ts\n--- a/src/locked.ts\n+++ b/src/locked.ts\n@@ -1 +1 @@\n-old\n+new\n',
+        summary: {
+          canLoad: false,
+          reason: 'Codiff could not load full file context.',
+        },
+      },
+    ],
+    status: 'modified',
+  } satisfies ChangedFile;
+
+  const binaryFile = {
+    fingerprint: 'binary-placeholder',
+    path: 'assets/logo.bin',
+    sections: [
+      {
+        binary: true,
+        id: 'assets/logo.bin:unstaged',
+        kind: 'unstaged',
+        patch: '',
+      },
+    ],
+    status: 'modified',
+  } satisfies ChangedFile;
+
+  for (const file of [nonLoadableFile, binaryFile]) {
+    const { fileDiff } = getVisibleDiffSections(file, false)[0];
+    expect(fileDiff.isPartial).toBe(true);
+    expect(getSectionForFileDiff(fileDiff)).toBeUndefined();
+  }
 });
 
 test('empty patch-only sections are not visible or countable', () => {

--- a/core/__tests__/MergeRequestReviewApp.test.tsx
+++ b/core/__tests__/MergeRequestReviewApp.test.tsx
@@ -138,7 +138,9 @@ test('merge request reviews expose navigation, actions, and lazy walkthrough gen
     expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
     expect(view.container.querySelector('.codiff-web-source-description')).toBeNull();
     await waitFor(() => {
-      const sourceDescription = view.container.querySelector('.codiff-source-description-item');
+      const sourceDescription = view.container.querySelector(
+        '[data-diffs-code-view-header] .codiff-code-view-source-description',
+      );
       expect(sourceDescription).not.toBeNull();
       expect(sourceDescription?.closest('.code-view')).not.toBeNull();
       expect(sourceDescription?.textContent).toContain('Review in Codiff');
@@ -1115,7 +1117,9 @@ test('merge request walkthrough shows the merge request description before the f
 
     await waitFor(() => {
       const surface = view.container.querySelector('.wt-diff-surface');
-      const descriptionPanel = surface?.querySelector('.codiff-source-description-item');
+      const descriptionPanel = surface?.querySelector(
+        '[data-diffs-code-view-header] .codiff-code-view-source-description',
+      );
       expect(descriptionPanel).not.toBeNull();
       expect(descriptionPanel?.querySelector('.codiff-file-header')).not.toBeNull();
       expect(surface?.textContent?.indexOf('Review in Codiff')).toBeLessThan(

--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -889,15 +889,15 @@ test('read-only markdown previews trigger CodeView layout remeasurement after he
 
   try {
     const markdownItemId = `diff:${markdownSectionId}`;
-    const sourceItemId = 'source-description:github:https://github.com/nkzw-tech/codiff/pull/12';
     const initialMarkdownVersion = getCodeViewItemVersion(markdownItemId);
-    const initialSourceVersion = getCodeViewItemVersion(sourceItemId);
 
     const markdownPreview = app.container.querySelector<HTMLElement>(
       '[aria-label="Preview plan.md"]',
     );
+    // The source description renders in CodeView's header region, where height
+    // changes are observed by the viewer directly instead of item versions.
     const sourceDescription = app.container.querySelector<HTMLElement>(
-      '[aria-label="Preview source description"]',
+      '[data-diffs-code-view-header] [aria-label="Preview source description"]',
     );
 
     expect(markdownPreview).not.toBeNull();
@@ -905,12 +905,10 @@ test('read-only markdown previews trigger CodeView layout remeasurement after he
 
     await act(async () => {
       markdownPreview?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
-      sourceDescription?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
     });
 
     await waitFor(() => {
       expect(getCodeViewItemVersion(markdownItemId)).not.toBe(initialMarkdownVersion);
-      expect(getCodeViewItemVersion(sourceItemId)).not.toBe(initialSourceVersion);
     });
   } finally {
     await app.cleanup();

--- a/core/__tests__/helpers/review-code-view.tsx
+++ b/core/__tests__/helpers/review-code-view.tsx
@@ -43,6 +43,7 @@ vi.mock('@pierre/diffs/react', async () => {
           annotation: { metadata: unknown },
           item: CodeViewItem<unknown>,
         ) => React.ReactNode;
+        renderCodeViewHeader?: () => React.ReactNode;
         renderCustomHeader?: (item: CodeViewItem<unknown>) => React.ReactNode;
       },
       ref: React.ForwardedRef<unknown>,
@@ -109,6 +110,13 @@ vi.mock('@pierre/diffs/react', async () => {
       return React.createElement(
         'div',
         { className: props.className },
+        props.renderCodeViewHeader
+          ? React.createElement(
+              'div',
+              { 'data-diffs-code-view-header': '', key: 'code-view-header' },
+              props.renderCodeViewHeader(),
+            )
+          : null,
         props.items.map((item) =>
           React.createElement(
             'div',

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -13,6 +13,7 @@ import {
   type CodeViewOptions,
   type CodeViewScrollTarget,
   type DiffLineAnnotation,
+  type FileDiffLoadedFiles,
   type FileDiffMetadata,
   type LineAnnotation,
   type SelectedLineRange,
@@ -73,8 +74,10 @@ import {
   getDiffLineCountFromVisibleSections,
   getItemId,
   getMarkdownPreviewContents,
+  getSectionForFileDiff,
   getVisibleDiffSections,
   isMarkdownFilePath,
+  loadSectionContents,
   shouldLoadDiffSectionContents,
 } from '../../lib/diff.ts';
 import { getItemVersion } from '../../lib/item-version.ts';
@@ -211,7 +214,7 @@ function CodeViewHeader({
     walkthroughNote,
   } = meta;
   const canOpenFile = file.status !== 'deleted';
-  const canLoadSection = section.loadState === 'deferred' && shouldLoadDiffSectionContents(section);
+  const canLoadSection = shouldLoadDiffSectionContents(section);
 
   return (
     <div
@@ -2373,6 +2376,7 @@ export function ReviewCodeView({
   onDeleteComment,
   onLoadImageContent,
   onLoadSection,
+  onLoadSectionContents,
   onOpenFile,
   onRefreshMarkdown,
   onResolveThread = noopResolveThread,
@@ -2430,6 +2434,7 @@ export function ReviewCodeView({
   onDeleteComment: (commentId: string) => void;
   onLoadImageContent?: (request: DiffImageContentRequest) => Promise<DiffImageContentResult>;
   onLoadSection: (file: ChangedFile, section: DiffSection) => void;
+  onLoadSectionContents?: (file: ChangedFile, section: DiffSection) => Promise<FileDiffLoadedFiles>;
   onOpenFile?: (file: ChangedFile) => void;
   onRefreshMarkdown?: (file: ChangedFile, section: DiffSection) => Promise<boolean>;
   onResolveThread?: (threadId: string, resolved: boolean) => Promise<void> | void;
@@ -3064,6 +3069,26 @@ export function ReviewCodeView({
     ],
   );
 
+  // Lets the library fetch full file contents when the user expands unchanged
+  // context on a patch-only diff; the partial FileDiffMetadata is hydrated in
+  // place (see `parseSectionDiffWithOptions` for the identity contract).
+  const loadDiffFiles = useMemo(() => {
+    if (!onLoadSectionContents || isReadOnly) {
+      return undefined;
+    }
+
+    return (fileDiff: FileDiffMetadata) => {
+      const target = getSectionForFileDiff(fileDiff);
+      if (!target) {
+        return Promise.reject(
+          new Error(`No loadable diff section registered for '${fileDiff.name}'.`),
+        );
+      }
+
+      return loadSectionContents(target.file, target.section, onLoadSectionContents);
+    };
+  }, [isReadOnly, onLoadSectionContents]);
+
   const codeViewOptions: CodeViewOptions<ReviewAnnotationMetadata> = useMemo(
     () =>
       ({
@@ -3081,6 +3106,7 @@ export function ReviewCodeView({
           paddingBottom: bottomInset,
         },
         lineHoverHighlight: 'both',
+        loadDiffFiles,
         onGutterUtilityClick: (range, context) => {
           if (isReadOnly) {
             return;
@@ -3101,10 +3127,7 @@ export function ReviewCodeView({
             return;
           }
 
-          if (
-            meta.section.loadState === 'deferred' &&
-            shouldLoadDiffSectionContents(meta.section)
-          ) {
+          if (shouldLoadDiffSectionContents(meta.section)) {
             onLoadSection(meta.file, meta.section);
             return;
           }
@@ -3161,8 +3184,7 @@ export function ReviewCodeView({
           );
           node.classList.toggle(
             'codiff-loadable-summary-item',
-            metadata?.section.loadState === 'deferred' &&
-              shouldLoadDiffSectionContents(metadata.section),
+            metadata != null && shouldLoadDiffSectionContents(metadata.section),
           );
           node.classList.toggle(
             'codiff-loading-summary-item',
@@ -3186,6 +3208,7 @@ export function ReviewCodeView({
       diffStyle,
       isReadOnly,
       itemMetadata,
+      loadDiffFiles,
       loadingSectionIds,
       onCreateComment,
       onLoadSection,

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -1816,6 +1816,10 @@ const groupReviewCommentsByThread = (comments: ReadonlyArray<ReviewComment>) => 
 
 const noopResolveThread = () => {};
 
+// The CodeView header host is measured by a ResizeObserver, so no manual
+// layout pass is needed when the description body settles.
+const noopLayoutReady = () => {};
+
 function ReviewCommentThreadGroup({
   agentId,
   agentLabel,
@@ -2398,7 +2402,6 @@ export function ReviewCodeView({
   source,
   sourceDescriptionActions,
   sourceDescriptionFooter,
-  sourceDescriptionFooterKey,
   theme = 'system',
   viewed,
   walkthroughNotes,
@@ -2456,7 +2459,6 @@ export function ReviewCodeView({
   source: ReviewSource;
   sourceDescriptionActions?: ReactNode;
   sourceDescriptionFooter?: ReactNode;
-  sourceDescriptionFooterKey?: string;
   theme?: CodiffPreferences['theme'];
   viewed: Record<string, string>;
   walkthroughNotes: ReadonlyMap<string, WalkthroughNote>;
@@ -2544,7 +2546,6 @@ export function ReviewCodeView({
   const sourceDescriptionAriaLabel = shouldShowCommitMessage
     ? 'Preview commit message'
     : 'Preview source description';
-  const [sourceDescriptionLayoutPass, setSourceDescriptionLayoutPass] = useState(0);
   const [collapsedSourceDescriptionItemId, setCollapsedSourceDescriptionItemId] = useState<
     string | null
   >(null);
@@ -2598,10 +2599,6 @@ export function ReviewCodeView({
     }));
   }, []);
 
-  const markSourceDescriptionLayoutReady = useCallback((_layoutKey: string) => {
-    setSourceDescriptionLayoutPass((current) => current + 1);
-  }, []);
-
   const {
     firstItemByBlockId,
     firstItemByPath,
@@ -2617,58 +2614,6 @@ export function ReviewCodeView({
     const nextItemMetadata = new Map<string, CodeViewItemMetadata>();
     const nextSearchTargetsByBaseItemId = new Map<string, Array<RenderedSearchTarget>>();
     const fontLayoutKey = `line-height:${diffLineHeight}`;
-
-    if (sourceDescriptionItemId) {
-      const sourceDescriptionLayoutKey = `${sourceDescriptionItemId}:${sourceTitle}:${sourceDescription}:${sourceAuthor?.displayName ?? ''}:${sourceAuthor?.title ?? ''}:${sourceAuthor?.avatarUrl ?? ''}:${sourceDescriptionCollapsed ? 'collapsed' : 'open'}:${sourceDescriptionFooterKey ?? ''}`;
-      nextItems.push({
-        annotations: [
-          {
-            lineNumber: 1,
-            metadata: {
-              header: (
-                <>
-                  <SourceDescriptionBody
-                    ariaLabel={sourceDescriptionAriaLabel}
-                    author={sourceAuthor}
-                    canEdit={canEditSourceDescription}
-                    description={sourceDescription}
-                    keymap={keymap}
-                    layoutKey={sourceDescriptionLayoutKey}
-                    onLayoutReady={markSourceDescriptionLayoutReady}
-                    onUpdateDescription={onUpdateSourceDescription}
-                    onUploadDescriptionAsset={onUploadSourceDescriptionAsset}
-                  />
-                  {sourceDescriptionFooter ? (
-                    <div className="codiff-source-description-footer">
-                      {sourceDescriptionFooter}
-                    </div>
-                  ) : null}
-                </>
-              ),
-              type: 'walkthrough-header',
-            },
-          } satisfies LineAnnotation<ReviewAnnotationMetadata>,
-        ].filter(
-          () =>
-            (sourceDescriptionHasContent || canEditSourceDescription) &&
-            !sourceDescriptionCollapsed,
-        ),
-        // The header (rendered via renderCustomHeader) carries the title; the body is the
-        // collapsible content.
-        collapsed: sourceDescriptionCollapsed,
-        file: {
-          cacheKey: sourceDescriptionLayoutKey,
-          contents: ' ',
-          lang: 'text',
-          name: shouldShowCommitMessage ? 'commit-message.md' : 'source-description.md',
-        },
-        id: sourceDescriptionItemId,
-        type: 'file',
-        version: getItemVersion(
-          `${sourceDescriptionLayoutKey}:${fontLayoutKey}:${sourceDescriptionLayoutPass}`,
-        ),
-      });
-    }
 
     for (const block of reviewBlocks) {
       if (block.header) {
@@ -2896,7 +2841,6 @@ export function ReviewCodeView({
     };
   }, [
     collapsed,
-    canEditSourceDescription,
     commentLayoutPassByItem,
     commentsBySection,
     diffLineHeight,
@@ -2905,27 +2849,12 @@ export function ReviewCodeView({
     imagePreviewLayoutPassBySection,
     isReadOnly,
     itemVersionByKey,
-    keymap,
-    markSourceDescriptionLayoutReady,
     markdownPreviewLayoutPassBySection,
     markdownPreviewSections,
     onLoadImageContent,
-    onUpdateSourceDescription,
-    onUploadSourceDescriptionAsset,
     reviewBlocks,
     selectedPath,
     showWhitespace,
-    sourceAuthor,
-    sourceDescriptionAriaLabel,
-    sourceDescription,
-    sourceDescriptionCollapsed,
-    sourceDescriptionFooter,
-    sourceDescriptionFooterKey,
-    sourceDescriptionHasContent,
-    sourceDescriptionItemId,
-    sourceDescriptionLayoutPass,
-    sourceTitle,
-    shouldShowCommitMessage,
     source.type,
     viewed,
     reviewIdentityByPath,
@@ -3167,10 +3096,6 @@ export function ReviewCodeView({
         onPostRender: (node, _instance, _phase, context) => {
           const metadata = itemMetadata.get(context.item.id);
           const isWalkthroughHeaderItem = context.item.id.endsWith(':walkthrough-header');
-          node.classList.toggle(
-            'codiff-source-description-item',
-            context.item.id === sourceDescriptionItemId,
-          );
           node.classList.toggle('codiff-walkthrough-header-item', isWalkthroughHeaderItem);
           node.classList.toggle('codiff-selected-item', metadata?.isSelected === true);
           node.classList.toggle(
@@ -3212,7 +3137,6 @@ export function ReviewCodeView({
       loadingSectionIds,
       onCreateComment,
       onLoadSection,
-      sourceDescriptionItemId,
       theme,
       wordWrap,
     ],
@@ -3446,10 +3370,6 @@ export function ReviewCodeView({
     };
 
     for (const item of items) {
-      if (item.id === sourceDescriptionItemId) {
-        continue;
-      }
-
       const itemTop = viewer.getTopForItem(item.id);
       if (itemTop == null) {
         continue;
@@ -3595,15 +3515,7 @@ export function ReviewCodeView({
       clearCommentLineHighlight();
     }
     handle.scrollTo(target.scrollTarget);
-  }, [
-    clearCommentLineHighlight,
-    diffLineHeight,
-    diffStyle,
-    hunkNavigation,
-    itemMetadata,
-    items,
-    sourceDescriptionItemId,
-  ]);
+  }, [clearCommentLineHighlight, diffLineHeight, diffStyle, hunkNavigation, itemMetadata, items]);
 
   // Enter on a navigated hunk starts a review comment on its selection and moves
   // focus into the new comment input.
@@ -3731,23 +3643,65 @@ export function ReviewCodeView({
     scheduleSearchHighlights();
   }, [resolvedActiveSearchMatch, scheduleSearchHighlights]);
 
+  // Rendered as a non-virtualized element at the top of the CodeView scroll
+  // content. Height changes (async markdown layout, editing) are re-measured
+  // by the viewer automatically.
+  const renderCodeViewHeader = useCallback(
+    () => (
+      <div className="codiff-source-description-panel codiff-code-view-source-description">
+        <SourceDescriptionHeader
+          actions={sourceDescriptionActions}
+          canCollapse={sourceDescription.length > 0 || canEditSourceDescription}
+          canEditTitle={canEditSourceTitle}
+          isCollapsed={sourceDescriptionCollapsed}
+          label={sourceDescriptionLabel}
+          onToggleCollapsed={toggleSourceDescriptionCollapsed}
+          onUpdateTitle={onUpdateSourceTitle}
+          title={sourceTitle}
+        />
+        {!sourceDescriptionCollapsed &&
+        (sourceDescriptionHasContent || canEditSourceDescription) ? (
+          <div className="codiff-source-description-panel-body">
+            <SourceDescriptionBody
+              ariaLabel={sourceDescriptionAriaLabel}
+              author={sourceAuthor}
+              canEdit={canEditSourceDescription}
+              description={sourceDescription}
+              keymap={keymap}
+              layoutKey="code-view-header"
+              onLayoutReady={noopLayoutReady}
+              onUpdateDescription={onUpdateSourceDescription}
+              onUploadDescriptionAsset={onUploadSourceDescriptionAsset}
+            />
+            {sourceDescriptionFooter ? (
+              <div className="codiff-source-description-footer">{sourceDescriptionFooter}</div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    ),
+    [
+      canEditSourceDescription,
+      canEditSourceTitle,
+      keymap,
+      onUpdateSourceDescription,
+      onUpdateSourceTitle,
+      onUploadSourceDescriptionAsset,
+      sourceAuthor,
+      sourceDescription,
+      sourceDescriptionActions,
+      sourceDescriptionAriaLabel,
+      sourceDescriptionCollapsed,
+      sourceDescriptionFooter,
+      sourceDescriptionHasContent,
+      sourceDescriptionLabel,
+      sourceTitle,
+      toggleSourceDescriptionCollapsed,
+    ],
+  );
+
   const renderCustomHeader = useCallback(
     (item: CodeViewItem<ReviewAnnotationMetadata>) => {
-      if (item.id === sourceDescriptionItemId) {
-        return (
-          <SourceDescriptionHeader
-            actions={sourceDescriptionActions}
-            canCollapse={sourceDescription.length > 0 || canEditSourceDescription}
-            canEditTitle={canEditSourceTitle}
-            isCollapsed={sourceDescriptionCollapsed}
-            label={sourceDescriptionLabel}
-            onToggleCollapsed={toggleSourceDescriptionCollapsed}
-            onUpdateTitle={onUpdateSourceTitle}
-            title={sourceTitle}
-          />
-        );
-      }
-
       const meta = itemMetadata.get(item.id);
       return meta ? (
         <CodeViewHeader
@@ -3767,8 +3721,6 @@ export function ReviewCodeView({
     },
     [
       allowViewedToggle,
-      canEditSourceDescription,
-      canEditSourceTitle,
       canCreateFileComments,
       createFileComment,
       itemMetadata,
@@ -3778,14 +3730,6 @@ export function ReviewCodeView({
       onOpenFile,
       onToggleCollapsed,
       onToggleViewed,
-      onUpdateSourceTitle,
-      sourceDescription,
-      sourceDescriptionCollapsed,
-      sourceDescriptionItemId,
-      sourceDescriptionLabel,
-      sourceDescriptionActions,
-      sourceTitle,
-      toggleSourceDescriptionCollapsed,
       toggleMarkdownPreview,
     ],
   );
@@ -3923,6 +3867,7 @@ export function ReviewCodeView({
       options={codeViewOptions}
       ref={codeViewRef}
       renderAnnotation={renderAnnotation}
+      renderCodeViewHeader={sourceDescriptionItemId ? renderCodeViewHeader : undefined}
       renderCustomHeader={renderCustomHeader}
       selectedLines={isReadOnly ? null : selectedLines}
     />
@@ -3944,6 +3889,7 @@ export function ReviewCodeView({
         options={codeViewOptions}
         ref={codeViewRef}
         renderAnnotation={renderAnnotation}
+        renderCodeViewHeader={sourceDescriptionItemId ? renderCodeViewHeader : undefined}
         renderCustomHeader={renderCustomHeader}
         selectedLines={isReadOnly ? null : selectedLines}
       />

--- a/core/lib/code-view-options.ts
+++ b/core/lib/code-view-options.ts
@@ -195,35 +195,6 @@ export const codeViewUnsafeCSS = `
     display: none;
   }
 
-  /* Review descriptions render through CodeView's file layout with no real code. */
-  :host(.codiff-source-description-item) {
-    --diffs-scrollbar-gutter-override: 0px;
-  }
-
-  :host(.codiff-source-description-item) [data-file] [data-code] {
-    overflow: visible;
-    padding-bottom: 0;
-    padding-top: 0;
-    scrollbar-width: none;
-  }
-
-  :host(.codiff-source-description-item) [data-file] [data-code]::-webkit-scrollbar {
-    display: none;
-  }
-
-  :host(.codiff-source-description-item) [data-file] :is([data-line], [data-column-number], [data-gutter-buffer], [data-gutter-gap]) {
-    display: none;
-  }
-
-  :host(.codiff-source-description-item) [data-file] :is([data-code], [data-content]) {
-    display: block;
-  }
-
-  :host(.codiff-source-description-item) [data-file] [data-line-annotation] {
-    background: transparent;
-    grid-column: 1 / -1;
-  }
-
   .review-comment-thread {
     padding: 8px 0 8px 16px;
   }

--- a/core/lib/diff.ts
+++ b/core/lib/diff.ts
@@ -1,4 +1,5 @@
 import {
+  hydratePartialDiff,
   parseDiffFromFile,
   parsePatchFiles,
   type FileDiffLoadedFiles,
@@ -74,6 +75,13 @@ export const loadSectionContents = (
   const promise = load(file, section)
     .then((files) => {
       loadedSectionContents.set(key, files);
+      // Inside CodeView the library hydrates a clone and keeps it internally,
+      // so the partial object cached here never becomes full. Evict it so the
+      // next items rebuild re-parses from the loaded contents; otherwise a
+      // later version bump re-delivers the stale partial and resets the
+      // expanded diff.
+      parsedDiffCache.delete(`${key}:ws`);
+      parsedDiffCache.delete(`${key}:ignore-ws`);
       return files;
     })
     .finally(() => {
@@ -338,36 +346,41 @@ export const parseSectionDiffWithOptions = (
   } else if (section.patch.trim().length === 0) {
     fileDiff = createEmptyFileDiff(file, section);
   } else {
-    const loaded = getLoadedSectionContents(file, section);
-    if (loaded?.oldFile && loaded.newFile) {
-      try {
-        fileDiff = {
-          ...parseDiffFromFile(loaded.oldFile, loaded.newFile, {
-            ignoreWhitespace: !showWhitespace,
-          }),
-          cacheKey,
-        };
-      } catch {
-        fileDiff = createEmptyFileDiff(file, section);
+    const parsedFileDiff = parsePatchFiles(section.patch)[0]?.files[0];
+    if (parsedFileDiff) {
+      const loaded = parsedFileDiff.isPartial ? getLoadedSectionContents(file, section) : undefined;
+      let hydrated: FileDiffMetadata | null = null;
+      if (loaded) {
+        try {
+          // Hydrate the patch parse with the library's own routine so the hunk
+          // geometry matches the clone CodeView hydrated internally after a
+          // `loadDiffFiles` expansion. A geometry mismatch (e.g. via
+          // parseDiffFromFile) breaks the renderer's expansion state when the
+          // rebuilt object replaces the clone.
+          hydrated = hydratePartialDiff('merge', parsedFileDiff, loaded);
+        } catch {
+          hydrated = null;
+        }
       }
-    } else {
-      const parsedFileDiff = parsePatchFiles(section.patch)[0]?.files[0];
-      if (parsedFileDiff) {
+
+      if (hydrated) {
+        fileDiff = hydrated;
+      } else {
         fileDiff = {
           ...parsedFileDiff,
           cacheKey,
         };
-        // `loadDiffFiles` hydration mutates this object in place while the
-        // parse cache key derives from section identity, so the same object
-        // keeps being returned across re-renders — required for hydration to
-        // persist. Binary/summary placeholders are intentionally never
+        // The library hydrates a clone of this object when the user expands
+        // unchanged context; `loadSectionContents` evicts this cache entry
+        // once contents arrive so the next rebuild goes through the hydrated
+        // branch above. Binary/summary placeholders are intentionally never
         // registered; they must not be hydrated.
         if (section.summary?.canLoad !== false) {
           fileDiffSectionLookup.set(fileDiff, { file, section });
         }
-      } else {
-        fileDiff = createBinaryFileDiff(file, section);
       }
+    } else {
+      fileDiff = createBinaryFileDiff(file, section);
     }
   }
 

--- a/core/lib/diff.ts
+++ b/core/lib/diff.ts
@@ -74,14 +74,11 @@ export const loadSectionContents = (
 
   const promise = load(file, section)
     .then((files) => {
+      // CodeView hydrates the cached partial object in place once these
+      // contents reach it, so cache hits keep returning the hydrated diff.
+      // The hydrated re-parse branch in `parseSectionDiffWithOptions` covers
+      // re-parses under a different cache key (e.g. a whitespace toggle).
       loadedSectionContents.set(key, files);
-      // Inside CodeView the library hydrates a clone and keeps it internally,
-      // so the partial object cached here never becomes full. Evict it so the
-      // next items rebuild re-parses from the loaded contents; otherwise a
-      // later version bump re-delivers the stale partial and resets the
-      // expanded diff.
-      parsedDiffCache.delete(`${key}:ws`);
-      parsedDiffCache.delete(`${key}:ignore-ws`);
       return files;
     })
     .finally(() => {
@@ -352,11 +349,11 @@ export const parseSectionDiffWithOptions = (
       let hydrated: FileDiffMetadata | null = null;
       if (loaded) {
         try {
-          // Hydrate the patch parse with the library's own routine so the hunk
-          // geometry matches the clone CodeView hydrated internally after a
-          // `loadDiffFiles` expansion. A geometry mismatch (e.g. via
-          // parseDiffFromFile) breaks the renderer's expansion state when the
-          // rebuilt object replaces the clone.
+          // A fresh parse under a new cache key (e.g. a whitespace toggle)
+          // starts partial again even though contents were already fetched.
+          // Hydrate it with the library's own routine so the hunk geometry
+          // matches what CodeView produced when it hydrated the previous
+          // object in place after a `loadDiffFiles` expansion.
           hydrated = hydratePartialDiff('merge', parsedFileDiff, loaded);
         } catch {
           hydrated = null;
@@ -370,11 +367,11 @@ export const parseSectionDiffWithOptions = (
           ...parsedFileDiff,
           cacheKey,
         };
-        // The library hydrates a clone of this object when the user expands
-        // unchanged context; `loadSectionContents` evicts this cache entry
-        // once contents arrive so the next rebuild goes through the hydrated
-        // branch above. Binary/summary placeholders are intentionally never
-        // registered; they must not be hydrated.
+        // CodeView hydrates this object in place when the user expands
+        // unchanged context, so the cache key must derive from section
+        // identity and keep returning the same object. Binary/summary
+        // placeholders are intentionally never registered; they must not be
+        // hydrated.
         if (section.summary?.canLoad !== false) {
           fileDiffSectionLookup.set(fileDiff, { file, section });
         }

--- a/core/lib/diff.ts
+++ b/core/lib/diff.ts
@@ -1,4 +1,9 @@
-import { parseDiffFromFile, parsePatchFiles, type FileDiffMetadata } from '@pierre/diffs';
+import {
+  parseDiffFromFile,
+  parsePatchFiles,
+  type FileDiffLoadedFiles,
+  type FileDiffMetadata,
+} from '@pierre/diffs';
 import type { ChangedFile, DiffSection } from '../types.ts';
 import type { DiffLineCount } from './app-types.ts';
 
@@ -21,8 +26,62 @@ export const isPatchOnlyDiffSection = (section: DiffSection) =>
   section.newFile == null;
 
 export const shouldLoadDiffSectionContents = (section: DiffSection) =>
-  section.summary?.canLoad !== false &&
-  (section.loadState === 'deferred' || isPatchOnlyDiffSection(section));
+  section.summary?.canLoad !== false && section.loadState === 'deferred';
+
+// Diff search needs full context lines in app state, so it also preloads
+// patch-only sections through the eager (state-replacing) flow.
+export const shouldPreloadSectionContentsForSearch = (section: DiffSection) =>
+  shouldLoadDiffSectionContents(section) ||
+  (section.summary?.canLoad !== false && isPatchOnlyDiffSection(section));
+
+// Full file contents fetched lazily for patch-only sections via the CodeView
+// `loadDiffFiles` option. Kept outside React state so the library's in-place
+// hydration of the rendered diff is not reset by re-renders. Keyed without the
+// whitespace flag so re-parses after a whitespace toggle reuse the contents.
+const getLoadedContentsKey = (file: ChangedFile, section: DiffSection) =>
+  `${file.fingerprint}:${section.id}:${getSectionCacheIdentity(section)}`;
+
+const loadedSectionContents = new Map<string, FileDiffLoadedFiles>();
+const pendingSectionLoads = new Map<string, Promise<FileDiffLoadedFiles>>();
+
+const fileDiffSectionLookup = new WeakMap<
+  FileDiffMetadata,
+  { file: ChangedFile; section: DiffSection }
+>();
+
+export const getSectionForFileDiff = (fileDiff: FileDiffMetadata) =>
+  fileDiffSectionLookup.get(fileDiff);
+
+export const getLoadedSectionContents = (file: ChangedFile, section: DiffSection) =>
+  loadedSectionContents.get(getLoadedContentsKey(file, section));
+
+export const loadSectionContents = (
+  file: ChangedFile,
+  section: DiffSection,
+  load: (file: ChangedFile, section: DiffSection) => Promise<FileDiffLoadedFiles>,
+): Promise<FileDiffLoadedFiles> => {
+  const key = getLoadedContentsKey(file, section);
+  const loaded = loadedSectionContents.get(key);
+  if (loaded) {
+    return Promise.resolve(loaded);
+  }
+
+  const pending = pendingSectionLoads.get(key);
+  if (pending) {
+    return pending;
+  }
+
+  const promise = load(file, section)
+    .then((files) => {
+      loadedSectionContents.set(key, files);
+      return files;
+    })
+    .finally(() => {
+      pendingSectionLoads.delete(key);
+    });
+  pendingSectionLoads.set(key, promise);
+  return promise;
+};
 
 const joinDiffLines = (lines: ReadonlyArray<string>) =>
   lines.some((line) => line.includes('\n')) ? lines.join('') : lines.join('\n');
@@ -73,10 +132,11 @@ export const getMarkdownPreviewContents = (
     return null;
   }
 
-  if (section.newFile) {
+  const newFile = section.newFile ?? getLoadedSectionContents(file, section)?.newFile;
+  if (newFile) {
     return {
       addedLines: getAddedLineNumbers(file, fileDiff),
-      contents: section.newFile.contents,
+      contents: newFile.contents,
     };
   }
 
@@ -278,13 +338,37 @@ export const parseSectionDiffWithOptions = (
   } else if (section.patch.trim().length === 0) {
     fileDiff = createEmptyFileDiff(file, section);
   } else {
-    const parsedFileDiff = parsePatchFiles(section.patch)[0]?.files[0];
-    fileDiff = parsedFileDiff
-      ? {
+    const loaded = getLoadedSectionContents(file, section);
+    if (loaded?.oldFile && loaded.newFile) {
+      try {
+        fileDiff = {
+          ...parseDiffFromFile(loaded.oldFile, loaded.newFile, {
+            ignoreWhitespace: !showWhitespace,
+          }),
+          cacheKey,
+        };
+      } catch {
+        fileDiff = createEmptyFileDiff(file, section);
+      }
+    } else {
+      const parsedFileDiff = parsePatchFiles(section.patch)[0]?.files[0];
+      if (parsedFileDiff) {
+        fileDiff = {
           ...parsedFileDiff,
           cacheKey,
+        };
+        // `loadDiffFiles` hydration mutates this object in place while the
+        // parse cache key derives from section identity, so the same object
+        // keeps being returned across re-renders — required for hydration to
+        // persist. Binary/summary placeholders are intentionally never
+        // registered; they must not be hydrated.
+        if (section.summary?.canLoad !== false) {
+          fileDiffSectionLookup.set(fileDiff, { file, section });
         }
-      : createBinaryFileDiff(file, section);
+      } else {
+        fileDiff = createBinaryFileDiff(file, section);
+      }
+    }
   }
 
   parsedDiffCache.set(cacheKey, fileDiff);

--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
     "@nkzw/mdx-editor": "^0.2.1",
     "@nkzw/use-relative-time": "^1.2.3",
     "@phosphor-icons/react": "^2.1.10",
-    "@pierre/diffs": "1.3.0-beta.8",
+    "@pierre/diffs": "1.3.0-beta.9",
     "@pierre/trees": "1.0.0-beta.5",
     "ghostty-web": "^0.4.0",
     "lucide-react": "^1.23.0"

--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
     "@nkzw/mdx-editor": "^0.2.1",
     "@nkzw/use-relative-time": "^1.2.3",
     "@phosphor-icons/react": "^2.1.10",
-    "@pierre/diffs": "1.3.0-beta.7",
+    "@pierre/diffs": "1.3.0-beta.8",
     "@pierre/trees": "1.0.0-beta.5",
     "ghostty-web": "^0.4.0",
     "lucide-react": "^1.23.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@pierre/diffs':
-        specifier: 1.3.0-beta.8
-        version: 1.3.0-beta.8(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 1.3.0-beta.9
+        version: 1.3.0-beta.9(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@pierre/trees':
         specifier: 1.0.0-beta.5
         version: 1.0.0-beta.5(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)
@@ -1492,8 +1492,8 @@ packages:
       react: '>= 16.8'
       react-dom: '>= 16.8'
 
-  '@pierre/diffs@1.3.0-beta.8':
-    resolution: {integrity: sha512-Z2cRpsyKvE//oxoL074gYsd9VzU822C0QnsHcUZ6s0ftG1MC2tPNrEX9ijCUZickOjgPzw3bxQS8J/Drakhmmg==}
+  '@pierre/diffs@1.3.0-beta.9':
+    resolution: {integrity: sha512-XoSLsyHA9UjNb/5UGQoKN1Bqma+ecHHaaM2T2edYdeJ67iS27qivWNoKq+uWjKhRzZEB4JQQRzlXxKy79UvY9A==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
@@ -7569,7 +7569,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@pierre/diffs@1.3.0-beta.8(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@pierre/diffs@1.3.0-beta.9(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@pierre/theme': 1.1.0
       '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@pierre/diffs':
-        specifier: 1.3.0-beta.7
-        version: 1.3.0-beta.7(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 1.3.0-beta.8
+        version: 1.3.0-beta.8(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@pierre/trees':
         specifier: 1.0.0-beta.5
         version: 1.0.0-beta.5(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)
@@ -1492,8 +1492,8 @@ packages:
       react: '>= 16.8'
       react-dom: '>= 16.8'
 
-  '@pierre/diffs@1.3.0-beta.7':
-    resolution: {integrity: sha512-Lkf9Sr6mdXIzM4q9OxgxlCHyG7+WjPYbFta0DfMbVAd1nYJLMRemi1vP/bIzuMg+xQIookH6drZ+J+eYjxB7ww==}
+  '@pierre/diffs@1.3.0-beta.8':
+    resolution: {integrity: sha512-Z2cRpsyKvE//oxoL074gYsd9VzU822C0QnsHcUZ6s0ftG1MC2tPNrEX9ijCUZickOjgPzw3bxQS8J/Drakhmmg==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
@@ -7569,7 +7569,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@pierre/diffs@1.3.0-beta.7(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@pierre/diffs@1.3.0-beta.8(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@pierre/theme': 1.1.0
       '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)


### PR DESCRIPTION
Ports things over to use thew new custom CodeView header api and also take advantage of the new hydration APIs.

You'll see the history updates to 2 different versions, Fable noticed a bit of an issue that was worth resolving in a secondary update.

Pretty much all this code was vibed, and since i don't have a strong understanding of the internals, unclear if this is the correct way forward on this stuff.

If it sucks, blame Fable 🤣 