### PR TITLE
fix: explain pending GitHub review comment failures

### DIFF
--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -1107,6 +1107,59 @@ test('review comment typing stays local until a comment action commits it', asyn
   }
 });
 
+test('failed pull request comments keep their draft and can be retried', async () => {
+  const file = createChangedFile('src/comment.ts');
+  const comment = {
+    body: 'Keep this comment.',
+    filePath: file.path,
+    id: 'comment-1',
+    lineNumber: 1,
+    remoteSubmit: {
+      error:
+        'You already have a pending GitHub review on this pull request. Submit or discard it on GitHub, then retry. Your comment draft is still here.',
+      status: 'error' as const,
+    },
+    sectionId: 'src/comment.ts:unstaged',
+    side: 'additions' as const,
+  } satisfies ReviewComment;
+  const onSubmitComment = vi.fn();
+  const onUpdateComment = vi.fn();
+  const view = await renderReact(
+    <ReviewCodeViewHarness
+      comments={[comment]}
+      files={[file]}
+      isPullRequest
+      onSubmitComment={onSubmitComment}
+      onUpdateComment={onUpdateComment}
+    />,
+  );
+
+  try {
+    const textarea = view.container.querySelector<HTMLTextAreaElement>('.review-comment-input');
+    expect(textarea?.value).toBe('Keep this comment.');
+    expect(view.container.querySelector('.review-comment-error')?.textContent).toBe(
+      comment.remoteSubmit.error,
+    );
+
+    const commentButton = [...view.container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent === 'Comment',
+    );
+    if (!commentButton) {
+      throw new Error('Expected Comment button.');
+    }
+
+    await act(async () => {
+      commentButton.click();
+    });
+
+    expect(onUpdateComment).not.toHaveBeenCalled();
+    expect(onSubmitComment).toHaveBeenCalledWith(comment.id);
+    expect(textarea?.value).toBe(comment.body);
+  } finally {
+    await view.cleanup();
+  }
+});
+
 test('file comments can be created for GitLab merge requests but not GitHub pull requests', async () => {
   const file = createChangedFile('src/comment.ts');
   const onCreateComment = vi.fn();

--- a/core/__tests__/git-state.test.ts
+++ b/core/__tests__/git-state.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
@@ -90,6 +91,7 @@ type GitStateModule = {
     url: string;
   };
   parseStatus: (raw: string) => Array<StatusEntry>;
+  PENDING_REVIEW_COMMENT_ERROR: string;
   readDiffSectionContent: (
     launchPath: string,
     request: DiffSectionContentRequest,
@@ -120,6 +122,18 @@ type GitStateModule = {
     comments: ReadonlyArray<Record<string, unknown>>,
     resolvedCommentIds: ReadonlySet<number>,
   ) => Array<Record<string, unknown>>;
+  submitPullRequestComment: (
+    launchPath: string,
+    request: {
+      comment: {
+        body: string;
+        filePath: string;
+        lineNumber: number;
+        side: 'additions' | 'deletions';
+      };
+      source: Extract<ReviewSource, { type: 'pull-request' }>;
+    },
+  ) => Promise<Record<string, unknown>>;
   validateRepositoryPath: (path: unknown) => string;
 };
 
@@ -139,6 +153,7 @@ const {
   normalizePullRequestComment,
   parseGitHubPullRequestUrl,
   parseStatus,
+  PENDING_REVIEW_COMMENT_ERROR,
   readDiffSectionContent,
   readRepositoryChangeSignature,
   readRepositoryState,
@@ -146,6 +161,7 @@ const {
   readWorkingTreeState,
   resolvePullRequestContentRefs,
   selectUnresolvedReviewComments,
+  submitPullRequestComment,
   validateRepositoryPath,
 } = require('../../electron/git-state.cjs') as GitStateModule;
 
@@ -177,6 +193,115 @@ const writeRepoFile = async (repo: string, path: string, contents: string | Uint
 const commitAll = async (repo: string, message: string) => {
   await git(repo, ['add', '--all']);
   await git(repo, ['commit', '-m', message]);
+};
+
+const withFakeGitHub = async (
+  mode: 'diagnosis-fails' | 'no-pending-review' | 'pending-review' | 'success',
+  callback: (repo: string, readCalls: () => ReadonlyArray<ReadonlyArray<string>>) => Promise<void>,
+) => {
+  const repo = await createRepo();
+  const fakeBin = await mkdtemp(join(tmpdir(), 'codiff-github-'));
+  const fakeGh = join(fakeBin, 'gh');
+  const callsPath = join(fakeBin, 'calls.jsonl');
+  const originalPath = process.env.PATH;
+  const originalMode = process.env.CODIFF_GITHUB_TEST_MODE;
+  const originalCallsPath = process.env.CODIFF_GITHUB_TEST_CALLS;
+
+  await git(repo, ['remote', 'add', 'origin', 'https://github.com/octo/example.git']);
+  await writeFile(
+    fakeGh,
+    `#!/usr/bin/env node
+const { appendFileSync } = require('node:fs');
+const args = process.argv.slice(2);
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  appendFileSync(process.env.CODIFF_GITHUB_TEST_CALLS, JSON.stringify({ args, input }) + '\\n');
+  const endpoint = args.find((argument) => argument.startsWith('repos/')) || '';
+  if (endpoint.endsWith('/comments')) {
+    if (process.env.CODIFF_GITHUB_TEST_MODE === 'success') {
+      process.stdout.write(JSON.stringify({
+        body: 'Keep this comment.',
+        created_at: '2026-07-10T12:00:00Z',
+        html_url: 'https://github.com/octo/example/pull/118#discussion_r1',
+        id: 1,
+        line: 1,
+        path: 'src/app.ts',
+        side: 'RIGHT',
+        user: { login: 'octocat' },
+      }));
+      return;
+    }
+    process.stderr.write('gh: Validation Failed (HTTP 422)\\n');
+    process.exitCode = 1;
+    return;
+  }
+  if (endpoint.includes('/reviews?')) {
+    if (process.env.CODIFF_GITHUB_TEST_MODE === 'diagnosis-fails') {
+      process.stderr.write('gh: review lookup failed\\n');
+      process.exitCode = 1;
+      return;
+    }
+    process.stdout.write(
+      process.env.CODIFF_GITHUB_TEST_MODE === 'pending-review'
+        ? '[[{"id": 7, "state": "PENDING"}]]'
+        : '[[]]',
+    );
+    return;
+  }
+  process.stdout.write(JSON.stringify({ head: { sha: 'head-sha' } }));
+});
+`,
+  );
+  await chmod(fakeGh, 0o755);
+  process.env.PATH = `${fakeBin}:${originalPath ?? ''}`;
+  process.env.CODIFF_GITHUB_TEST_MODE = mode;
+  process.env.CODIFF_GITHUB_TEST_CALLS = callsPath;
+
+  try {
+    await callback(repo, () =>
+      readFileSync(callsPath, 'utf8')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => (JSON.parse(line) as { args: ReadonlyArray<string> }).args),
+    );
+  } finally {
+    if (originalPath == null) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    if (originalMode == null) {
+      delete process.env.CODIFF_GITHUB_TEST_MODE;
+    } else {
+      process.env.CODIFF_GITHUB_TEST_MODE = originalMode;
+    }
+    if (originalCallsPath == null) {
+      delete process.env.CODIFF_GITHUB_TEST_CALLS;
+    } else {
+      process.env.CODIFF_GITHUB_TEST_CALLS = originalCallsPath;
+    }
+    await Promise.all([
+      rm(repo, { force: true, recursive: true }),
+      rm(fakeBin, { force: true, recursive: true }),
+    ]);
+  }
+};
+
+const pullRequestCommentRequest = {
+  comment: {
+    body: 'Keep this comment.',
+    filePath: 'src/app.ts',
+    lineNumber: 1,
+    side: 'additions' as const,
+  },
+  source: {
+    provider: 'github' as const,
+    type: 'pull-request' as const,
+    url: 'https://github.com/octo/example/pull/118',
+  },
 };
 
 const withRepo = async (run: (repo: string) => Promise<void>) => {
@@ -782,6 +907,48 @@ test('normalizePullRequestComment uses the start side for ranged comments', () =
     side: 'RIGHT',
     start_line: 5,
     start_side: 'LEFT',
+  });
+});
+
+test('pull request comments explain when a pending GitHub review blocks submission', async () => {
+  await withFakeGitHub('pending-review', async (repo, readCalls) => {
+    await expect(submitPullRequestComment(repo, pullRequestCommentRequest)).rejects.toThrow(
+      PENDING_REVIEW_COMMENT_ERROR,
+    );
+
+    expect(
+      readCalls().some((args) =>
+        args.some((argument) => argument.includes('/reviews?per_page=100')),
+      ),
+    ).toBe(true);
+  });
+});
+
+test('pull request comments preserve GitHub validation errors when no pending review is found', async () => {
+  for (const mode of ['diagnosis-fails', 'no-pending-review'] as const) {
+    await withFakeGitHub(mode, async (repo) => {
+      await expect(submitPullRequestComment(repo, pullRequestCommentRequest)).rejects.toThrow(
+        'gh: Validation Failed (HTTP 422)',
+      );
+    });
+  }
+});
+
+test('successful pull request comments skip pending review diagnosis', async () => {
+  await withFakeGitHub('success', async (repo, readCalls) => {
+    await expect(submitPullRequestComment(repo, pullRequestCommentRequest)).resolves.toMatchObject({
+      body: 'Keep this comment.',
+      filePath: 'src/app.ts',
+      id: 'github:1',
+      lineNumber: 1,
+      side: 'additions',
+    });
+
+    expect(
+      readCalls().some((args) =>
+        args.some((argument) => argument.includes('/reviews?per_page=100')),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/electron/git-state/pull-request.cjs
+++ b/electron/git-state/pull-request.cjs
@@ -903,6 +903,25 @@ const normalizePullRequestComment = (comment) => {
   return payload;
 };
 
+const PENDING_REVIEW_COMMENT_ERROR =
+  'You already have a pending GitHub review on this pull request. Submit or discard it on GitHub, then retry. Your comment draft is still here.';
+
+/** @param {unknown} error */
+const isGitHubValidationError = (error) =>
+  error instanceof Error && /(?:validation failed|http 422)/i.test(error.message);
+
+/** @param {string} repoRoot @param {PullRequestReference} pullRequest */
+const hasPendingPullRequestReview = async (repoRoot, pullRequest) => {
+  const pages = JSON.parse(
+    await ghApi(repoRoot, [
+      '--paginate',
+      '--slurp',
+      `repos/${pullRequest.owner}/${pullRequest.repo}/pulls/${pullRequest.number}/reviews?per_page=100`,
+    ]),
+  );
+  return Array.isArray(pages) && pages.flat().some((review) => review?.state === 'PENDING');
+};
+
 /** @param {string} launchPath @param {SubmitPullRequestCommentRequest} request */
 const submitPullRequestComment = async (launchPath, request) => {
   const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
@@ -925,7 +944,17 @@ const submitPullRequestComment = async (launchPath, request) => {
       '-',
     ],
     payload,
-  );
+  ).catch(async (error) => {
+    if (isGitHubValidationError(error)) {
+      const hasPendingReview = await hasPendingPullRequestReview(repoRoot, pullRequest).catch(
+        () => false,
+      );
+      if (hasPendingReview) {
+        throw new Error(PENDING_REVIEW_COMMENT_ERROR);
+      }
+    }
+    throw error;
+  });
   const comment = normalizeGitHubReviewComment(JSON.parse(rawComment));
   if (!comment) {
     throw new Error('GitHub accepted the comment but did not return line metadata.');
@@ -961,12 +990,15 @@ const submitPullRequestReview = async (launchPath, request) => {
 };
 
 module.exports = {
+  PENDING_REVIEW_COMMENT_ERROR,
   collectResolvedReviewCommentIds,
   createPatchFromPullRequestFile,
   createPullRequestHistoryFetchRefspecs,
   createPullRequestSection,
   createPullRequestSource,
   getPullRequestHeadImageSource,
+  hasPendingPullRequestReview,
+  isGitHubValidationError,
   listPullRequestHistory,
   normalizeGitHubCommit,
   normalizeGitHubPullRequestCommit,


### PR DESCRIPTION
## Summary

- detect GitHub's generic validation failure when an existing pending review blocks a standalone inline comment
- replace it with actionable guidance to submit or discard the pending review while keeping the local comment draft retryable
- preserve the original GitHub error when no pending review is found or diagnosis fails, and avoid the extra review lookup on successful submissions

Closes #118.

## Impact

- **Architecture**: The change is isolated to the GitHub pull-request adapter and existing review-comment UI state.
- **Performance / bundle size**: No bundle-size impact; one paginated review lookup is added only after a GitHub validation failure.
- **Risk**: Low. Successful comments and GitLab behavior are unchanged, and regression coverage exercises pending-review, fallback-error, success, and retry paths.
- **User-facing changes**: Reviewers now see a specific recovery path instead of `gh: Validation Failed (HTTP 422)`, and their draft remains available to retry.

## Testing

- `pnpm exec vp check --fix`
- `pnpm exec vp test` — 559 tests passed
- `pnpm exec vp build`
