### PR TITLE
feat: add comment-only pull request reviews

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -3493,6 +3493,10 @@ diffs-container .review-comment-thread {
   color: var(--viewed);
 }
 
+.review-submit-button.comment {
+  color: var(--text);
+}
+
 .review-submit-button.close {
   color: var(--text);
 }
@@ -3542,6 +3546,10 @@ diffs-container .review-comment-thread {
 
 .review-submit-popover-submit.approve {
   color: var(--viewed);
+}
+
+.review-submit-popover-submit.comment {
+  color: var(--text);
 }
 
 .copy-comments-button:hover {

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -2386,9 +2386,12 @@ export default function App() {
       const pendingComments = reviewCommentsRef.current.filter(
         (comment) => !comment.isReadOnly && !comment.threadId && comment.body.trim(),
       );
+      if (event === 'COMMENT' && pendingComments.length === 0 && !body?.trim()) {
+        return;
+      }
       const pendingCommentIds = new Set(pendingComments.map((comment) => comment.id));
       setPullRequestReviewSubmitting(event);
-      void window.codiff
+      return window.codiff
         .submitPullRequestReview({
           ...(body ? { body } : {}),
           comments: pendingComments.map(toPullRequestReviewComment),
@@ -2402,6 +2405,7 @@ export default function App() {
         })
         .catch((error: unknown) => {
           window.alert(error instanceof Error ? error.message : String(error));
+          throw error;
         })
         .finally(() => {
           setPullRequestReviewSubmitting(null);
@@ -2640,8 +2644,15 @@ export default function App() {
     sourceDescriptionActions: isPullRequest ? (
       <PullRequestReviewButtons
         disabled={pullRequestReviewSubmitting != null}
+        hasPendingComments={reviewComments.some(
+          (comment) => !comment.isReadOnly && !comment.threadId && Boolean(comment.body.trim()),
+        )}
         onSubmitReview={submitPullRequestReview}
         reviewStatus={state.source.type === 'pull-request' ? state.source.reviewStatus : undefined}
+        showCommentReview={
+          state.source.type === 'pull-request' &&
+          (state.source.provider === 'github' || state.source.host === 'github.com')
+        }
       />
     ) : undefined,
     theme: preferences.theme,

--- a/core/SharedWalkthroughApp.tsx
+++ b/core/SharedWalkthroughApp.tsx
@@ -1369,13 +1369,16 @@ function ReviewSurface({
       const pendingComments = reviewCommentsRef.current.filter(
         (comment) => !comment.isReadOnly && !comment.threadId && comment.body.trim(),
       );
+      if (event === 'COMMENT' && pendingComments.length === 0 && !body?.trim()) {
+        return;
+      }
       const pendingIds = new Set(pendingComments.map((comment) => comment.id));
       setPullRequestReviewSubmitting(event);
       const formattedComments = pendingComments.map(toPullRequestReviewComment);
       const submission = body
         ? interactive.onSubmitReview(event, formattedComments, body)
         : interactive.onSubmitReview(event, formattedComments);
-      void submission
+      return submission
         .then(() => {
           setLocalReviewComments((current) =>
             current.filter((comment) => !pendingIds.has(comment.id)),
@@ -1383,6 +1386,7 @@ function ReviewSurface({
         })
         .catch((error: unknown) => {
           window.alert(error instanceof Error ? error.message : String(error));
+          throw error;
         })
         .finally(() => setPullRequestReviewSubmitting(null));
     },
@@ -1742,9 +1746,13 @@ function ReviewSurface({
     interactive && source.type === 'pull-request' ? (
       <PullRequestReviewButtons
         disabled={pullRequestReviewSubmitting != null || pullRequestCloseSubmitting}
+        hasPendingComments={localReviewComments.some(
+          (comment) => !comment.isReadOnly && !comment.threadId && Boolean(comment.body.trim()),
+        )}
         onClosePullRequest={closePullRequest}
         onSubmitReview={submitReview}
         reviewStatus={source.reviewStatus}
+        showCommentReview={source.provider === 'github' || source.host === 'github.com'}
       >
         {sourceMergeStatusBadge}
       </PullRequestReviewButtons>

--- a/core/__tests__/PullRequestReviewButtons.test.tsx
+++ b/core/__tests__/PullRequestReviewButtons.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, type KeyboardEventHandler } from 'react';
+import { expect, test, vi } from 'vite-plus/test';
+import { PullRequestReviewButtons } from '../app/components/Panels.tsx';
+import { renderReact, setInputValue, waitFor } from './helpers/react.tsx';
+
+vi.mock('@nkzw/mdx-editor', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react');
+  return {
+    MarkdownEditor: forwardRef(function MockMarkdownEditor(
+      {
+        ariaLabel,
+        onChange,
+        onKeyDown,
+        placeholder,
+        readOnly,
+        value,
+      }: {
+        ariaLabel: string;
+        onChange: (value: string) => void;
+        onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
+        placeholder?: string;
+        readOnly?: boolean;
+        value: string;
+      },
+      ref,
+    ) {
+      useImperativeHandle(ref, () => ({ focus: () => {} }));
+      return (
+        <textarea
+          aria-label={ariaLabel}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          value={value}
+        />
+      );
+    }),
+  };
+});
+
+test('GitHub comment reviews require inline comments or a review body', async () => {
+  const onSubmitReview = vi.fn(async () => {});
+  const view = await renderReact(
+    <PullRequestReviewButtons
+      disabled={false}
+      hasPendingComments={false}
+      onSubmitReview={onSubmitReview}
+      showCommentReview
+    />,
+  );
+
+  try {
+    const submitComments = view.container.querySelector<HTMLButtonElement>(
+      '[aria-label="Submit review comments"]',
+    );
+    const addReviewComment = view.container.querySelector<HTMLButtonElement>(
+      '[aria-label="Add review comment"]',
+    );
+    expect(submitComments?.disabled).toBe(true);
+    expect(addReviewComment?.disabled).toBe(false);
+
+    await act(async () => addReviewComment?.click());
+    const textarea = view.container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Add review comment"]',
+    );
+    expect(textarea?.placeholder).toBe('Add a review comment…');
+    await setInputValue(textarea!, 'Neutral review feedback.');
+
+    const submitBody = view.container.querySelector<HTMLButtonElement>(
+      '.review-submit-popover-submit.comment',
+    );
+    expect(submitBody?.disabled).toBe(false);
+    await act(async () => submitBody?.click());
+    await waitFor(() => {
+      expect(onSubmitReview).toHaveBeenCalledWith('COMMENT', 'Neutral review feedback.');
+      expect(view.container.querySelector('[aria-label="Comment with comment"]')).toBeNull();
+    });
+  } finally {
+    await view.cleanup();
+  }
+});
+
+test('GitHub comment reviews submit pending inline comments without a body', async () => {
+  const onSubmitReview = vi.fn(async () => {});
+  const view = await renderReact(
+    <PullRequestReviewButtons
+      disabled={false}
+      hasPendingComments
+      onSubmitReview={onSubmitReview}
+      showCommentReview
+    />,
+  );
+
+  try {
+    const submitComments = view.container.querySelector<HTMLButtonElement>(
+      '[aria-label="Submit review comments"]',
+    );
+    expect(submitComments?.disabled).toBe(false);
+    await act(async () => submitComments?.click());
+    expect(onSubmitReview).toHaveBeenCalledWith('COMMENT');
+  } finally {
+    await view.cleanup();
+  }
+});
+
+test('GitHub comment reviews preserve the review body after submission fails', async () => {
+  const onSubmitReview = vi.fn(async () => {
+    throw new Error('GitHub rejected the review.');
+  });
+  const view = await renderReact(
+    <PullRequestReviewButtons
+      disabled={false}
+      hasPendingComments={false}
+      onSubmitReview={onSubmitReview}
+      showCommentReview
+    />,
+  );
+
+  try {
+    await act(async () =>
+      view.container.querySelector<HTMLButtonElement>('[aria-label="Add review comment"]')?.click(),
+    );
+    const textarea = view.container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Add review comment"]',
+    );
+    await setInputValue(textarea!, 'Keep this draft.');
+    await act(async () =>
+      view.container
+        .querySelector<HTMLButtonElement>('.review-submit-popover-submit.comment')
+        ?.click(),
+    );
+
+    await waitFor(() => expect(onSubmitReview).toHaveBeenCalledOnce());
+    expect(textarea?.value).toBe('Keep this draft.');
+    expect(view.container.querySelector('[aria-label="Comment with comment"]')).not.toBeNull();
+  } finally {
+    await view.cleanup();
+  }
+});
+
+test('comment review remains available when decision reviews are provider-blocked', async () => {
+  const view = await renderReact(
+    <PullRequestReviewButtons
+      disabled={false}
+      hasPendingComments={false}
+      onSubmitReview={vi.fn()}
+      reviewStatus={{
+        approve: { disabled: true, reason: 'You cannot review your own pull request.' },
+        requestChanges: { disabled: true, reason: 'You cannot review your own pull request.' },
+      }}
+      showCommentReview
+    />,
+  );
+
+  try {
+    expect(view.container.querySelector('[aria-label="Submit review comments"]')).not.toBeNull();
+    expect(view.container.querySelector('[aria-label="Approve review"]')).toBeNull();
+    expect(view.container.querySelector('[aria-label="Request changes"]')).toBeNull();
+  } finally {
+    await view.cleanup();
+  }
+});
+
+test('non-GitHub reviews keep the existing review actions', async () => {
+  const view = await renderReact(
+    <PullRequestReviewButtons disabled={false} hasPendingComments onSubmitReview={vi.fn()} />,
+  );
+
+  try {
+    expect(view.container.querySelector('[aria-label="Submit review comments"]')).toBeNull();
+    expect(view.container.querySelector('[aria-label="Approve review"]')).not.toBeNull();
+    expect(view.container.querySelector('[aria-label="Request changes"]')).not.toBeNull();
+  } finally {
+    await view.cleanup();
+  }
+});

--- a/core/app/components/Panels.tsx
+++ b/core/app/components/Panels.tsx
@@ -1,6 +1,7 @@
 import { MarkdownEditor, type MarkdownEditorHandle } from '@nkzw/mdx-editor';
 import { CaretDownIcon as CaretDown } from '@phosphor-icons/react/CaretDown';
 import { CaretUpIcon as CaretUp } from '@phosphor-icons/react/CaretUp';
+import { ChatCircleIcon as ChatCircle } from '@phosphor-icons/react/ChatCircle';
 import { CheckIcon as Check } from '@phosphor-icons/react/Check';
 import { CheckCircleIcon as CheckCircle } from '@phosphor-icons/react/CheckCircle';
 import { PowerIcon as Power } from '@phosphor-icons/react/Power';
@@ -358,7 +359,12 @@ export function CopyCommentsButton({
 const getPullRequestReviewActionStatus = (
   reviewStatus: PullRequestReviewStatus | undefined,
   event: PullRequestReviewEvent,
-) => (event === 'APPROVE' ? reviewStatus?.approve : reviewStatus?.requestChanges);
+) =>
+  event === 'APPROVE'
+    ? reviewStatus?.approve
+    : event === 'COMMENT'
+      ? reviewStatus?.comment
+      : reviewStatus?.requestChanges;
 
 export const isPullRequestReviewActionDisabled = (
   reviewStatus: PullRequestReviewStatus | undefined,
@@ -371,9 +377,10 @@ const getPullRequestReviewActionTitle = (
   fallback: string,
 ) => getPullRequestReviewActionStatus(reviewStatus, event)?.reason ?? fallback;
 
-function PullRequestReviewAction({
+export function PullRequestReviewAction({
   disabled,
   event,
+  hasPendingComments = false,
   icon,
   label,
   onSubmitReview,
@@ -381,9 +388,10 @@ function PullRequestReviewAction({
 }: {
   disabled: boolean;
   event: PullRequestReviewEvent;
+  hasPendingComments?: boolean;
   icon: ReactNode;
   label: string;
-  onSubmitReview: (event: PullRequestReviewEvent, body?: string) => void;
+  onSubmitReview: (event: PullRequestReviewEvent, body?: string) => Promise<void> | void;
   title: string;
 }) {
   const [body, setBody] = useState('');
@@ -394,7 +402,24 @@ function PullRequestReviewAction({
   const popoverId = useId();
   const trimmedBody = body.trim();
   const isApprove = event === 'APPROVE';
-  const commentLabel = isApprove ? 'Add approval comment' : 'Add request changes comment';
+  const isComment = event === 'COMMENT';
+  const variant = isApprove ? 'approve' : isComment ? 'comment' : 'request-changes';
+  const actionLabel = isApprove
+    ? 'Approve review'
+    : isComment
+      ? 'Submit review comments'
+      : 'Request changes';
+  const commentLabel = isApprove
+    ? 'Add approval comment'
+    : isComment
+      ? 'Add review comment'
+      : 'Add request changes comment';
+  const placeholder = isApprove
+    ? 'Add an approval comment…'
+    : isComment
+      ? 'Add a review comment…'
+      : 'Add a change request comment…';
+  const primaryDisabled = disabled || (isComment && !hasPendingComments);
 
   useEffect(() => {
     if (!open) {
@@ -435,10 +460,21 @@ function PullRequestReviewAction({
     if (disabled || !trimmedBody) {
       return;
     }
-    onSubmitReview(event, trimmedBody);
-    setBody('');
-    setOpen(false);
+    void Promise.resolve(onSubmitReview(event, trimmedBody))
+      .then(() => {
+        setBody('');
+        setOpen(false);
+      })
+      .catch(() => {});
   }, [disabled, event, onSubmitReview, trimmedBody]);
+
+  const submitWithoutComment = useCallback(() => {
+    if (primaryDisabled) {
+      return;
+    }
+    setOpen(false);
+    void Promise.resolve(onSubmitReview(event)).catch(() => {});
+  }, [event, onSubmitReview, primaryDisabled]);
 
   const handleEditorKeyDown = useCallback(
     (keyboardEvent: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -459,20 +495,19 @@ function PullRequestReviewAction({
   return (
     <div className="review-submit-action" ref={rootRef}>
       <div
-        className={`codiff-open-button review-submit-button ${
-          isApprove ? 'approve' : 'request-changes'
-        }`}
+        className={`codiff-open-button review-submit-button ${variant}`}
         data-disabled={disabled || undefined}
       >
         <button
-          aria-label={isApprove ? 'Approve review' : 'Request changes'}
+          aria-label={actionLabel}
           className="review-submit-primary"
-          disabled={disabled}
-          onClick={() => {
-            setOpen(false);
-            onSubmitReview(event);
-          }}
-          title={title}
+          disabled={primaryDisabled}
+          onClick={submitWithoutComment}
+          title={
+            isComment && !hasPendingComments
+              ? 'Add an inline comment or write a review comment from the menu'
+              : title
+          }
           type="button"
         >
           {icon}
@@ -514,7 +549,7 @@ function PullRequestReviewAction({
             density="compact"
             onChange={setBody}
             onKeyDown={handleEditorKeyDown}
-            placeholder={isApprove ? 'Add an approval comment…' : 'Add a change request comment…'}
+            placeholder={placeholder}
             readOnly={disabled}
             ref={editorRef}
             spellCheck
@@ -523,9 +558,7 @@ function PullRequestReviewAction({
           />
           <div className="review-submit-popover-footer">
             <button
-              className={`codiff-open-button review-submit-popover-submit ${
-                isApprove ? 'approve' : 'request-changes'
-              }`}
+              className={`codiff-open-button review-submit-popover-submit ${variant}`}
               disabled={disabled || !trimmedBody}
               onClick={submitWithComment}
               type="button"
@@ -543,21 +576,28 @@ function PullRequestReviewAction({
 export function PullRequestReviewButtons({
   children,
   disabled,
+  hasPendingComments,
   onClosePullRequest,
   onSubmitReview,
   reviewStatus,
+  showCommentReview = false,
 }: {
   children?: ReactNode;
   disabled: boolean;
+  hasPendingComments: boolean;
   onClosePullRequest?: () => void;
-  onSubmitReview: (event: PullRequestReviewEvent, body?: string) => void;
+  onSubmitReview: (event: PullRequestReviewEvent, body?: string) => Promise<void> | void;
   reviewStatus?: PullRequestReviewStatus;
+  showCommentReview?: boolean;
 }) {
   const approveBlocked = isPullRequestReviewActionDisabled(reviewStatus, 'APPROVE');
+  const commentBlocked = isPullRequestReviewActionDisabled(reviewStatus, 'COMMENT');
   const requestChangesBlocked = isPullRequestReviewActionDisabled(reviewStatus, 'REQUEST_CHANGES');
   const closeStatus = reviewStatus?.close;
   const closeVisible = onClosePullRequest && closeStatus && closeStatus.disabled !== true;
-  const hasReviewActions = !approveBlocked || !requestChangesBlocked || closeVisible;
+  const commentVisible = showCommentReview && !commentBlocked;
+  const hasReviewActions =
+    commentVisible || !approveBlocked || !requestChangesBlocked || closeVisible;
   if (!hasReviewActions && !children) {
     return null;
   }
@@ -568,6 +608,24 @@ export function PullRequestReviewButtons({
       className="source-description-review-actions"
     >
       {children}
+      {commentVisible ? (
+        <PullRequestReviewAction
+          disabled={disabled}
+          event="COMMENT"
+          hasPendingComments={hasPendingComments}
+          icon={
+            <ChatCircle
+              aria-hidden
+              className="review-submit-icon comment"
+              size={15}
+              weight="bold"
+            />
+          }
+          label="Comment"
+          onSubmitReview={onSubmitReview}
+          title={getPullRequestReviewActionTitle(reviewStatus, 'COMMENT', 'Submit review comments')}
+        />
+      ) : null}
       {!approveBlocked ? (
         <PullRequestReviewAction
           disabled={disabled}

--- a/core/types.ts
+++ b/core/types.ts
@@ -58,6 +58,7 @@ export type PullRequestReviewActionStatus = {
 export type PullRequestReviewStatus = {
   approve?: PullRequestReviewActionStatus;
   close?: PullRequestReviewActionStatus;
+  comment?: PullRequestReviewActionStatus;
   requestChanges?: PullRequestReviewActionStatus;
 };
 
@@ -769,7 +770,7 @@ export type PullRequestGeneralCommentThread = {
   isResolved?: boolean;
 };
 
-export type PullRequestReviewEvent = 'APPROVE' | 'REQUEST_CHANGES';
+export type PullRequestReviewEvent = 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES';
 
 export type SubmitPullRequestCommentRequest = {
   comment: PullRequestReviewComment;

--- a/electron/__tests__/pull-request-review.test.ts
+++ b/electron/__tests__/pull-request-review.test.ts
@@ -1,0 +1,62 @@
+import { createRequire } from 'node:module';
+import { expect, test } from 'vite-plus/test';
+
+const require = createRequire(import.meta.url);
+const { createPullRequestReviewPayload } = require('../git-state/pull-request.cjs') as {
+  createPullRequestReviewPayload: (request: {
+    body?: string;
+    comments: ReadonlyArray<Record<string, unknown>>;
+    event: 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES';
+  }) => Record<string, unknown>;
+};
+
+test('builds a neutral GitHub review payload from inline comments', () => {
+  expect(
+    createPullRequestReviewPayload({
+      comments: [
+        {
+          body: 'Please keep this explicit.',
+          filePath: 'src/app.ts',
+          lineNumber: 7,
+          side: 'additions',
+        },
+      ],
+      event: 'COMMENT',
+    }),
+  ).toEqual({
+    body: '',
+    comments: [
+      {
+        body: 'Please keep this explicit.',
+        line: 7,
+        path: 'src/app.ts',
+        side: 'RIGHT',
+      },
+    ],
+    event: 'COMMENT',
+  });
+});
+
+test('builds a neutral GitHub review payload from a trimmed review body', () => {
+  expect(
+    createPullRequestReviewPayload({
+      body: '  General feedback.  ',
+      comments: [],
+      event: 'COMMENT',
+    }),
+  ).toEqual({ body: 'General feedback.', comments: [], event: 'COMMENT' });
+});
+
+test('rejects empty neutral GitHub reviews before calling GitHub', () => {
+  expect(() =>
+    createPullRequestReviewPayload({ body: '   ', comments: [], event: 'COMMENT' }),
+  ).toThrow('A comment review requires an inline comment or a review comment.');
+});
+
+test('keeps the fallback body for an empty request-changes review', () => {
+  expect(createPullRequestReviewPayload({ comments: [], event: 'REQUEST_CHANGES' })).toEqual({
+    body: 'Requesting changes.',
+    comments: [],
+    event: 'REQUEST_CHANGES',
+  });
+});

--- a/electron/git-state/pull-request.cjs
+++ b/electron/git-state/pull-request.cjs
@@ -948,20 +948,31 @@ const submitPullRequestReview = async (launchPath, request) => {
       '--input',
       '-',
     ],
-    {
-      body:
-        request.body ||
-        (request.event === 'REQUEST_CHANGES' && request.comments.length === 0
-          ? 'Requesting changes.'
-          : ''),
-      comments: request.comments.map(normalizePullRequestComment),
-      event: request.event,
-    },
+    createPullRequestReviewPayload(request),
   );
+};
+
+/** @param {SubmitPullRequestReviewRequest} request */
+const createPullRequestReviewPayload = (request) => {
+  const body = request.body?.trim() || '';
+  if (request.event === 'COMMENT' && request.comments.length === 0 && !body) {
+    throw new Error('A comment review requires an inline comment or a review comment.');
+  }
+
+  return {
+    body:
+      body ||
+      (request.event === 'REQUEST_CHANGES' && request.comments.length === 0
+        ? 'Requesting changes.'
+        : ''),
+    comments: request.comments.map(normalizePullRequestComment),
+    event: request.event,
+  };
 };
 
 module.exports = {
   collectResolvedReviewCommentIds,
+  createPullRequestReviewPayload,
   createPatchFromPullRequestFile,
   createPullRequestHistoryFetchRefspecs,
   createPullRequestSection,


### PR DESCRIPTION
## Summary

- add a first-class GitHub **Comment** review action alongside Approve and Request Changes
- allow neutral reviews to submit pending inline comments, an overall review comment, or both
- preserve local inline and review-body drafts after failed submissions while rejecting empty neutral reviews

## Impact

- **Architecture**: Extends the shared review event contract with `COMMENT` and keeps the UI/provider path gated to GitHub; GitLab behavior is unchanged.
- **Performance / bundle size**: No new dependencies or data fetching; the UI adds one existing Phosphor icon.
- **Risk**: Limited to batch review submission. UI and backend guards prevent the invalid empty-comment review case.
- **User-facing changes**: Reviewers, including authors reviewing their own PRs, can publish neutral batch feedback without approving or requesting changes.

## Testing

- `vp test` — 53 files, 564 tests passed
- `vp check --fix`
- `vp build`
- `git diff --check`

Closes #119
