### PR TITLE
Add walkthrough persistence, resumable sessions, and staleness UI

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -712,6 +712,16 @@ html[data-codiff-platform='darwin'] .collapsed-sidebar-bar {
   background: rgb(127 127 127 / 0.2);
 }
 
+.sidebar-refresh-button {
+  flex: none;
+  margin-left: 4px;
+}
+
+.sidebar-refresh-button:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
 .sidebar-resizer {
   -webkit-app-region: no-drag;
   border-left: 1px solid var(--sidebar-border);

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -136,9 +136,11 @@ import type {
   SharedWalkthroughSnapshot,
   TerminalHelperStatus,
   NarrativeWalkthrough,
+  NarrativeWalkthroughResult,
   WalkthroughCommitMessageRequest,
   WalkthroughCommitRequest,
   WalkthroughProgressEvent,
+  WalkthroughStaleness,
   DiffSection,
 } from './types.ts';
 
@@ -279,6 +281,9 @@ export default function App() {
     null,
   );
   const [walkthroughError, setWalkthroughError] = useState<WalkthroughError | null>(null);
+  const [walkthroughStaleness, setWalkthroughStaleness] = useState<WalkthroughStaleness | null>(
+    null,
+  );
   const [walkthroughFileError, setWalkthroughFileError] = useState<WalkthroughFileError | null>(
     null,
   );
@@ -316,6 +321,7 @@ export default function App() {
   const markdownRefreshQueueRef = useRef<Promise<void>>(Promise.resolve());
   const viewedRef = useRef<Record<string, string>>({});
   const narrativeWalkthroughRef = useRef<NarrativeWalkthrough | null>(null);
+  const walkthroughStalenessRef = useRef<WalkthroughStaleness | null>(null);
   const walkthroughOutdatedPathsRef = useRef<ReadonlySet<string>>(new Set());
   const navigationResetKey = state ? `${state.root}:${getSourceKey(state.source)}` : '';
   const narrativeNavigation = useNarrativeNavigation(
@@ -620,6 +626,7 @@ export default function App() {
       viewed: viewedRef.current,
       walkthroughError: walkthroughErrorRef.current,
       walkthroughOutdatedPaths: walkthroughOutdatedPathsRef.current,
+      walkthroughStaleness: walkthroughStalenessRef.current,
     });
   }, []);
 
@@ -713,17 +720,27 @@ export default function App() {
 
       // Always consult the main process for a pre-authored walkthrough file, even
       // when the diff is empty, so it can diagnose *why* (e.g. the changes were
-      // committed) rather than us guessing in the renderer.
-      const shouldFetchNarrative = shouldLoadNarrative || walkthroughFilePath != null;
-      const narrativeResult = shouldFetchNarrative
-        ? await window.codiff.getNarrativeWalkthrough(orderedState.source)
-        : null;
+      // committed) rather than us guessing in the renderer. Otherwise, prefer the
+      // walkthrough saved on disk and only generate when none exists.
+      let narrativeResult: NarrativeWalkthroughResult | null = null;
+      if (walkthroughFilePath != null) {
+        narrativeResult = await window.codiff.getNarrativeWalkthrough(orderedState.source);
+      } else if (shouldLoadNarrative) {
+        const stored = await window.codiff.getWalkthroughStatus(orderedState.source);
+        narrativeResult =
+          stored.status === 'ready'
+            ? { staleness: stored.staleness, status: 'ready', walkthrough: stored.walkthrough }
+            : await window.codiff.getNarrativeWalkthrough(orderedState.source);
+      }
       if (canceled) {
         return;
       }
       const loadedNarrative =
         narrativeResult?.status === 'ready' ? narrativeResult.walkthrough : null;
       setNarrativeWalkthrough(loadedNarrative);
+      setWalkthroughStaleness(
+        narrativeResult?.status === 'ready' ? (narrativeResult.staleness ?? null) : null,
+      );
 
       if (narrativeResult?.status === 'unavailable') {
         setWalkthroughError(narrativeResult);
@@ -1197,6 +1214,10 @@ export default function App() {
   }, [narrativeWalkthrough]);
 
   useEffect(() => {
+    walkthroughStalenessRef.current = walkthroughStaleness;
+  }, [walkthroughStaleness]);
+
+  useEffect(() => {
     walkthroughOutdatedPathsRef.current = walkthroughOutdatedPaths;
   }, [walkthroughOutdatedPaths]);
 
@@ -1554,6 +1575,23 @@ export default function App() {
           setMainMode('review');
         }
         setLocalChangesDetected(false);
+
+        // The head/working tree may have moved, so recompute how stale the shown
+        // walkthrough is (without replacing it).
+        if (narrativeWalkthroughRef.current) {
+          window.codiff
+            .getWalkthroughStatus(orderedState.source)
+            .then((status) => {
+              if (
+                sourceRequestRef.current === request &&
+                status.status === 'ready' &&
+                narrativeWalkthroughRef.current
+              ) {
+                setWalkthroughStaleness(status.staleness);
+              }
+            })
+            .catch(() => {});
+        }
       })
       .catch(() => {
         // Keep the current state; the banner stays up as a retry affordance.
@@ -1664,6 +1702,7 @@ export default function App() {
           setViewed(nextViewed);
           setSelectedPath(nextSelectedPath);
           setNarrativeWalkthrough(session?.narrativeWalkthrough ?? null);
+          setWalkthroughStaleness(session?.walkthroughStaleness ?? null);
           setWalkthroughError(session?.walkthroughError ?? null);
           setWalkthroughLoading(false);
           setWalkthroughUnread(false);
@@ -1738,60 +1777,110 @@ export default function App() {
 
   // Ask the connected agent for a narrative walkthrough of the given source.
   // Results are dropped if the reviewer switched sources while it was running.
-  const loadNarrativeWalkthrough = useCallback((source: ReviewSource) => {
+  const loadNarrativeWalkthrough = useCallback(
+    (source: ReviewSource, previousWalkthrough?: NarrativeWalkthrough) => {
+      const sourceKey = getSourceKey(source);
+      setWalkthroughProgress((current) => ({
+        phase: null,
+        responseLabelIndex: nextWalkthroughResponseLabelIndex(current.responseLabelIndex),
+        stageRevision: current.stageRevision + 1,
+      }));
+      setWalkthroughLoading(true);
+      setWalkthroughError(null);
+      window.codiff
+        .getNarrativeWalkthrough(source, previousWalkthrough ? { previousWalkthrough } : undefined)
+        .then((result) => {
+          if (getSourceKey(stateRef.current?.source ?? source) !== sourceKey) {
+            return;
+          }
+
+          if (result.status === 'ready') {
+            setNarrativeWalkthrough(result.walkthrough);
+            setWalkthroughStaleness(result.staleness ?? null);
+            setWalkthroughOutdatedPaths(new Set());
+            if (sidebarModeRef.current === 'walkthrough') {
+              setSidebarMode('walkthrough');
+            } else {
+              setWalkthroughUnread(true);
+            }
+          } else {
+            setWalkthroughError(result);
+          }
+        })
+        .catch((error: unknown) => {
+          if (getSourceKey(stateRef.current?.source ?? source) !== sourceKey) {
+            return;
+          }
+
+          setWalkthroughError({
+            reason: error instanceof Error ? error.message : String(error),
+            status: 'unavailable',
+          });
+        })
+        .finally(() => {
+          if (getSourceKey(stateRef.current?.source ?? source) === sourceKey) {
+            setWalkthroughLoading(false);
+          }
+        });
+    },
+    [],
+  );
+
+  // Load the walkthrough saved on disk for this source, without regenerating.
+  // Resolves true when one was found and shown. Drops stale results.
+  const loadStoredWalkthrough = useCallback((source: ReviewSource): Promise<boolean> => {
     const sourceKey = getSourceKey(source);
-    setWalkthroughProgress((current) => ({
-      phase: null,
-      responseLabelIndex: nextWalkthroughResponseLabelIndex(current.responseLabelIndex),
-      stageRevision: current.stageRevision + 1,
-    }));
-    setWalkthroughLoading(true);
-    setWalkthroughError(null);
-    window.codiff
-      .getNarrativeWalkthrough(source)
+    return window.codiff
+      .getWalkthroughStatus(source)
       .then((result) => {
+        if (getSourceKey(stateRef.current?.source ?? source) !== sourceKey) {
+          return false;
+        }
+        if (result.status === 'ready') {
+          setNarrativeWalkthrough(result.walkthrough);
+          setWalkthroughStaleness(result.staleness);
+          setWalkthroughError(null);
+          setWalkthroughOutdatedPaths(new Set());
+          return true;
+        }
+        return false;
+      })
+      .catch(() => false);
+  }, []);
+
+  // Prefer the saved walkthrough on open; only generate when none is saved.
+  const loadWalkthroughForSource = useCallback(
+    (source: ReviewSource) => {
+      const sourceKey = getSourceKey(source);
+      setWalkthroughLoading(true);
+      setWalkthroughError(null);
+      loadStoredWalkthrough(source).then((found) => {
         if (getSourceKey(stateRef.current?.source ?? source) !== sourceKey) {
           return;
         }
-
-        if (result.status === 'ready') {
-          setNarrativeWalkthrough(result.walkthrough);
-          setWalkthroughOutdatedPaths(new Set());
-          if (sidebarModeRef.current === 'walkthrough') {
-            setSidebarMode('walkthrough');
-          } else {
+        if (found) {
+          setWalkthroughLoading(false);
+          if (sidebarModeRef.current !== 'walkthrough') {
             setWalkthroughUnread(true);
           }
         } else {
-          setWalkthroughError(result);
-        }
-      })
-      .catch((error: unknown) => {
-        if (getSourceKey(stateRef.current?.source ?? source) !== sourceKey) {
-          return;
-        }
-
-        setWalkthroughError({
-          reason: error instanceof Error ? error.message : String(error),
-          status: 'unavailable',
-        });
-      })
-      .finally(() => {
-        if (getSourceKey(stateRef.current?.source ?? source) === sourceKey) {
-          setWalkthroughLoading(false);
+          loadNarrativeWalkthrough(source);
         }
       });
-  }, []);
+    },
+    [loadNarrativeWalkthrough, loadStoredWalkthrough],
+  );
 
   // Regenerate the walkthrough on demand, e.g. after an in-place refresh
   // surfaced changes the current walkthrough doesn't narrate. The existing
-  // walkthrough stays visible until the new one arrives.
+  // walkthrough stays visible until the new one arrives. The current walkthrough
+  // is passed so the agent updates it in place for the new changes.
   const regenerateWalkthrough = useCallback(() => {
     const currentState = stateRef.current;
     if (!currentState || currentState.files.length === 0 || walkthroughLoading) {
       return;
     }
-    loadNarrativeWalkthrough(currentState.source);
+    loadNarrativeWalkthrough(currentState.source, narrativeWalkthroughRef.current ?? undefined);
   }, [loadNarrativeWalkthrough, walkthroughLoading]);
 
   const changeSidebarMode = useCallback(
@@ -1819,9 +1908,9 @@ export default function App() {
         return;
       }
 
-      loadNarrativeWalkthrough(state.source);
+      loadWalkthroughForSource(state.source);
     },
-    [loadNarrativeWalkthrough, narrativeWalkthrough, state, walkthroughError, walkthroughLoading],
+    [loadWalkthroughForSource, narrativeWalkthrough, state, walkthroughError, walkthroughLoading],
   );
 
   const openCommitView = useCallback(() => {
@@ -2573,6 +2662,36 @@ export default function App() {
     state.source.type !== 'working-tree' ? ` · ${getSourceLabel(state.source)}` : '';
   const emptySourceDetail = getEmptySourceDetail(state.source, state.root);
 
+  // Re-read the diff in place so a reviewer can pull in new commits/changes
+  // without reloading the window. Rendered in the sidebar's PR/source bar.
+  const refreshRepositoryButton = (
+    <button
+      aria-label="Refresh changes"
+      className="sidebar-toggle-button sidebar-refresh-button"
+      disabled={Boolean(pendingSource)}
+      onClick={refreshRepository}
+      title="Refresh changes"
+      type="button"
+    >
+      <svg
+        aria-hidden
+        fill="none"
+        height="16"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        width="16"
+      >
+        <path d="M21 2v6h-6" />
+        <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+        <path d="M3 22v-6h6" />
+        <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+      </svg>
+    </button>
+  );
+
   const showNarrativeWalkthrough = narrativeWalkthrough != null && sidebarMode === 'walkthrough';
   const plainCommitModel = narrativeNavigation.walkthroughView
     ? buildCommitModel(narrativeNavigation.walkthroughView, state.files)
@@ -2711,6 +2830,7 @@ export default function App() {
             {sidebarLabel}
             {sidebarSourceLabel}
           </div>
+          {refreshRepositoryButton}
         </div>
       ) : null}
       <RepositoryChangeBanner
@@ -2778,6 +2898,7 @@ export default function App() {
               {sidebarLabel}
               {sidebarSourceLabel}
             </div>
+            {refreshRepositoryButton}
           </div>
         </div>
         <Sidebar
@@ -2796,6 +2917,7 @@ export default function App() {
           onActivatePath={activatePath}
           onLoadMoreHistory={loadMoreHistory}
           onModeChange={changeSidebarMode}
+          onRegenerateWalkthrough={regenerateWalkthrough}
           onSearchQueryChange={
             sidebarMode === 'history' ? setHistorySearchQuery : setFileSearchQuery
           }
@@ -2804,6 +2926,7 @@ export default function App() {
           onShareWalkthrough={enabledShareWalkthrough}
           onToggleCommitView={showPlainCommitView ? closeCommitView : openCommitView}
           pullRequestSource={historySource?.type === 'pull-request' ? historySource : null}
+          regenerateDisabled={walkthroughLoading}
           reloadDeltaPaths={reloadDeltaPaths}
           searchQuery={sidebarMode === 'history' ? historySearchQuery : fileSearchQuery}
           selectedPath={visibleSelectedPath}
@@ -2814,6 +2937,7 @@ export default function App() {
           walkthroughLoading={walkthroughLoading}
           walkthroughOutdatedPaths={walkthroughOutdatedPaths}
           walkthroughProgress={walkthroughProgress}
+          walkthroughStaleness={walkthroughStaleness}
           walkthroughUnread={walkthroughUnread}
         />
       </aside>

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -211,6 +211,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
     installed: true,
     path: '/usr/local/bin/codiff',
   })),
+  getWalkthroughStatus: vi.fn(async () => ({ status: 'none' as const })),
   increaseCodeFontSize: vi.fn(async () => {}),
   installAgentSkill: vi.fn(async () => ({
     installed: true,
@@ -1728,6 +1729,105 @@ test('a walkthrough file loads even without the walkthrough launch flag', async 
 
     expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
     expect(container.querySelector('.walkthrough-error')).toBeNull();
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+  }
+});
+
+test('a walkthrough launch shows the saved walkthrough instead of regenerating', async () => {
+  const source = { ref: 'abc1234', type: 'commit' } satisfies ReviewSource;
+  const savedWalkthrough = {
+    agent: 'claude',
+    chapters: [
+      {
+        blurb: 'Review the implementation.',
+        icon: 'gear',
+        id: 'impl',
+        stops: [
+          {
+            added: 1,
+            deleted: 1,
+            hunkIds: ['src/app.ts:unstaged:h1'],
+            hunks: [
+              {
+                added: 1,
+                anchor: { display: 'src/app.ts', sectionId: 'src/app.ts:unstaged', side: 'both' },
+                deleted: 1,
+                id: 'src/app.ts:unstaged:h1',
+                path: 'src/app.ts',
+                status: 'modified',
+              },
+            ],
+            id: 'saved-path',
+            importance: 'critical',
+            prose: 'Review this saved file.',
+            summary: 'The saved path.',
+            title: 'Saved stop',
+          },
+        ],
+        title: 'Implementation',
+      },
+    ],
+    focus: 'Focus.',
+    generatedAt: '2026-06-07T00:00:00.000Z',
+    kind: 'narrative',
+    repo: { branch: 'main', root: '/repo' },
+    source,
+    support: [],
+    title: 'Saved narrative',
+    version: 4,
+  } satisfies NarrativeWalkthrough;
+
+  const getNarrativeWalkthrough = vi.fn(async () => ({
+    reason: 'Should not be called.',
+    status: 'unavailable' as const,
+  }));
+  const getWalkthroughStatus = vi.fn(async () => ({
+    staleness: {
+      commitsBehind: 0,
+      currentHead: 'abc1234',
+      diverged: false,
+      generatedHead: 'abc1234',
+      isLatest: true,
+      treeMatches: true,
+    },
+    status: 'ready' as const,
+    walkthrough: savedWalkthrough,
+  }));
+  window.codiff = createCodiffMock({
+    getLaunchOptions: vi.fn(async () => ({
+      repositoryPathProvided: true,
+      source,
+      walkthrough: true,
+    })),
+    getNarrativeWalkthrough,
+    getRepositoryState: vi.fn(async () => ({
+      ...repositoryState,
+      files: [createChangedFile('src/app.ts')],
+      source,
+    })),
+    getWalkthroughStatus,
+  });
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.wt-stage-title')?.textContent).toContain('Saved stop');
+    });
+
+    expect(getWalkthroughStatus).toHaveBeenCalled();
+    expect(getNarrativeWalkthrough).not.toHaveBeenCalled();
   } finally {
     if (root) {
       await act(async () => root?.unmount());

--- a/core/app/components/Sidebar.tsx
+++ b/core/app/components/Sidebar.tsx
@@ -27,7 +27,13 @@ import {
 import { fileTreeSort, statusForTree } from '../../lib/files.ts';
 import { isNativeInputTarget } from '../../lib/keyboard.ts';
 import { getShortRef, getSourceKey } from '../../lib/source.ts';
-import type { ChangedFile, HistoryEntry, NarrativeWalkthrough, ReviewSource } from '../../types.ts';
+import type {
+  ChangedFile,
+  HistoryEntry,
+  NarrativeWalkthrough,
+  ReviewSource,
+  WalkthroughStaleness,
+} from '../../types.ts';
 import { Gravatar } from './Gravatar.tsx';
 import { NarrativeSidebar } from './walkthrough/NarrativeSidebar.tsx';
 import type { NarrativeNavigation } from './walkthrough/useNarrativeNavigation.ts';
@@ -49,12 +55,14 @@ export function Sidebar({
   onActivatePath,
   onLoadMoreHistory,
   onModeChange,
+  onRegenerateWalkthrough,
   onSearchQueryChange,
   onSelectPath,
   onSelectSource,
   onShareWalkthrough,
   onToggleCommitView,
   pullRequestSource,
+  regenerateDisabled,
   reloadDeltaPaths,
   searchQuery,
   selectedPath,
@@ -65,6 +73,7 @@ export function Sidebar({
   walkthroughLoading,
   walkthroughOutdatedPaths,
   walkthroughProgress,
+  walkthroughStaleness,
   walkthroughUnread,
 }: {
   branchSource: Extract<ReviewSource, { type: 'branch-diff' }> | null;
@@ -82,12 +91,14 @@ export function Sidebar({
   onActivatePath: (path: string) => void;
   onLoadMoreHistory: () => void;
   onModeChange: (mode: SidebarMode) => void;
+  onRegenerateWalkthrough?: () => void;
   onSearchQueryChange: (query: string) => void;
   onSelectPath: (path: string) => void;
   onSelectSource: (source: ReviewSource) => void;
   onShareWalkthrough?: () => void;
   onToggleCommitView: () => void;
   pullRequestSource: PullRequestSource | null;
+  regenerateDisabled?: boolean;
   reloadDeltaPaths: ReadonlySet<string>;
   searchQuery: string;
   selectedPath: string | null;
@@ -102,6 +113,7 @@ export function Sidebar({
     responseLabelIndex: number;
     stageRevision: number;
   };
+  walkthroughStaleness?: WalkthroughStaleness | null;
   walkthroughUnread: boolean;
 }) {
   const allowSelectionScroll = useRef(false);
@@ -363,9 +375,12 @@ export function Sidebar({
           changedPaths={walkthroughOutdatedPaths}
           files={commitFiles}
           navigation={narrativeNavigation}
+          onRegenerate={onRegenerateWalkthrough}
           onShareWalkthrough={onShareWalkthrough}
+          regenerateDisabled={regenerateDisabled}
           shareWalkthroughDisabled={shareWalkthroughDisabled}
           showWhitespace={showWhitespace}
+          staleness={walkthroughStaleness}
           walkthrough={narrativeWalkthrough}
         />
       ) : mode === 'walkthrough' ? (

--- a/core/app/components/walkthrough/NarrativeSidebar.tsx
+++ b/core/app/components/walkthrough/NarrativeSidebar.tsx
@@ -2,6 +2,7 @@ import { getAgentLabel } from '../../../lib/app-constants.ts';
 import { renderInlineMarkdown } from '../../../lib/markdown.tsx';
 import {
   buildCommitModel,
+  describeWalkthroughStaleness,
   formatWalkthroughFileLineRows,
   getUncoveredWalkthroughFileLineItems,
   isWalkthroughCommittable,
@@ -9,7 +10,7 @@ import {
   type WalkthroughView,
   type WalkthroughStopView,
 } from '../../../lib/narrative-walkthrough.ts';
-import type { ChangedFile, NarrativeWalkthrough } from '../../../types.ts';
+import type { ChangedFile, NarrativeWalkthrough, WalkthroughStaleness } from '../../../types.ts';
 import { ArrowsClockwise, Check, GitBranch, Path, ShareNetwork } from './icons.tsx';
 import { ChapterIcon } from './parts.tsx';
 import type { NarrativeNavigation } from './useNarrativeNavigation.ts';
@@ -203,18 +204,24 @@ export function NarrativeSidebar({
   changedPaths,
   files,
   navigation,
+  onRegenerate,
   onShareWalkthrough,
+  regenerateDisabled = false,
   shareWalkthroughDisabled = false,
   showWhitespace,
+  staleness,
   walkthrough,
 }: {
   allowCommit?: boolean;
   changedPaths?: ReadonlySet<string>;
   files: ReadonlyArray<ChangedFile>;
   navigation: NarrativeNavigation;
+  onRegenerate?: () => void;
   onShareWalkthrough?: () => void;
+  regenerateDisabled?: boolean;
   shareWalkthroughDisabled?: boolean;
   showWhitespace: boolean;
+  staleness?: WalkthroughStaleness | null;
   walkthrough: NarrativeWalkthrough;
 }) {
   const { walkthroughView } = navigation;
@@ -235,6 +242,27 @@ export function NarrativeSidebar({
 
   return (
     <div className="walkthrough-list">
+      {onRegenerate || staleness ? (
+        <div className={`wt-staleness${staleness?.isLatest ? ' latest' : ' stale'}`}>
+          <span className="wt-staleness-label">
+            {staleness?.isLatest ? <Check size={13} weight="bold" /> : null}
+            {staleness ? describeWalkthroughStaleness(staleness) : 'Saved from an earlier state'}
+          </span>
+          {onRegenerate ? (
+            <button
+              className="wt-staleness-sync"
+              disabled={regenerateDisabled}
+              onClick={onRegenerate}
+              title="Regenerate the walkthrough for the latest changes"
+              type="button"
+            >
+              <ArrowsClockwise size={13} weight="bold" />
+              {regenerateDisabled ? 'Syncing…' : staleness?.isLatest ? 'Regenerate' : 'Sync'}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
       <div className="wt-focus">
         <span className="wt-focus-label">Review focus</span>
         <p>{renderInlineMarkdown(walkthrough.focus)}</p>

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -10,6 +10,7 @@ import type {
   DiffSection,
   DiffSectionContentRequest,
   GitIdentity,
+  NarrativeWalkthroughRequestOptions,
   NarrativeWalkthroughResult,
   PlanHandoffStatus,
   PlanReview,
@@ -32,6 +33,7 @@ import type {
   WalkthroughCommitRequest,
   WalkthroughCommitResult,
   WalkthroughProgressEvent,
+  WalkthroughStatusResult,
 } from './types.ts';
 
 declare module '*.css';
@@ -56,12 +58,16 @@ declare global {
         kind: CodiffMarkdownDocument['kind'];
         path: string;
       }) => Promise<CodiffMarkdownDocument>;
-      getNarrativeWalkthrough: (source?: ReviewSource) => Promise<NarrativeWalkthroughResult>;
+      getNarrativeWalkthrough: (
+        source?: ReviewSource,
+        options?: NarrativeWalkthroughRequestOptions,
+      ) => Promise<NarrativeWalkthroughResult>;
       getPlanReview: () => Promise<PlanReview | null>;
       getPreferences: () => Promise<CodiffPreferences>;
       getRepositoryHistory: (limit?: number, source?: ReviewSource) => Promise<RepositoryHistory>;
       getRepositoryState: (source?: ReviewSource) => Promise<RepositoryState>;
       getTerminalHelperStatus: () => Promise<TerminalHelperStatus>;
+      getWalkthroughStatus: (source?: ReviewSource) => Promise<WalkthroughStatusResult>;
       increaseCodeFontSize: () => Promise<void>;
       installAgentSkill: () => Promise<AgentSkillStatus>;
       installTerminalHelper: () => Promise<TerminalHelperStatus>;

--- a/core/lib/app-types.ts
+++ b/core/lib/app-types.ts
@@ -8,6 +8,7 @@ import type {
   PullRequestCodeQualityFinding,
   PullRequestExistingReviewComment,
   ReviewSource,
+  WalkthroughStaleness,
 } from '../types.ts';
 
 export type WalkthroughError = Extract<NarrativeWalkthroughResult, { status: 'unavailable' }>;
@@ -143,6 +144,7 @@ export type SourceSession = {
   viewed: Record<string, string>;
   walkthroughError: WalkthroughError | null;
   walkthroughOutdatedPaths: ReadonlySet<string>;
+  walkthroughStaleness?: WalkthroughStaleness | null;
 };
 
 export type RepositoryLoadError = {

--- a/core/lib/narrative-walkthrough.ts
+++ b/core/lib/narrative-walkthrough.ts
@@ -7,6 +7,7 @@ import type {
   WalkthroughHunk,
   WalkthroughHunkGroup,
   WalkthroughIcon,
+  WalkthroughStaleness,
   WalkthroughSupportGroup,
   WalkthroughStop,
 } from '../types.ts';
@@ -20,6 +21,28 @@ import {
 export type NarrativeLineCount = {
   added: number;
   deleted: number;
+};
+
+/** Human-readable summary of how far a saved walkthrough has drifted. */
+export const describeWalkthroughStaleness = (staleness: WalkthroughStaleness): string => {
+  if (staleness.isLatest) {
+    return 'Up to date with the latest commit';
+  }
+  if (staleness.diverged) {
+    return 'History changed since this walkthrough was generated';
+  }
+  const parts: Array<string> = [];
+  if (staleness.commitsBehind > 0) {
+    parts.push(
+      `${staleness.commitsBehind} commit${staleness.commitsBehind === 1 ? '' : 's'} behind`,
+    );
+  }
+  if (!staleness.treeMatches) {
+    parts.push('working tree changed');
+  }
+  return parts.length > 0
+    ? parts.join(' · ')
+    : 'This walkthrough may not match the current changes';
 };
 
 /** A stop with a global position in the walkthrough. */

--- a/core/types.ts
+++ b/core/types.ts
@@ -576,6 +576,7 @@ export type NarrativeWalkthrough = {
 
 export type NarrativeWalkthroughResult =
   | {
+      staleness?: WalkthroughStaleness;
       status: 'ready';
       walkthrough: NarrativeWalkthrough;
     }
@@ -584,6 +585,39 @@ export type NarrativeWalkthroughResult =
       reason: string;
       status: 'unavailable';
     };
+
+/**
+ * How far a saved walkthrough has drifted from the current repository state.
+ * `commitsBehind` counts commits added since it was generated; `treeMatches`
+ * is false when the working tree (or head) fingerprint changed. `diverged` is
+ * true when the generating commit is no longer in the current history.
+ */
+export type WalkthroughStaleness = {
+  commitsBehind: number;
+  currentHead: string | null;
+  diverged: boolean;
+  generatedHead: string | null;
+  isLatest: boolean;
+  treeMatches: boolean;
+};
+
+/** Result of loading a saved walkthrough from disk without regenerating. */
+export type WalkthroughStatusResult =
+  | {
+      staleness: WalkthroughStaleness;
+      status: 'ready';
+      walkthrough: NarrativeWalkthrough;
+    }
+  | { status: 'none' };
+
+/** Options for a walkthrough generation request. */
+export type NarrativeWalkthroughRequestOptions = {
+  /**
+   * The walkthrough currently shown, passed on regeneration so the agent can
+   * update it in place for the new changes instead of authoring from scratch.
+   */
+  previousWalkthrough?: NarrativeWalkthrough;
+};
 
 /** Commit the selected files from a walkthrough's staging set. */
 export type WalkthroughCommitRequest = {

--- a/core/walkthrough.css
+++ b/core/walkthrough.css
@@ -347,6 +347,49 @@
   cursor: default;
   opacity: 0.6;
 }
+/* ---- Staleness header ----------------------------------------------------- */
+.wt-staleness {
+  align-items: center;
+  border-bottom: 1px solid var(--file-border);
+  display: flex;
+  flex: none;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 6px 16px;
+}
+.wt-staleness-label {
+  align-items: center;
+  color: var(--muted);
+  display: inline-flex;
+  font: 500 12px/1.3 var(--font-sans);
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wt-staleness.latest .wt-staleness-label {
+  color: var(--diff-add-text, var(--muted));
+}
+.wt-staleness-sync {
+  align-items: center;
+  background: color-mix(in srgb, var(--tree-selection-focus) 13%, transparent);
+  border: 0;
+  border-radius: 12px;
+  color: var(--tree-selection-focus);
+  corner-shape: squircle;
+  cursor: pointer;
+  display: inline-flex;
+  flex: none;
+  font: 600 12px/1 var(--font-sans);
+  gap: 6px;
+  padding: 6px 11px;
+}
+.wt-staleness-sync:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
 /* ---- Variation C — hybrid arc timeline ------------------------------------ */
 .wt-hybrid {
   display: flex;

--- a/electron/__tests__/claude.test.ts
+++ b/electron/__tests__/claude.test.ts
@@ -26,7 +26,14 @@ const {
     schema: unknown,
     outputName?: string,
     timeoutMessage?: string,
-    options?: { model?: string; onProgress?: (phase: string) => void; timeoutMs?: number },
+    options?: {
+      model?: string;
+      onProgress?: (phase: string) => void;
+      onSessionId?: (sessionId: string) => void;
+      persistSession?: boolean;
+      resumeSessionId?: string;
+      timeoutMs?: number;
+    },
   ) => Promise<string>;
 };
 
@@ -104,6 +111,56 @@ process.stdin.on('end', () => {
     expect(args).toContain('--add-dir');
     expect(args).toContain(directory);
     expect(args).toContain('--no-session-persistence');
+  } finally {
+    if (previousClaudePath == null) {
+      delete process.env.CODIFF_CLAUDE_PATH;
+    } else {
+      process.env.CODIFF_CLAUDE_PATH = previousClaudePath;
+    }
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test('resumes a persisted Claude session and captures its session id', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-claude-resume-'));
+  const fakeClaudePath = join(directory, 'claude');
+  const argsPath = join(directory, 'args.txt');
+  const previousClaudePath = process.env.CODIFF_CLAUDE_PATH;
+
+  try {
+    await writeFile(
+      fakeClaudePath,
+      `#!/usr/bin/env node
+const { appendFileSync } = require('node:fs');
+const argsPath = ${JSON.stringify(argsPath)};
+for (const arg of process.argv.slice(2)) {
+  appendFileSync(argsPath, arg + '\\n');
+}
+process.stdin.resume();
+process.stdin.on('end', () => {
+  process.stdout.write(${JSON.stringify(
+    '{"is_error":false,"session_id":"sess-123","result":"{\\"version\\":1}","structured_output":{"version":1}}',
+  )});
+});
+`,
+    );
+    await chmod(fakeClaudePath, 0o755);
+    process.env.CODIFF_CLAUDE_PATH = fakeClaudePath;
+    const sessionIds: Array<string> = [];
+
+    await expect(
+      runClaude(directory, 'prompt', { type: 'object' }, 'walkthrough.json', 'Timed out.', {
+        onSessionId: (sessionId) => sessionIds.push(sessionId),
+        persistSession: true,
+        resumeSessionId: 'sess-abc',
+      }),
+    ).resolves.toBe('{"version":1}');
+
+    const args = (await readFile(argsPath, 'utf8')).trim().split('\n');
+    expect(args).toContain('--resume');
+    expect(args).toContain('sess-abc');
+    expect(args).not.toContain('--no-session-persistence');
+    expect(sessionIds).toEqual(['sess-123']);
   } finally {
     if (previousClaudePath == null) {
       delete process.env.CODIFF_CLAUDE_PATH;

--- a/electron/__tests__/narrative-walkthrough.test.ts
+++ b/electron/__tests__/narrative-walkthrough.test.ts
@@ -423,6 +423,21 @@ test('omits the previous-walkthrough block when none is provided', () => {
   expect(prompt).not.toContain('Previous walkthrough to update:');
 });
 
+test('instructs the agent to order chapters bottom-up by architectural layer', () => {
+  const prompt = buildNarrativeWalkthroughPrompt({
+    branch: 'main',
+    files: files.slice(0, 1),
+    generatedAt: 1,
+    root: '/repo',
+    source: { type: 'working-tree' },
+  });
+
+  expect(prompt).toContain('Ordering contract:');
+  expect(prompt).toContain('Order chapters bottom-up by architectural layer');
+  expect(prompt).toContain('data layer first');
+  expect(prompt).toContain('only club together closely related entities');
+});
+
 test('omits blank custom walkthrough prompt guidance', () => {
   const prompt = buildNarrativeWalkthroughPrompt(
     {

--- a/electron/__tests__/narrative-walkthrough.test.ts
+++ b/electron/__tests__/narrative-walkthrough.test.ts
@@ -346,11 +346,14 @@ test('scales walkthrough timeouts with reviewable files and hunks', () => {
   const mediumTimeout = getNarrativeWalkthroughTimeoutMs(createState(32));
   const largeTimeout = getNarrativeWalkthroughTimeoutMs(createState(100));
 
-  expect(smallTimeout).toBe(90_000);
+  // Every walkthrough gets well over ten minutes so generation (and resumed
+  // regeneration) is not killed prematurely.
+  expect(smallTimeout).toBe(660_000);
+  expect(smallTimeout).toBeGreaterThan(600_000);
   expect(mediumTimeout).toBeGreaterThan(smallTimeout);
-  expect(mediumTimeout).toBeLessThan(300_000);
-  expect(largeTimeout).toBe(300_000);
-  expect(getNarrativeWalkthroughTimeoutMs(createState(4), 180_000)).toBe(180_000);
+  expect(mediumTimeout).toBeLessThan(900_000);
+  expect(largeTimeout).toBe(900_000);
+  expect(getNarrativeWalkthroughTimeoutMs(createState(4), 800_000)).toBe(800_000);
 });
 
 test('prompts generated walkthroughs with custom user guidance without replacing core constraints', () => {
@@ -371,6 +374,53 @@ test('prompts generated walkthroughs with custom user guidance without replacing
   expect(prompt).toContain('Answer in Japanese and use concise reviewer-facing explanations.');
   expect(prompt).toContain('Return JSON only.');
   expect(prompt).toContain('Repository change digest:');
+});
+
+test('passes the previous walkthrough into a regeneration prompt', () => {
+  const prompt = buildNarrativeWalkthroughPrompt(
+    {
+      branch: 'main',
+      files: files.slice(0, 1),
+      generatedAt: 1,
+      root: '/repo',
+      source: { type: 'working-tree' },
+    },
+    null,
+    'Claude Code',
+    undefined,
+    {
+      chapters: [
+        {
+          blurb: 'Entry point',
+          stops: [{ prose: 'Guards against duplicate submits.', title: 'Prevent double submit' }],
+          title: 'Runtime',
+        },
+      ],
+      focus: 'Harden the submit path.',
+      title: 'Submit hardening',
+    },
+  );
+
+  expect(prompt).toContain('Previous walkthrough to update:');
+  expect(prompt).toContain('Prevent double submit');
+  expect(prompt).toContain('Re-anchor every stop to the current digest');
+  expect(prompt).toContain('Repository change digest:');
+});
+
+test('omits the previous-walkthrough block when none is provided', () => {
+  const prompt = buildNarrativeWalkthroughPrompt(
+    {
+      branch: 'main',
+      files: files.slice(0, 1),
+      generatedAt: 1,
+      root: '/repo',
+      source: { type: 'working-tree' },
+    },
+    null,
+    'Codex',
+  );
+
+  expect(prompt).not.toContain('Previous walkthrough to update:');
 });
 
 test('omits blank custom walkthrough prompt guidance', () => {

--- a/electron/__tests__/walkthrough-store.test.ts
+++ b/electron/__tests__/walkthrough-store.test.ts
@@ -1,0 +1,89 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, expect, test } from 'vite-plus/test';
+
+const require = createRequire(import.meta.url);
+
+// os.homedir() honors $HOME on POSIX, so point it at a temp dir to keep the
+// store out of the real ~/.codiff during tests.
+let home = '';
+let previousHome: string | undefined;
+
+beforeEach(() => {
+  previousHome = process.env.HOME;
+  home = mkdtempSync(join(tmpdir(), 'codiff-wt-store-'));
+  process.env.HOME = home;
+});
+
+afterEach(() => {
+  if (previousHome == null) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = previousHome;
+  }
+  rmSync(home, { force: true, recursive: true });
+});
+
+const loadStore = () => {
+  const path = require.resolve('../walkthrough-store.cjs');
+  delete require.cache[path];
+  return require('../walkthrough-store.cjs') as typeof import('../walkthrough-store.cjs');
+};
+
+const sampleWalkthrough = () =>
+  ({
+    agent: 'claude',
+    chapters: [],
+    focus: 'Walk through the change.',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    kind: 'narrative',
+    repo: { branch: 'main', root: '/repo' },
+    source: { type: 'working-tree' },
+    support: [],
+    title: 'Walkthrough',
+    version: 4,
+  }) as never;
+
+test('returns null when no walkthrough is saved', () => {
+  const store = loadStore();
+  expect(store.readStoredWalkthrough('claude:/repo:working-tree')).toBe(null);
+});
+
+test('round-trips a saved walkthrough with its commit and signature', () => {
+  const store = loadStore();
+  const key = 'claude:/repo:working-tree';
+  store.writeStoredWalkthrough(key, {
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    head: 'abc123',
+    sessionId: 'sess-1',
+    signature: 'sig-1',
+    version: 1,
+    walkthrough: sampleWalkthrough(),
+  });
+
+  expect(existsSync(store.getWalkthroughStorePath(key))).toBe(true);
+  const stored = store.readStoredWalkthrough(key);
+  expect(stored?.head).toBe('abc123');
+  expect(stored?.signature).toBe('sig-1');
+  expect(stored?.sessionId).toBe('sess-1');
+  expect(stored?.walkthrough.title).toBe('Walkthrough');
+});
+
+test('keys different repos/sources to different files', () => {
+  const store = loadStore();
+  expect(store.getWalkthroughStorePath('claude:/a:working-tree')).not.toBe(
+    store.getWalkthroughStorePath('claude:/b:working-tree'),
+  );
+});
+
+test('treats a corrupt store file as nothing saved', () => {
+  const store = loadStore();
+  const key = 'claude:/repo:working-tree';
+  const { mkdirSync, writeFileSync } = require('node:fs');
+  const path = store.getWalkthroughStorePath(key);
+  mkdirSync(join(home, '.codiff', 'walkthroughs'), { recursive: true });
+  writeFileSync(path, '{ not json');
+  expect(store.readStoredWalkthrough(key)).toBe(null);
+});

--- a/electron/agent.cjs
+++ b/electron/agent.cjs
@@ -27,7 +27,10 @@ const { readPiSessionContext } = require('./pi-session-context.cjs');
  *   onModelFallback?: (fallbackModel: string, originalModel: string) => Promise<void> | void;
  *   onPartialText?: (delta: string) => void;
  *   onProgress?: (phase: import('../core/types.ts').WalkthroughProgressPhase) => void;
+ *   onSessionId?: (sessionId: string) => void;
+ *   persistSession?: boolean;
  *   reasoningEffort?: 'low' | 'medium' | 'high';
+ *   resumeSessionId?: string;
  *   timeoutMs?: number;
  * }} AgentOptions
  * @typedef {{

--- a/electron/claude.cjs
+++ b/electron/claude.cjs
@@ -26,6 +26,9 @@ const CLAUDE_NOT_LOGGED_IN_MESSAGE =
  *   model?: string;
  *   onModelFallback?: (fallbackModel: string, originalModel: string) => Promise<void> | void;
  *   onProgress?: (phase: import('../core/types.ts').WalkthroughProgressPhase) => void;
+ *   onSessionId?: (sessionId: string) => void;
+ *   persistSession?: boolean;
+ *   resumeSessionId?: string;
  *   timeoutMs?: number;
  * }} ClaudeOptions
  */
@@ -109,6 +112,12 @@ const isClaudeNotLoggedInError = (value) =>
 /** @param {unknown} value @returns {string} */
 const normalizeClaudeModel = (value) =>
   normalizeEnum(value, CLAUDE_MODEL_IDS, DEFAULT_CLAUDE_MODEL);
+
+/** @param {string} value */
+const isClaudeSessionResumeError = (value) =>
+  /\b(?:no conversation found|session .*not found|could not (?:find|load) .*session|no such session|invalid session id)\b/i.test(
+    value,
+  );
 
 /** @param {string} value */
 const isClaudeModelAvailabilityError = (value) =>
@@ -232,8 +241,8 @@ const runClaude = async (
   const fallbackModel = normalizeClaudeModel(options.fallbackModel || FALLBACK_CLAUDE_MODEL);
   const timeoutMs = options.timeoutMs ?? CLAUDE_TIMEOUT_MS;
 
-  /** @param {string} claudeModel @returns {Promise<string>} */
-  const invokeClaude = async (claudeModel) =>
+  /** @param {string} claudeModel @param {string} [resumeSessionId] @returns {Promise<string>} */
+  const invokeClaude = async (claudeModel, resumeSessionId) =>
     /** @type {Promise<string>} */ (
       new Promise((resolve, reject) => {
         let stderr = '';
@@ -257,7 +266,11 @@ const runClaude = async (
           repoRoot,
           '--permission-mode',
           'dontAsk',
-          '--no-session-persistence',
+          // Resuming keeps the prior walkthrough context so regeneration can
+          // update it; a persisted session leaves a transcript we can resume
+          // later. Otherwise stay stateless and leave nothing behind.
+          ...(resumeSessionId ? ['--resume', resumeSessionId] : []),
+          ...(options.persistSession || resumeSessionId ? [] : ['--no-session-persistence']),
           '--tools',
           '',
         ];
@@ -322,6 +335,10 @@ const runClaude = async (
             }
           }
 
+          if (typeof envelope?.session_id === 'string' && envelope.session_id) {
+            options.onSessionId?.(envelope.session_id);
+          }
+
           const resultText = typeof envelope?.result === 'string' ? envelope.result : '';
           if (envelope?.is_error) {
             reject(
@@ -346,15 +363,30 @@ const runClaude = async (
       })
     );
 
+  // A stored session id may be stale (transcript pruned, different machine).
+  // Retry once without resuming rather than failing the whole generation.
+  /** @param {string} claudeModel @returns {Promise<string>} */
+  const invokeWithResume = async (claudeModel) => {
+    try {
+      return await invokeClaude(claudeModel, options.resumeSessionId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (options.resumeSessionId && isClaudeSessionResumeError(message)) {
+        return invokeClaude(claudeModel, undefined);
+      }
+      throw error;
+    }
+  };
+
   try {
-    return await invokeClaude(model);
+    return await invokeWithResume(model);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (model === fallbackModel || !isClaudeModelAvailabilityError(message)) {
       throw error;
     }
 
-    const response = await invokeClaude(fallbackModel);
+    const response = await invokeWithResume(fallbackModel);
     await options.onModelFallback?.(fallbackModel, model);
     return response;
   }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -88,6 +88,8 @@ const {
 } = require('./walkthrough-sharing.cjs');
 const { createCloudflareAccessClient } = require('./cloudflare-access.cjs');
 const { mergeWalkthroughContexts } = require('./walkthrough-context.cjs');
+const { readStoredWalkthrough, writeStoredWalkthrough } = require('./walkthrough-store.cjs');
+const { gitOrEmpty } = require('./git-state/common.cjs');
 const {
   MarkdownDocumentConflictError,
   readMarkdownDocument,
@@ -133,6 +135,11 @@ const windowLaunchOptions = new Map();
 const windowInitialRepositoryStates = new Map();
 /** @type {Map<number, number>} */
 const walkthroughProgressGenerations = new Map();
+// Reuse the agent session that authored a PR's walkthrough so regenerating it
+// resumes the same conversation instead of starting cold. Keyed by agent +
+// repository + review source. Not persisted across app restarts.
+/** @type {Map<string, string>} */
+const walkthroughSessionIds = new Map();
 /** @type {Map<number, string>} */
 const planInitialVersions = new Map();
 /** @type {Set<number>} */
@@ -384,6 +391,94 @@ const getAgentOptions = (agent) => ({
     updateConfig({ settings: { ...config.settings, [agent.modelSettingKey]: fallbackModel } });
   },
 });
+
+/**
+ * Stable key identifying "the walkthrough for this PR" so a regeneration can
+ * reuse the agent session that authored the previous one.
+ * @param {import('./agent.cjs').Agent} agent
+ * @param {string} repositoryPath
+ * @param {ReviewSource} source
+ */
+const getWalkthroughSessionKey = (agent, repositoryPath, source) => {
+  const sourceKey =
+    source.type === 'commit'
+      ? `commit:${source.ref}`
+      : source.type === 'branch-diff'
+        ? `branch-diff:${source.ref}:${source.baseRef}:${source.headRef}`
+        : source.type === 'branch'
+          ? `branch:${source.ref}`
+          : source.type === 'range'
+            ? `range:${source.base}${source.symmetric ? '...' : '..'}${source.head}`
+            : source.type === 'pull-request'
+              ? `pull-request:${source.provider ?? ''}:${source.projectPath ?? `${source.owner ?? ''}/${source.repo ?? ''}`}#${source.number ?? source.url ?? ''}`
+              : 'working-tree';
+  return `${agent.id}:${repositoryPath}:${sourceKey}`;
+};
+
+/**
+ * Compare a saved walkthrough against the current head + working tree so the UI
+ * can report how stale it is.
+ * @param {string} repositoryPath
+ * @param {{ head?: string; signature?: string }} stored
+ * @returns {Promise<import('../core/types.ts').WalkthroughStaleness>}
+ */
+const computeWalkthroughStaleness = async (repositoryPath, stored) => {
+  const generatedHead = typeof stored.head === 'string' && stored.head ? stored.head : null;
+  const current = await readRepositoryChangeSignature(repositoryPath).catch(() => null);
+  const currentHead = current?.head?.trim() || null;
+  const treeMatches = Boolean(
+    current && stored.signature && current.signature === stored.signature,
+  );
+
+  let commitsBehind = 0;
+  let diverged = false;
+  if (generatedHead && currentHead && generatedHead !== currentHead) {
+    const count = (
+      await gitOrEmpty(repositoryPath, ['rev-list', '--count', `${generatedHead}..${currentHead}`])
+    ).trim();
+    if (/^\d+$/.test(count)) {
+      commitsBehind = Number(count);
+      // The generating commit is no longer an ancestor of HEAD (rewritten or a
+      // different branch) when nothing is reachable ahead of it.
+      diverged = commitsBehind === 0;
+    } else {
+      diverged = true;
+    }
+  }
+
+  return {
+    commitsBehind,
+    currentHead,
+    diverged,
+    generatedHead,
+    isLatest: !diverged && commitsBehind === 0 && treeMatches,
+    treeMatches,
+  };
+};
+
+/**
+ * Persist a freshly generated walkthrough plus the head + working-tree signature
+ * it was generated against, so it can be reloaded and staleness-checked later.
+ * @param {string} sessionKey
+ * @param {string} repositoryPath
+ * @param {import('../core/types.ts').NarrativeWalkthrough} walkthrough
+ * @param {string | undefined} sessionId
+ */
+const persistWalkthrough = async (sessionKey, repositoryPath, walkthrough, sessionId) => {
+  try {
+    const signature = await readRepositoryChangeSignature(repositoryPath);
+    writeStoredWalkthrough(sessionKey, {
+      generatedAt: walkthrough.generatedAt || new Date().toISOString(),
+      head: (signature.head || '').trim(),
+      sessionId,
+      signature: signature.signature,
+      version: 1,
+      walkthrough,
+    });
+  } catch {
+    // Persistence is best-effort; a failure must not break generation.
+  }
+};
 
 /** @param {CodiffTheme} theme */
 const updateTheme = (theme) => {
@@ -1496,7 +1591,7 @@ ipcMain.handle('codiff:installTerminalHelper', async (event) => {
   return getTerminalHelperStatus();
 });
 
-ipcMain.handle('codiff:getNarrativeWalkthrough', async (event, source) => {
+ipcMain.handle('codiff:getNarrativeWalkthrough', async (event, source, options) => {
   const launchOptions = windowLaunchOptions.get(event.sender.id);
   const progressGeneration = (walkthroughProgressGenerations.get(event.sender.id) || 0) + 1;
   walkthroughProgressGenerations.set(event.sender.id, progressGeneration);
@@ -1512,6 +1607,15 @@ ipcMain.handle('codiff:getNarrativeWalkthrough', async (event, source) => {
       source || launchOptions?.source,
     );
     const agent = resolveWindowAgent(event.sender.id);
+    const sessionKey = getWalkthroughSessionKey(agent, repositoryPath, state.source);
+    // Seed the resume id from the last saved walkthrough so session reuse
+    // survives an app restart, not just an in-memory run.
+    if (!walkthroughSessionIds.has(sessionKey)) {
+      const stored = readStoredWalkthrough(sessionKey);
+      if (stored?.sessionId) {
+        walkthroughSessionIds.set(sessionKey, stored.sessionId);
+      }
+    }
     const walkthroughFile = launchOptions?.walkthroughFile;
     if (walkthroughFile) {
       let contents;
@@ -1540,16 +1644,25 @@ ipcMain.handle('codiff:getNarrativeWalkthrough', async (event, source) => {
       }
 
       try {
+        const walkthrough = normalizeNarrativeWalkthrough(input, state.files, {
+          agent: agent.id,
+          branch: state.branch,
+          context: sessionContext,
+          generatedAt: state.generatedAt,
+          root: state.root,
+          source: state.source,
+        });
+        await persistWalkthrough(
+          sessionKey,
+          repositoryPath,
+          walkthrough,
+          walkthroughSessionIds.get(sessionKey),
+        );
+        const stored = readStoredWalkthrough(sessionKey);
         return {
+          staleness: stored ? await computeWalkthroughStaleness(repositoryPath, stored) : undefined,
           status: 'ready',
-          walkthrough: normalizeNarrativeWalkthrough(input, state.files, {
-            agent: agent.id,
-            branch: state.branch,
-            context: sessionContext,
-            generatedAt: state.generatedAt,
-            root: state.root,
-            source: state.source,
-          }),
+          walkthrough,
         };
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
@@ -1572,18 +1685,71 @@ ipcMain.handle('codiff:getNarrativeWalkthrough', async (event, source) => {
       launchOptions?.walkthroughContext,
       await agent.readSessionContext(launchOptions?.[agent.sessionLaunchOptionKey]),
     );
-    return readNarrativeWalkthrough(
-      state,
-      agent,
-      { ...getAgentOptions(agent), onProgress: reportProgress },
-      walkthroughContext,
-      config.settings.walkthroughPrompt,
+    // Resume the session that authored this PR's previous walkthrough so a
+    // regeneration updates it in place, and remember whatever session id the
+    // run ends up using for the next regeneration.
+    const result = /** @type {import('../core/types.ts').NarrativeWalkthroughResult} */ (
+      await readNarrativeWalkthrough(
+        state,
+        agent,
+        {
+          ...getAgentOptions(agent),
+          onProgress: reportProgress,
+          onSessionId: (/** @type {string} */ sessionId) =>
+            walkthroughSessionIds.set(sessionKey, sessionId),
+          persistSession: true,
+          resumeSessionId: walkthroughSessionIds.get(sessionKey),
+        },
+        walkthroughContext,
+        config.settings.walkthroughPrompt,
+        options?.previousWalkthrough,
+      )
     );
+
+    if (result.status === 'ready') {
+      // Save the walkthrough with the commit + working-tree signature it was
+      // generated against so reopening Codiff shows it without regenerating.
+      await persistWalkthrough(
+        sessionKey,
+        repositoryPath,
+        result.walkthrough,
+        walkthroughSessionIds.get(sessionKey),
+      );
+      const stored = readStoredWalkthrough(sessionKey);
+      if (stored) {
+        result.staleness = await computeWalkthroughStaleness(repositoryPath, stored);
+      }
+    }
+    return result;
   } catch (error) {
     return {
       reason: error instanceof Error ? error.message : String(error),
       status: 'unavailable',
     };
+  }
+});
+
+// Load the saved walkthrough for a repo + source without regenerating, plus how
+// stale it is relative to the current head/working tree. Returns 'none' when
+// nothing is saved so the renderer can fall back to generating.
+ipcMain.handle('codiff:getWalkthroughStatus', async (event, source) => {
+  try {
+    const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
+    const launchOptions = windowLaunchOptions.get(event.sender.id);
+    const agent = resolveWindowAgent(event.sender.id);
+    const reviewSource = source || launchOptions?.source || { type: 'working-tree' };
+    const sessionKey = getWalkthroughSessionKey(agent, repositoryPath, reviewSource);
+    const stored = readStoredWalkthrough(sessionKey);
+    if (!stored) {
+      return { status: 'none' };
+    }
+    return {
+      staleness: await computeWalkthroughStaleness(repositoryPath, stored),
+      status: 'ready',
+      walkthrough: stored.walkthrough,
+    };
+  } catch {
+    return { status: 'none' };
   }
 });
 

--- a/electron/narrative-walkthrough.cjs
+++ b/electron/narrative-walkthrough.cjs
@@ -46,8 +46,12 @@ const MAX_TOTAL_PATCH_CHARS = 60_000;
 const MAX_LARGE_TOTAL_PATCH_CHARS = 35_000;
 const MAX_SECTION_PATCH_CHARS = 2_500;
 const MAX_LARGE_SECTION_PATCH_CHARS = 700;
-const BASE_WALKTHROUGH_TIMEOUT_MS = 90_000;
-const MAX_WALKTHROUGH_TIMEOUT_MS = 300_000;
+// Walkthrough generation can run a full agent turn (and, on regeneration, a
+// resumed session that re-reads prior context), so allow well over ten minutes
+// before giving up. The base is the floor every generation gets; the max caps
+// the size-based scaling.
+const BASE_WALKTHROUGH_TIMEOUT_MS = 660_000;
+const MAX_WALKTHROUGH_TIMEOUT_MS = 900_000;
 const INCLUDED_WALKTHROUGH_FILES = 8;
 const INCLUDED_WALKTHROUGH_HUNKS = 12;
 const TIMEOUT_MS_PER_EXTRA_FILE = 1_000;
@@ -648,6 +652,46 @@ Use these instructions to customize language, tone, and review detail. If they c
     : '';
 };
 
+/**
+ * A compact, hunk-id-free summary of the walkthrough being replaced. Passed on
+ * regeneration so the agent revises the existing narrative for the new diff
+ * instead of authoring from scratch. Hunk ids are omitted on purpose: the new
+ * request uses fresh request-local aliases, so the model must re-anchor against
+ * the digest below rather than reuse stale ids.
+ * @param {any} previousWalkthrough
+ */
+const buildPreviousWalkthroughInput = (previousWalkthrough) => {
+  if (!previousWalkthrough || typeof previousWalkthrough !== 'object') {
+    return '';
+  }
+
+  const chapters = (Array.isArray(previousWalkthrough.chapters) ? previousWalkthrough.chapters : [])
+    .map((chapter) => ({
+      blurb: oneLine(chapter?.blurb),
+      stops: (Array.isArray(chapter?.stops) ? chapter.stops : []).map((stop) => ({
+        prose: truncate(cleanText(stop?.prose), MAX_PROSE_CHARS),
+        title: oneLine(stop?.title),
+      })),
+      title: oneLine(chapter?.title),
+    }))
+    .filter((chapter) => chapter.title || chapter.stops.length > 0);
+  if (chapters.length === 0) {
+    return '';
+  }
+
+  const summary = {
+    chapters,
+    focus: oneLine(previousWalkthrough.focus),
+    title: oneLine(previousWalkthrough.title),
+  };
+
+  return `Previous walkthrough to update:
+${JSON.stringify(summary)}
+
+The reviewer already has this walkthrough. Re-author it for the CURRENT digest: keep stops that are still accurate (you may reuse their titles and prose), revise prose where the referenced code changed, add stops for new changes, and drop stops whose code is gone. Re-anchor every stop to the current digest's hunk aliases; never reuse ids from the previous walkthrough. Return the full updated walkthrough JSON in the schema above.
+`;
+};
+
 /** @param {RepositoryState} state */
 const getWalkthroughSize = (state) => ({
   fileCount: state.files.length,
@@ -725,7 +769,13 @@ Grouping contract:
 `;
 };
 
-const buildNarrativeWalkthroughRequest = (state, context, agentLabel = 'Codex', customPrompt) => {
+const buildNarrativeWalkthroughRequest = (
+  state,
+  context,
+  agentLabel = 'Codex',
+  customPrompt,
+  previousWalkthrough,
+) => {
   const { hunkIdByAlias, input } = buildPromptInput(state);
   return {
     hunkIdByAlias,
@@ -738,16 +788,31 @@ ${buildWalkthroughSizingGuidance(state)}
 
 ${buildWalkthroughContextInput(context, agentLabel)}
 ${buildCustomPromptInput(customPrompt)}
+${buildPreviousWalkthroughInput(previousWalkthrough)}
 Repository change digest:
 ${JSON.stringify(input)}
 `,
   };
 };
 
-const buildNarrativeWalkthroughPrompt = (state, context, agentLabel = 'Codex', customPrompt) =>
-  buildNarrativeWalkthroughRequest(state, context, agentLabel, customPrompt).prompt;
+const buildNarrativeWalkthroughPrompt = (
+  state,
+  context,
+  agentLabel = 'Codex',
+  customPrompt,
+  previousWalkthrough,
+) =>
+  buildNarrativeWalkthroughRequest(state, context, agentLabel, customPrompt, previousWalkthrough)
+    .prompt;
 
-const readNarrativeWalkthrough = async (state, agent, agentOptions, context, customPrompt) => {
+const readNarrativeWalkthrough = async (
+  state,
+  agent,
+  agentOptions,
+  context,
+  customPrompt,
+  previousWalkthrough,
+) => {
   try {
     const timeoutMs = getNarrativeWalkthroughTimeoutMs(state, agent.defaultTimeoutMs);
     const { fileCount, hunkCount } = getWalkthroughSize(state);
@@ -756,6 +821,7 @@ const readNarrativeWalkthrough = async (state, agent, agentOptions, context, cus
       context,
       agent.label,
       customPrompt,
+      previousWalkthrough,
     );
     agentOptions?.onProgress?.('agent-generation');
     const response = await agent.run(

--- a/electron/narrative-walkthrough.cjs
+++ b/electron/narrative-walkthrough.cjs
@@ -752,10 +752,15 @@ const buildWalkthroughSizingGuidance = (state) => {
 - Use stable item ids like s1, s2, ... for main stops. Do not invent hunk ids.
 - Default to one review idea per stop. Include multiple hunkIds when the hunks implement the same idea, especially in small diffs.
 
+Ordering contract:
+- Order chapters bottom-up by architectural layer, following the change from the root of the stack toward the surface: data layer first (database schema, migrations, SQL), then domain models/entities, then repositories/data access, then services/business logic, then API (handlers, routes, controllers, resolvers), then UI (components, views, styles), and finally peripheral changes (config, build/tooling, tests, docs).
+- Skip layers this diff does not touch, but keep the remaining layers in that bottom-up order. Order stops within and across chapters the same way.
+- Within a single layer, only club together closely related entities — hunks for the same entity or feature (e.g. one model and its repository, or one endpoint and its request/response types). Do not put unrelated entities in the same chapter or stop just because they share a layer; give each distinct entity its own stop.
+
 Grouping contract:
 - Target ${targetStops} main-path stops and at most ${MAX_WALKTHROUGH_STOPS}. Prefer the low end when it still preserves distinct state transitions, submission paths, or runtime contracts.
 - Use ${targetChapterInstruction}. A chapter is a conceptual group, not a file. For one- or two-file diffs, prefer one chapter unless there are clearly separate review phases.
-- Chapter titles render in a compact top bar: keep each title to 1-2 short words and at most 16 characters, e.g. "UI", "CLI", "Tests", "Docs", "Runtime", "Cleanup".
+- Chapter titles render in a compact top bar: keep each title to 1-2 short words and at most 16 characters, and prefer naming the layer, e.g. "DB", "Model", "Service", "API", "UI", "Tests".
 - Every stop must have a concise semantic title that names the review idea in roughly 2-6 words, e.g. "Prevent duplicate payments" or "Preserve offline drafts". Never use a filename or path as a stop title.
 - A stop may contain at most ${MAX_HUNKS_PER_WALKTHROUGH_GROUP} hunkIds. Use multiple hunkIds when the prose needs those hunks read together to understand one invariant, behavior, or repeated pattern.
 - Generated-like files have "generated": true and one synthetic hunk per changed section. Never split them; main-path them only when they explain behavior, like snapshots proving output.

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -35,7 +35,9 @@ const codiff = {
     ipcRenderer.invoke('codiff:getRepositoryHistory', limit, source),
   getRepositoryState: (source) => ipcRenderer.invoke('codiff:getRepositoryState', source),
   getTerminalHelperStatus: () => ipcRenderer.invoke('codiff:getTerminalHelperStatus'),
-  getNarrativeWalkthrough: (source) => ipcRenderer.invoke('codiff:getNarrativeWalkthrough', source),
+  getNarrativeWalkthrough: (source, options) =>
+    ipcRenderer.invoke('codiff:getNarrativeWalkthrough', source, options),
+  getWalkthroughStatus: (source) => ipcRenderer.invoke('codiff:getWalkthroughStatus', source),
   installAgentSkill: () => ipcRenderer.invoke('codiff:installAgentSkill'),
   installTerminalHelper: () => ipcRenderer.invoke('codiff:installTerminalHelper'),
   increaseCodeFontSize: () => ipcRenderer.invoke('codiff:increaseCodeFontSize'),

--- a/electron/walkthrough-store.cjs
+++ b/electron/walkthrough-store.cjs
@@ -1,0 +1,85 @@
+// @ts-check
+
+// Persist the most recently generated narrative walkthrough for a repository +
+// review source so reopening Codiff shows the same walkthrough instantly instead
+// of regenerating. Stored under ~/.codiff/walkthroughs/ keyed by a hash of the
+// caller-supplied key (agent + repo root + source), alongside the git commit and
+// working-tree signature it was generated against so staleness can be reported.
+
+const { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } = require('node:fs');
+const { createHash } = require('node:crypto');
+const { homedir } = require('node:os');
+const { join } = require('node:path');
+
+/**
+ * @typedef {import('../core/types.ts').NarrativeWalkthrough} NarrativeWalkthrough
+ * @typedef {{
+ *   version: 1;
+ *   walkthrough: NarrativeWalkthrough;
+ *   head: string;
+ *   signature: string;
+ *   generatedAt: string;
+ *   sessionId?: string;
+ * }} StoredWalkthrough
+ */
+
+// Guard against a corrupt/huge file blocking startup.
+const MAX_STORED_WALKTHROUGH_BYTES = 8 * 1024 * 1024;
+
+const getWalkthroughStoreDir = () => join(homedir(), '.codiff', 'walkthroughs');
+
+/** @param {string} key */
+const getWalkthroughStorePath = (key) =>
+  join(getWalkthroughStoreDir(), `${createHash('sha256').update(key).digest('hex')}.json`);
+
+/**
+ * @param {string} key
+ * @returns {StoredWalkthrough | null}
+ */
+const readStoredWalkthrough = (key) => {
+  const path = getWalkthroughStorePath(key);
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    const text = readFileSync(path, 'utf8');
+    if (text.length > MAX_STORED_WALKTHROUGH_BYTES) {
+      return null;
+    }
+    const parsed = JSON.parse(text);
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      !parsed.walkthrough ||
+      typeof parsed.walkthrough !== 'object'
+    ) {
+      return null;
+    }
+    return /** @type {StoredWalkthrough} */ (parsed);
+  } catch {
+    // A malformed or unreadable store is treated as "nothing saved".
+    return null;
+  }
+};
+
+/**
+ * @param {string} key
+ * @param {StoredWalkthrough} value
+ */
+const writeStoredWalkthrough = (key, value) => {
+  const dir = getWalkthroughStoreDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const path = getWalkthroughStorePath(key);
+  // Write to a temp file and rename so a crash never leaves a half-written store.
+  const tempPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tempPath, JSON.stringify(value));
+  renameSync(tempPath, path);
+};
+
+module.exports = {
+  getWalkthroughStorePath,
+  readStoredWalkthrough,
+  writeStoredWalkthrough,
+};


### PR DESCRIPTION
Timeout & sessions:
- Raise the walkthrough generation timeout well past ten minutes so large diffs (and resumed regenerations) are not killed early.
- Generate walkthroughs in a persistent, resumable Claude session; a PR's regeneration resumes the same session and passes the previous walkthrough so the model updates it in place. Session id is stored per repo + source.

Persistence & staleness:
- Persist the last walkthrough to ~/.codiff/walkthroughs along with the commit and working-tree signature it was generated against.
- On open, show the saved walkthrough instead of regenerating (both on launch and when opening the walkthrough tab); only generate when none is saved.
- Show how stale the saved walkthrough is (latest / N commits behind / diverged / working tree changed) with a Sync/Regenerate button in the walkthrough panel.

UI:
- Add a refresh button to the PR/source bar.