### PR TITLE
Don't replace comment drafts that have unflushed content

### DIFF
--- a/core/App.tsx
+++ b/core/App.tsx
@@ -2179,9 +2179,15 @@ export default function App() {
         return;
       }
 
-      const emptyDraft = reviewCommentsRef.current.find(
-        (candidate) => !candidate.isReadOnly && candidate.body.length === 0,
-      );
+      const activeDraft = activeReviewCommentDraftRef.current;
+      const emptyDraft = reviewCommentsRef.current.find((candidate) => {
+        if (candidate.isReadOnly || candidate.body.length > 0) {
+          return false;
+        }
+        const hasUnflushedContent =
+          activeDraft?.id === candidate.id && activeDraft.body.trim().length > 0;
+        return !hasUnflushedContent;
+      });
       if (emptyDraft) {
         const id = crypto.randomUUID();
         setFocusCommentId(id);


### PR DESCRIPTION
I've run into this several times where I lose a comment I was writing. If you type in a review comment and then click the "+" gutter button on a different line, the first comment gets replaced and the typed text vanishes.

The draft text lives in local component state until `flushDraft` runs on blur. Clicking a line normally triggers blur, so that path works fine. But Claude helped me figure out that the "+" gutter button goes through `@pierre/diffs`' pointer gesture handling, which suppresses the blur — so `flushDraft` never runs and `createComment` sees the comment as empty.

`activeReviewCommentDraftRef` already tracks the in-flight draft body on every keystroke. This checks it before treating a comment as reusable.