### PR TITLE
fix: prevent walkthrough comment layout loop

### DIFF
--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -22,6 +22,9 @@ import {
 
 const markdownEditorMock = vi.hoisted(() => ({
   flush: vi.fn<() => Promise<boolean>>(async () => true),
+  heightByAriaLabel: new Map<string, number>(),
+  heightReportLimit: Number.POSITIVE_INFINITY,
+  heightReports: 0,
 }));
 
 vi.mock('../app/components/MarkdownDocumentEditor.tsx', async () => {
@@ -69,8 +72,14 @@ vi.mock('@nkzw/mdx-editor', async () => {
         focus: () => inputRef.current?.focus(),
       }));
       React.useEffect(() => {
-        onHeightChange?.(100);
-      }, [onHeightChange]);
+        if (
+          onHeightChange &&
+          markdownEditorMock.heightReports < markdownEditorMock.heightReportLimit
+        ) {
+          markdownEditorMock.heightReports += 1;
+          onHeightChange(markdownEditorMock.heightByAriaLabel.get(props.ariaLabel ?? '') ?? 100);
+        }
+      }, [onHeightChange, props.ariaLabel]);
       return (
         <textarea
           aria-label={props.ariaLabel}
@@ -96,6 +105,9 @@ beforeEach(() => {
   resetCodeViewMock();
   markdownEditorMock.flush.mockClear();
   markdownEditorMock.flush.mockResolvedValue(true);
+  markdownEditorMock.heightByAriaLabel.clear();
+  markdownEditorMock.heightReportLimit = Number.POSITIVE_INFINITY;
+  markdownEditorMock.heightReports = 0;
 });
 
 const getCodeViewItemVersion = (id: string) =>
@@ -1285,6 +1297,46 @@ test('review comment typing stays local until a comment action commits it', asyn
       await act(async () => root?.unmount());
     }
     container.remove();
+  }
+});
+
+test('a Codex reply does not repeatedly invalidate the diff item layout', async () => {
+  const file = createChangedFile('src/comment.ts');
+  const comment = {
+    body: 'Please explain this change.',
+    filePath: file.path,
+    id: 'comment-1',
+    lineNumber: 1,
+    sectionId: 'src/comment.ts:unstaged',
+    side: 'additions',
+  } satisfies ReviewComment;
+  markdownEditorMock.heightByAriaLabel.set('Comment on src/comment.ts New line 1', 100);
+  markdownEditorMock.heightByAriaLabel.set('Codex reply', 320);
+  markdownEditorMock.heightReportLimit = 6;
+  const view = await renderReact(<ReviewCodeViewHarness comments={[comment]} files={[file]} />);
+
+  try {
+    const renderCountBeforeReply = codeViewMock.renderCount;
+
+    await view.rerender(
+      <ReviewCodeViewHarness
+        comments={[
+          {
+            ...comment,
+            codexReply: {
+              body: 'This reply is tall enough to use a different markdown measurement.',
+              status: 'ready',
+            },
+          },
+        ]}
+        files={[file]}
+      />,
+    );
+
+    expect(view.container.querySelector('[aria-label="Codex reply"]')).not.toBeNull();
+    expect(codeViewMock.renderCount).toBe(renderCountBeforeReply + 1);
+  } finally {
+    await view.cleanup();
   }
 });
 

--- a/core/__tests__/helpers/review-code-view.tsx
+++ b/core/__tests__/helpers/review-code-view.tsx
@@ -11,6 +11,7 @@ const codeViewMockState = vi.hoisted(() => ({
   lastItems: [] as ReadonlyArray<{ id: string; type: string; version?: unknown }>,
   lastOptions: null as Record<string, unknown> | null,
   postRenderNodes: [] as Array<HTMLElement>,
+  renderCount: 0,
   scrollTo: vi.fn(),
 }));
 export const codeViewMock = codeViewMockState;
@@ -19,6 +20,7 @@ export const resetCodeViewMock = () => {
   codeViewMock.lastItems = [];
   codeViewMock.lastOptions = null;
   codeViewMock.postRenderNodes = [];
+  codeViewMock.renderCount = 0;
   codeViewMock.scrollTo.mockClear();
 };
 
@@ -54,6 +56,7 @@ vi.mock('@pierre/diffs/react', async () => {
       const scrollTopRef = React.useRef(0);
 
       React.useLayoutEffect(() => {
+        codeViewMock.renderCount += 1;
         itemsRef.current = props.items;
         codeViewMock.lastItems = props.items;
         codeViewMock.lastOptions = props.options ?? null;

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -1276,7 +1276,6 @@ function ReviewCommentEditor({
   onCommentDraftChange,
   onCommentFocus,
   onDeleteComment,
-  onHeightChange,
   onSaveCommentEdit,
   onSubmitComment,
   onUpdateComment,
@@ -1295,7 +1294,6 @@ function ReviewCommentEditor({
   onCommentDraftChange?: (comment: Pick<ReviewComment, 'body' | 'id'> | null) => void;
   onCommentFocus: (comment: ReviewComment) => void;
   onDeleteComment: (commentId: string) => void;
-  onHeightChange: () => void;
   onSaveCommentEdit: (commentId: string, body: string) => Promise<void> | void;
   onSubmitComment: (commentId: string) => void;
   onUpdateComment: (commentId: string, body: string) => void;
@@ -1585,21 +1583,6 @@ function ReviewCommentEditor({
       onDeleteComment,
     ],
   );
-  const previousHeightRef = useRef<number | null>(null);
-  const handleHeightChange = useCallback(
-    (height: number) => {
-      if (previousHeightRef.current == null) {
-        previousHeightRef.current = height;
-        return;
-      }
-      if (previousHeightRef.current !== height) {
-        previousHeightRef.current = height;
-        onHeightChange();
-      }
-    },
-    [onHeightChange],
-  );
-
   return (
     <Fragment>
       <div className="review-comment">
@@ -1723,7 +1706,6 @@ function ReviewCommentEditor({
                     className="review-comment-markdown-editor"
                     contentClassName="review-comment-input read-only"
                     fallback={<div className="review-comment-input read-only" />}
-                    onHeightChange={handleHeightChange}
                     value={displayedBody}
                     variant="embedded"
                   />
@@ -1740,7 +1722,6 @@ function ReviewCommentEditor({
                       className="review-comment-markdown-editor review-comment-edit-preview"
                       contentClassName="review-comment-input read-only"
                       fallback={<div className="review-comment-input read-only" />}
-                      onHeightChange={handleHeightChange}
                       value={displayedBody}
                       variant="embedded"
                     />
@@ -1755,7 +1736,6 @@ function ReviewCommentEditor({
                       contentClassName="review-comment-input"
                       density="compact"
                       onChange={handleEditDraftChange}
-                      onHeightChange={handleHeightChange}
                       onKeyDown={handleEditKeyDown}
                       readOnly={editSubmitting}
                       ref={setEditEditorRef}
@@ -1774,7 +1754,6 @@ function ReviewCommentEditor({
               className="review-comment-markdown-editor"
               contentClassName="review-comment-input read-only"
               fallback={<div className="review-comment-input read-only" />}
-              onHeightChange={handleHeightChange}
               value={displayedBody}
               variant="embedded"
             />
@@ -1789,7 +1768,6 @@ function ReviewCommentEditor({
                 onBlur={handleBlur}
                 onChange={handleChange}
                 onFocus={handleFocus}
-                onHeightChange={handleHeightChange}
                 onKeyDown={handleKeyDown}
                 placeholder="Write a review comment…"
                 ref={comment.id === focusCommentId ? focusEditorRef : undefined}
@@ -1823,7 +1801,6 @@ function ReviewCommentEditor({
                   ariaLabel={`${agentLabel} reply`}
                   className="review-comment-codex-reply-markdown"
                   density="compact"
-                  onHeightChange={handleHeightChange}
                   value={comment.codexReply.body ?? comment.codexReply.error ?? ''}
                   variant="embedded"
                 />
@@ -1878,7 +1855,6 @@ function ReviewCommentThreadGroup({
   onCommentDraftChange,
   onCommentFocus,
   onDeleteComment,
-  onHeightChange,
   onReplyToThread,
   onResolveThread = noopResolveThread,
   onSaveCommentEdit,
@@ -1898,7 +1874,6 @@ function ReviewCommentThreadGroup({
   onCommentDraftChange?: (comment: Pick<ReviewComment, 'body' | 'id'> | null) => void;
   onCommentFocus: (comment: ReviewComment) => void;
   onDeleteComment: (commentId: string) => void;
-  onHeightChange: () => void;
   onReplyToThread: (threadId: string, comment: ReviewComment) => void;
   onResolveThread?: (threadId: string, resolved: boolean) => Promise<void> | void;
   onSaveCommentEdit: (commentId: string, body: string) => Promise<void> | void;
@@ -1975,7 +1950,6 @@ function ReviewCommentThreadGroup({
             onCommentDraftChange={onCommentDraftChange}
             onCommentFocus={onCommentFocus}
             onDeleteComment={onDeleteComment}
-            onHeightChange={onHeightChange}
             onSaveCommentEdit={onSaveCommentEdit}
             onSubmitComment={onSubmitComment}
             onUpdateComment={onUpdateComment}
@@ -2054,6 +2028,7 @@ function ReviewAnnotation({
   onUpdateComment: (commentId: string, body: string) => void;
 }) {
   const focusEditorRef = useRef<MarkdownEditorHandle>(null);
+  const threadRef = useRef<HTMLDivElement>(null);
   const setFocusEditorRef = useCallback((node: MarkdownEditorHandle | null) => {
     focusEditorRef.current = node;
   }, []);
@@ -2069,13 +2044,32 @@ function ReviewAnnotation({
     }
   }, [focusCommentId, focusCommentRequest, hasFocusedComment]);
 
+  // Observe the whole thread so independent markdown blocks cannot invalidate each other.
+  useLayoutEffect(() => {
+    const thread = threadRef.current;
+    if (!thread) {
+      return;
+    }
+
+    let height = thread.getBoundingClientRect().height;
+    const observer = new ResizeObserver(() => {
+      const nextHeight = thread.getBoundingClientRect().height;
+      if (height !== nextHeight) {
+        height = nextHeight;
+        onHeightChange();
+      }
+    });
+    observer.observe(thread);
+    return () => observer.disconnect();
+  }, [annotationComments.length, onHeightChange]);
+
   if (annotationComments.length === 0) {
     return null;
   }
   const commentGroups = groupReviewCommentsByThread(annotationComments);
 
   return (
-    <div className="review-comment-thread">
+    <div className="review-comment-thread" ref={threadRef}>
       {commentGroups.map((group) => (
         <ReviewCommentThreadGroup
           agentId={agentId}
@@ -2092,7 +2086,6 @@ function ReviewAnnotation({
           onCommentDraftChange={onCommentDraftChange}
           onCommentFocus={onCommentFocus}
           onDeleteComment={onDeleteComment}
-          onHeightChange={onHeightChange}
           onReplyToThread={onReplyToThread}
           onResolveThread={onResolveThread}
           onSaveCommentEdit={onSaveCommentEdit}


### PR DESCRIPTION
The walkthrough can enter a continuous layout invalidation loop after a Codex reply is added to a review comment. The comment editor and reply independently report different heights through one shared tracker, repeatedly rerendering the virtualized diff and blocking scrolling.

This PR observes the aggregate review thread instead, so its diff item is invalidated only when the thread's actual height changes. It also adds regression coverage for a tall Codex reply.

🤖 Generated with Codex
