### PR TITLE
Add simple diff mode to the codiff skill

### DIFF
--- a/claude/skills/codiff/SKILL.md
+++ b/claude/skills/codiff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codiff
-description: Open Codiff for a narrative code walkthrough, a blocking plan handoff, or a shared walkthrough URL. Use when the user writes "$codiff", "/codiff", "$codiff plan", "$codiff share", "show me codiff", "open Codiff", or asks to review a change or edit a plan in Codiff.
+description: Open Codiff for a narrative code walkthrough, a plain diff view, a blocking plan handoff, or a shared walkthrough URL. Use when the user writes "$codiff", "/codiff", "$codiff diff", "$codiff plan", "$codiff share", "show me codiff", "open Codiff", or asks to review a change or edit a plan in Codiff.
 metadata:
   short-description: Review code or hand off a plan in Codiff
 ---
@@ -23,6 +23,8 @@ change. Codiff owns the format and authoring guidance, so this skill only handle
 - Use **plan mode** for `$codiff plan` or when the user explicitly asks to edit or approve a
   plan in Codiff before execution.
 - Use **desktop mode** for plain `$codiff`, `/codiff`, "open Codiff", or "show me Codiff".
+- Use **simple diff mode** for `$codiff diff`, or when the user asks for the plain diff, the raw
+  diff, "just the diff", or a diff view without a narrative walkthrough.
 - In share mode, only pass `--open` when the user explicitly asks to open the resulting share in
   a browser. Otherwise return the URL without opening it.
 
@@ -73,6 +75,27 @@ approval document.
 
 3. Add `--open` only when the user explicitly asks to open the shared plan in a browser.
 4. Return only the `/p/…` URL printed by the command.
+
+## Simple Diff Mode
+
+Open Codiff's plain diff viewer with no narrative walkthrough. There is nothing to author — just
+launch it:
+
+```bash
+node scripts/open-codiff.mjs --diff
+```
+
+By default this reviews the staged and unstaged changes in the session's repository. Forward an
+explicit target after the flag when the user names one — a commit, `HEAD`, a branch, a PR/MR, a
+range, or a repository path:
+
+```bash
+node scripts/open-codiff.mjs --diff HEAD
+node scripts/open-codiff.mjs --diff main /path/to/repository
+node scripts/open-codiff.mjs --diff '#75'
+```
+
+This mode does not author or share JSON. Do not summarize the diff back to the user after opening it.
 
 ## Walkthrough Workflow
 

--- a/claude/skills/codiff/scripts/open-codiff.mjs
+++ b/claude/skills/codiff/scripts/open-codiff.mjs
@@ -7,6 +7,9 @@
 // Usage:
 //   node scripts/open-codiff.mjs --file <path> [target]
 //   node scripts/open-codiff.mjs --plan <path> [repository]
+//   node scripts/open-codiff.mjs --diff [target] [repository]
+//
+// `--diff` opens Codiff's plain diff viewer with no narrative walkthrough.
 //
 // `--file <path>` is forwarded to Codiff as `--walkthrough-file`. Any non-flag target
 // (commit, HEAD, PR number, or repository path) is forwarded verbatim; when no repository
@@ -232,6 +235,7 @@ const forwardedArgs = [];
 let openSharedWalkthrough = false;
 let planFile = '';
 let shareWalkthrough = false;
+let simpleDiff = false;
 let walkthroughFile = '';
 for (let index = 0; index < rawArgs.length; index += 1) {
   const arg = rawArgs[index];
@@ -261,11 +265,41 @@ for (let index = 0; index < rawArgs.length; index += 1) {
     openSharedWalkthrough = true;
     continue;
   }
+  if (arg === '--diff') {
+    simpleDiff = true;
+    continue;
+  }
   forwardedArgs.push(arg);
 }
 
 const sessionCwd =
   process.env.CLAUDE_SESSION_CWD || readSessionCwd(threadId) || getFallbackSessionCwd();
+
+// `--diff`: open Codiff's plain diff viewer. No walkthrough JSON is authored; any
+// forwarded target (commit, HEAD, branch, PR/MR, range, or path) is passed verbatim.
+if (simpleDiff) {
+  const hasRepositoryTarget = forwardedArgs.some(
+    (arg) => !arg.startsWith('-') && existsSync(resolve(sessionCwd, arg)),
+  );
+  const codiffCommand = getCodiffCommand();
+  const result = spawnSync(
+    codiffCommand.command,
+    [
+      ...codiffCommand.args,
+      '--agent',
+      'claude',
+      ...(threadId ? ['--claude-session', threadId] : []),
+      ...forwardedArgs,
+      ...(hasRepositoryTarget ? [] : [sessionCwd]),
+    ],
+    { cwd: sessionCwd, encoding: 'utf8', stdio: 'inherit' },
+  );
+  if (result.error) {
+    process.stderr.write(`${result.error.message}\n`);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 0);
+}
 
 if (planFile && shareWalkthrough) {
   const planFilePath = resolve(sessionCwd, planFile);

--- a/codex/skills/codiff/SKILL.md
+++ b/codex/skills/codiff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codiff
-description: Open Codiff for a narrative code walkthrough, a blocking plan handoff, or a shared walkthrough URL. Use when the user writes "$codiff", "/codiff", "$codiff plan", "$codiff share", "show me codiff", "open Codiff", or asks to review a change or edit a plan in Codiff.
+description: Open Codiff for a narrative code walkthrough, a plain diff view, a blocking plan handoff, or a shared walkthrough URL. Use when the user writes "$codiff", "/codiff", "$codiff diff", "$codiff plan", "$codiff share", "show me codiff", "open Codiff", or asks to review a change or edit a plan in Codiff.
 metadata:
   short-description: Review code or hand off a plan in Codiff
 ---
@@ -23,6 +23,8 @@ change. Codiff owns the format and authoring guidance, so this skill only handle
 - Use **plan mode** for `$codiff plan` or when the user explicitly asks to edit or approve a
   plan in Codiff before execution.
 - Use **desktop mode** for plain `$codiff`, `/codiff`, "open Codiff", or "show me Codiff".
+- Use **simple diff mode** for `$codiff diff`, or when the user asks for the plain diff, the raw
+  diff, "just the diff", or a diff view without a narrative walkthrough.
 - In share mode, only pass `--open` when the user explicitly asks to open the resulting share in
   a browser. Otherwise return the URL without opening it.
 
@@ -73,6 +75,27 @@ approval document.
 
 3. Add `--open` only when the user explicitly asks to open the shared plan in a browser.
 4. Return only the `/p/…` URL printed by the command.
+
+## Simple Diff Mode
+
+Open Codiff's plain diff viewer with no narrative walkthrough. There is nothing to author — just
+launch it:
+
+```bash
+node scripts/open-codiff.mjs --diff
+```
+
+By default this reviews the staged and unstaged changes in the session's repository. Forward an
+explicit target after the flag when the user names one — a commit, `HEAD`, a branch, a PR/MR, a
+range, or a repository path:
+
+```bash
+node scripts/open-codiff.mjs --diff HEAD
+node scripts/open-codiff.mjs --diff main /path/to/repository
+node scripts/open-codiff.mjs --diff '#75'
+```
+
+This mode does not author or share JSON. Do not summarize the diff back to the user after opening it.
 
 ## Walkthrough Workflow
 

--- a/codex/skills/codiff/scripts/open-codiff.mjs
+++ b/codex/skills/codiff/scripts/open-codiff.mjs
@@ -7,6 +7,9 @@
 // Usage:
 //   node scripts/open-codiff.mjs --file <path> [target]
 //   node scripts/open-codiff.mjs --plan <path> [repository]
+//   node scripts/open-codiff.mjs --diff [target] [repository]
+//
+// `--diff` opens Codiff's plain diff viewer with no narrative walkthrough.
 //
 // `--file <path>` is forwarded to Codiff as `--walkthrough-file`. Any non-flag target
 // (commit, HEAD, PR number, or repository path) is forwarded verbatim; when no repository
@@ -237,6 +240,7 @@ const forwardedArgs = [];
 let openSharedWalkthrough = false;
 let planFile = '';
 let shareWalkthrough = false;
+let simpleDiff = false;
 let walkthroughFile = '';
 for (let index = 0; index < rawArgs.length; index += 1) {
   const arg = rawArgs[index];
@@ -266,11 +270,41 @@ for (let index = 0; index < rawArgs.length; index += 1) {
     openSharedWalkthrough = true;
     continue;
   }
+  if (arg === '--diff') {
+    simpleDiff = true;
+    continue;
+  }
   forwardedArgs.push(arg);
 }
 
 const sessionCwd =
   process.env.CODEX_SESSION_CWD || readSessionCwd(threadId) || getFallbackSessionCwd();
+
+// `--diff`: open Codiff's plain diff viewer. No walkthrough JSON is authored; any
+// forwarded target (commit, HEAD, branch, PR/MR, range, or path) is passed verbatim.
+if (simpleDiff) {
+  const hasRepositoryTarget = forwardedArgs.some(
+    (arg) => !arg.startsWith('-') && existsSync(resolve(sessionCwd, arg)),
+  );
+  const codiffCommand = getCodiffCommand();
+  const result = spawnSync(
+    codiffCommand.command,
+    [
+      ...codiffCommand.args,
+      '--agent',
+      'codex',
+      ...(threadId ? ['--codex-session', threadId] : []),
+      ...forwardedArgs,
+      ...(hasRepositoryTarget ? [] : [sessionCwd]),
+    ],
+    { cwd: sessionCwd, encoding: 'utf8', stdio: 'inherit' },
+  );
+  if (result.error) {
+    process.stderr.write(`${result.error.message}\n`);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 0);
+}
 
 if (planFile && shareWalkthrough) {
   const planFilePath = resolve(sessionCwd, planFile);

--- a/opencode/skills/codiff/SKILL.md
+++ b/opencode/skills/codiff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codiff
-description: Open Codiff for a narrative code walkthrough, a blocking plan handoff, or a shared walkthrough URL. Use when the user writes "$codiff", "/codiff", "$codiff plan", "$codiff share", "show me codiff", "open Codiff", or asks to review a change or edit a plan in Codiff.
+description: Open Codiff for a narrative code walkthrough, a plain diff view, a blocking plan handoff, or a shared walkthrough URL. Use when the user writes "$codiff", "/codiff", "$codiff diff", "$codiff plan", "$codiff share", "show me codiff", "open Codiff", or asks to review a change or edit a plan in Codiff.
 metadata:
   short-description: Review code or hand off a plan in Codiff
 ---
@@ -23,6 +23,8 @@ change. Codiff owns the format and authoring guidance, so this skill only handle
 - Use **plan mode** for `$codiff plan` or when the user explicitly asks to edit or approve a
   plan in Codiff before execution.
 - Use **desktop mode** for plain `$codiff`, `/codiff`, "open Codiff", or "show me Codiff".
+- Use **simple diff mode** for `$codiff diff`, or when the user asks for the plain diff, the raw
+  diff, "just the diff", or a diff view without a narrative walkthrough.
 - In share mode, only pass `--open` when the user explicitly asks to open the resulting share in
   a browser. Otherwise return the URL without opening it.
 
@@ -73,6 +75,27 @@ approval document.
 
 3. Add `--open` only when the user explicitly asks to open the shared plan in a browser.
 4. Return only the `/p/…` URL printed by the command.
+
+## Simple Diff Mode
+
+Open Codiff's plain diff viewer with no narrative walkthrough. There is nothing to author — just
+launch it:
+
+```bash
+node scripts/open-codiff.mjs --diff
+```
+
+By default this reviews the staged and unstaged changes in the session's repository. Forward an
+explicit target after the flag when the user names one — a commit, `HEAD`, a branch, a PR/MR, a
+range, or a repository path:
+
+```bash
+node scripts/open-codiff.mjs --diff HEAD
+node scripts/open-codiff.mjs --diff main /path/to/repository
+node scripts/open-codiff.mjs --diff '#75'
+```
+
+This mode does not author or share JSON. Do not summarize the diff back to the user after opening it.
 
 ## Walkthrough Workflow
 

--- a/opencode/skills/codiff/scripts/open-codiff.mjs
+++ b/opencode/skills/codiff/scripts/open-codiff.mjs
@@ -6,6 +6,9 @@
 // Usage:
 //   node scripts/open-codiff.mjs --file <path> [target]
 //   node scripts/open-codiff.mjs --plan <path> [repository]
+//   node scripts/open-codiff.mjs --diff [target] [repository]
+//
+// `--diff` opens Codiff's plain diff viewer with no narrative walkthrough.
 //
 // `--file <path>` is forwarded to Codiff as `--walkthrough-file`. Any non-flag
 // target is forwarded verbatim; when no repository path is given, the current
@@ -208,6 +211,7 @@ const forwardedArgs = [];
 let openSharedWalkthrough = false;
 let planFile = '';
 let shareWalkthrough = false;
+let simpleDiff = false;
 let walkthroughFile = '';
 for (let index = 0; index < rawArgs.length; index += 1) {
   const arg = rawArgs[index];
@@ -237,10 +241,45 @@ for (let index = 0; index < rawArgs.length; index += 1) {
     openSharedWalkthrough = true;
     continue;
   }
+  if (arg === '--diff') {
+    simpleDiff = true;
+    continue;
+  }
   forwardedArgs.push(arg);
 }
 
 const sessionCwd = getSessionCwd();
+
+// `--diff`: open Codiff's plain diff viewer. No walkthrough JSON is authored; any
+// forwarded target (commit, HEAD, branch, PR/MR, range, or path) is passed verbatim.
+if (simpleDiff) {
+  const hasRepositoryTarget = forwardedArgs.some(
+    (arg) => !arg.startsWith('-') && existsSync(resolve(sessionCwd, arg)),
+  );
+  const environmentSessionId = process.env.OPENCODE_SESSION_ID || '';
+  const sessionId =
+    (sessionIdPattern.test(environmentSessionId) ? environmentSessionId : '') ||
+    findOpenCodeSessionIdForCwd(sessionCwd) ||
+    '';
+  const codiffCommand = getCodiffCommand();
+  const result = spawnSync(
+    codiffCommand.command,
+    [
+      ...codiffCommand.args,
+      '--agent',
+      'opencode',
+      ...(sessionId ? ['--opencode-session', sessionId] : []),
+      ...forwardedArgs,
+      ...(hasRepositoryTarget ? [] : [sessionCwd]),
+    ],
+    { cwd: sessionCwd, encoding: 'utf8', stdio: 'inherit' },
+  );
+  if (result.error) {
+    process.stderr.write(`${result.error.message}\n`);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 0);
+}
 
 if (planFile && shareWalkthrough) {
   const planFilePath = resolve(sessionCwd, planFile);

--- a/pi/skills/codiff/SKILL.md
+++ b/pi/skills/codiff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codiff
-description: Open Codiff for a narrative code walkthrough, a blocking plan handoff, or a shared walkthrough URL. Use when the user writes "$codiff", "/codiff", "$codiff plan", "$codiff share", "show me codiff", "open Codiff", or asks to review a change or edit a plan in Codiff.
+description: Open Codiff for a narrative code walkthrough, a plain diff view, a blocking plan handoff, or a shared walkthrough URL. Use when the user writes "$codiff", "/codiff", "$codiff diff", "$codiff plan", "$codiff share", "show me codiff", "open Codiff", or asks to review a change or edit a plan in Codiff.
 metadata:
   short-description: Review code or hand off a plan in Codiff
 ---
@@ -23,6 +23,8 @@ change. Codiff owns the format and authoring guidance, so this skill only handle
 - Use **plan mode** for `$codiff plan` or when the user explicitly asks to edit or approve a
   plan in Codiff before execution.
 - Use **desktop mode** for plain `$codiff`, `/codiff`, "open Codiff", or "show me Codiff".
+- Use **simple diff mode** for `$codiff diff`, or when the user asks for the plain diff, the raw
+  diff, "just the diff", or a diff view without a narrative walkthrough.
 - In share mode, only pass `--open` when the user explicitly asks to open the resulting share in
   a browser. Otherwise return the URL without opening it.
 
@@ -73,6 +75,27 @@ approval document.
 
 3. Add `--open` only when the user explicitly asks to open the shared plan in a browser.
 4. Return only the `/p/…` URL printed by the command.
+
+## Simple Diff Mode
+
+Open Codiff's plain diff viewer with no narrative walkthrough. There is nothing to author — just
+launch it:
+
+```bash
+node scripts/open-codiff.mjs --diff
+```
+
+By default this reviews the staged and unstaged changes in the session's repository. Forward an
+explicit target after the flag when the user names one — a commit, `HEAD`, a branch, a PR/MR, a
+range, or a repository path:
+
+```bash
+node scripts/open-codiff.mjs --diff HEAD
+node scripts/open-codiff.mjs --diff main /path/to/repository
+node scripts/open-codiff.mjs --diff '#75'
+```
+
+This mode does not author or share JSON. Do not summarize the diff back to the user after opening it.
 
 ## Walkthrough Workflow
 

--- a/pi/skills/codiff/scripts/open-codiff.mjs
+++ b/pi/skills/codiff/scripts/open-codiff.mjs
@@ -7,6 +7,9 @@
 // Usage:
 //   node scripts/open-codiff.mjs --file <path> [target]
 //   node scripts/open-codiff.mjs --plan <path> [repository]
+//   node scripts/open-codiff.mjs --diff [target] [repository]
+//
+// `--diff` opens Codiff's plain diff viewer with no narrative walkthrough.
 //
 // `--file <path>` is forwarded to Codiff as `--walkthrough-file`. Any non-flag target
 // (commit, HEAD, PR number, or repository path) is forwarded verbatim; when no repository
@@ -222,6 +225,7 @@ const forwardedArgs = [];
 let openSharedWalkthrough = false;
 let planFile = '';
 let shareWalkthrough = false;
+let simpleDiff = false;
 let walkthroughFile = '';
 for (let index = 0; index < rawArgs.length; index += 1) {
   const arg = rawArgs[index];
@@ -251,10 +255,41 @@ for (let index = 0; index < rawArgs.length; index += 1) {
     openSharedWalkthrough = true;
     continue;
   }
+  if (arg === '--diff') {
+    simpleDiff = true;
+    continue;
+  }
   forwardedArgs.push(arg);
 }
 
 const sessionCwd = getFallbackSessionCwd();
+
+// `--diff`: open Codiff's plain diff viewer. No walkthrough JSON is authored; any
+// forwarded target (commit, HEAD, branch, PR/MR, range, or path) is passed verbatim.
+if (simpleDiff) {
+  const hasRepositoryTarget = forwardedArgs.some(
+    (arg) => !arg.startsWith('-') && existsSync(resolve(sessionCwd, arg)),
+  );
+  const resolvedSessionId = threadId || findPiSessionIdForCwd(sessionCwd) || '';
+  const codiffCommand = getCodiffCommand();
+  const result = spawnSync(
+    codiffCommand.command,
+    [
+      ...codiffCommand.args,
+      '--agent',
+      'pi',
+      ...(resolvedSessionId ? ['--pi-session', resolvedSessionId] : []),
+      ...forwardedArgs,
+      ...(hasRepositoryTarget ? [] : [sessionCwd]),
+    ],
+    { cwd: sessionCwd, encoding: 'utf8', stdio: 'inherit' },
+  );
+  if (result.error) {
+    process.stderr.write(`${result.error.message}\n`);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 0);
+}
 
 if (planFile && shareWalkthrough) {
   const planFilePath = resolve(sessionCwd, planFile);


### PR DESCRIPTION
## Summary

Adds a **simple diff mode** to the `codiff` skill so users can open Codiff's plain diff viewer without generating a narrative walkthrough.

- Plain `$codiff` still generates a narrative walkthrough (unchanged).
- `$codiff diff` (new) opens the raw diff viewer.

## What changed

Applied consistently across all four agent skill copies — **claude, codex, opencode, pi**:

**`scripts/open-codiff.mjs`** — new `--diff` flag:
- Spawns `codiff` without `-w` / `--walkthrough-file`, so the app opens its plain diff viewer.
- Defaults to the session repo's staged + unstaged changes; forwards any explicit target (commit, `HEAD`, branch, PR/MR, range, or path) verbatim.
- Still passes `--agent` and the session id so a follow-up walkthrough can reuse the conversation.

**`SKILL.md`** — routing + docs:
- `description` frontmatter now advertises `$codiff diff` / plain diff view.
- New *simple diff mode* bullet in **Choose The Mode** (triggers on `$codiff diff`, "plain diff", "raw diff", "just the diff").
- New **Simple Diff Mode** section with example commands.

## Verification

- All four launchers pass `node --check`.
- `--diff` produces a plain `codiff` invocation (no `-w`, no walkthrough file); defaults to the session repo; forwards targets like `HEAD`.
- Existing walkthrough mode still requires `--file`.
- The real arg parser (`bin/arguments.js`) reports `walkthrough: false` for the generated invocation, confirming plain-diff behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)