### PR TITLE
feat: resolve pull requests by branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Review a GitHub pull request or GitLab merge request using the current repositor
 
 ```bash
 codiff pr 75
+codiff pr my-feature-branch
 codiff mr 23
 ```
 

--- a/bin/arguments.js
+++ b/bin/arguments.js
@@ -94,6 +94,7 @@ const usageExamples = [
   { command: 'codiff a1b2c3d', description: 'Review a specific commit.' },
   { command: "codiff '#75'", description: 'Review pull request #75.' },
   { command: 'codiff pr 75', description: 'Review pull request #75 (alternate syntax).' },
+  { command: 'codiff pr my-feature-branch', description: 'Review the open PR for a branch.' },
   { command: 'codiff mr 75', description: 'Review GitLab merge request !75.' },
   { command: 'codiff --plan plan.md', description: 'Edit a plan and wait for handoff.' },
   { command: 'codiff --plan plan.md --share', description: 'Share a Markdown plan.' },
@@ -275,6 +276,7 @@ export const parseArguments = (args) => {
     values.agent === 'pi'
       ? values.agent
       : null;
+  let pullRequestBranch = null;
   let pullRequestNumber = null;
   let pullRequestProvider = null;
   let pullRequestUrl = null;
@@ -305,11 +307,16 @@ export const parseArguments = (args) => {
       }
 
       const markerProvider = getReviewProviderMarker(arg);
-      const nextNumber = markerProvider
-        ? parsePullRequestNumberValue(positionals[index + 1] ?? '')
-        : null;
+      const nextValue = markerProvider ? positionals[index + 1] : null;
+      const nextNumber = nextValue ? parsePullRequestNumberValue(nextValue) : null;
       if (nextNumber != null) {
         pullRequestNumber = nextNumber;
+        pullRequestProvider = markerProvider;
+        index += 1;
+        continue;
+      }
+      if (markerProvider && nextValue) {
+        pullRequestBranch = nextValue;
         pullRequestProvider = markerProvider;
         index += 1;
         continue;
@@ -368,6 +375,7 @@ export const parseArguments = (args) => {
     ...(range ? { range } : {}),
     commitRef,
     help: values.help === true,
+    pullRequestBranch,
     pullRequestNumber,
     ...(pullRequestProvider ? { pullRequestProvider } : {}),
     pullRequestUrl,

--- a/bin/codiff.js
+++ b/bin/codiff.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import http from 'node:http';
 import https from 'node:https';
@@ -131,7 +131,7 @@ const run = async () => {
     opencodeSessionId,
     piSessionId,
     planFilePath,
-    pullRequestNumber,
+    pullRequestBranch,
     pullRequestProvider,
     range,
     requestedPath,
@@ -140,13 +140,39 @@ const run = async () => {
     walkthroughContextPath,
     walkthroughFilePath,
   } = parsedArguments;
-  let { pullRequestUrl } = parsedArguments;
+  let { pullRequestNumber, pullRequestUrl } = parsedArguments;
 
   if (planFilePath && (!existsSync(planFilePath) || !/\.md$/i.test(planFilePath))) {
     process.stderr.write(`codiff: plan file not found or not Markdown: ${planFilePath}\n`);
     process.exitCode = 1;
     return;
   }
+  if (pullRequestBranch && !pullRequestUrl && pullRequestNumber == null) {
+    if (pullRequestProvider === 'gitlab') {
+      process.stderr.write('codiff: branch lookup is GitHub-only for now.\n');
+      process.exit(1);
+    }
+    // Branch lookup currently supports GitHub only.
+    try {
+      const output = execFileSync(
+        'gh',
+        ['pr', 'view', pullRequestBranch, '--json', 'number', '-q', '.number'],
+        { cwd: requestedPath, encoding: 'utf8' },
+      ).trim();
+      if (!/^[1-9]\d*$/.test(output)) {
+        throw new Error('No open pull request found.');
+      }
+      pullRequestNumber = Number(output);
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message === 'No open pull request found.'
+          ? error.message
+          : `Could not find an open pull request for branch "${pullRequestBranch}".`;
+      process.stderr.write(`codiff: ${message}\n`);
+      process.exit(1);
+    }
+  }
+
   if (!pullRequestUrl && pullRequestNumber != null) {
     try {
       pullRequestUrl = resolvePullRequestUrl(

--- a/core/__tests__/codiff-cli.test.ts
+++ b/core/__tests__/codiff-cli.test.ts
@@ -73,6 +73,7 @@ test('parseArguments treats a hash positional as a commit ref', () => {
   expect(parseArguments(['-w', commitRef])).toEqual({
     commitRef,
     help: false,
+    pullRequestBranch: null,
     pullRequestNumber: null,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
@@ -85,6 +86,7 @@ test('parseArguments treats HEAD positional revisions as commit refs', () => {
   expect(parseArguments(['HEAD'])).toEqual({
     commitRef: 'HEAD',
     help: false,
+    pullRequestBranch: null,
     pullRequestNumber: null,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
@@ -95,6 +97,7 @@ test('parseArguments treats HEAD positional revisions as commit refs', () => {
   expect(parseArguments(['HEAD^1'])).toEqual({
     commitRef: 'HEAD^1',
     help: false,
+    pullRequestBranch: null,
     pullRequestNumber: null,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
@@ -109,6 +112,7 @@ test('parseArguments treats plain branch refs as branch refs', async () => {
       branchRef: 'feature',
       commitRef: null,
       help: false,
+      pullRequestBranch: null,
       pullRequestNumber: null,
       pullRequestUrl: null,
       requestedPath: refRepositoryPath,
@@ -174,6 +178,7 @@ test('parseArguments keeps existing hash-like paths as repository paths', async 
     expect(parseArguments([repositoryPath])).toEqual({
       commitRef: null,
       help: false,
+      pullRequestBranch: null,
       pullRequestNumber: null,
       pullRequestUrl: null,
       requestedPath: repositoryPath,
@@ -222,6 +227,7 @@ test('parseArguments treats GitHub pull request URLs as review sources', () => {
   expect(parseArguments([pullRequestUrl])).toEqual({
     commitRef: null,
     help: false,
+    pullRequestBranch: null,
     pullRequestNumber: null,
     pullRequestUrl,
     requestedPath: resolve(process.cwd()),
@@ -234,6 +240,7 @@ test('parseArguments treats PR number shorthands as review sources', () => {
   expect(parseArguments(['#75'])).toEqual({
     commitRef: null,
     help: false,
+    pullRequestBranch: null,
     pullRequestNumber: 75,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
@@ -246,12 +253,21 @@ test('parseArguments treats PR marker arguments as review sources', () => {
   expect(parseArguments(['pr', '75'])).toEqual({
     commitRef: null,
     help: false,
+    pullRequestBranch: null,
     pullRequestNumber: 75,
     pullRequestProvider: 'github',
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
     version: false,
     walkthrough: false,
+  });
+});
+
+test('parseArguments treats PR marker branch values as review sources', () => {
+  expect(parseArguments(['pr', 'my-feature-branch'])).toMatchObject({
+    pullRequestBranch: 'my-feature-branch',
+    pullRequestNumber: null,
+    pullRequestProvider: 'github',
   });
 });
 
@@ -268,6 +284,7 @@ test('parseArguments recognizes Codex walkthrough seed options', () => {
     codexSessionId: '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
     commitRef: null,
     help: false,
+    pullRequestBranch: null,
     pullRequestNumber: null,
     pullRequestUrl: null,
     requestedPath: resolve(process.cwd()),
@@ -347,6 +364,7 @@ test('parseArguments treats hash-prefixed PR marker values as review sources', (
   expect(parseArguments(['pr', '#75'])).toEqual({
     commitRef: null,
     help: false,
+    pullRequestBranch: null,
     pullRequestNumber: 75,
     pullRequestProvider: 'github',
     pullRequestUrl: null,
@@ -358,6 +376,7 @@ test('parseArguments treats hash-prefixed PR marker values as review sources', (
 
 test('parseArguments treats GitLab MR marker values as review sources', () => {
   expect(parseArguments(['mr', '23'])).toMatchObject({
+    pullRequestBranch: null,
     pullRequestNumber: 23,
     pullRequestProvider: 'gitlab',
   });


### PR DESCRIPTION
## Summary
- resolve GitHub pull requests from branch names
- preserve the existing pull request URL and fetch flow
- document and test branch marker parsing

```bash
codiff pr iminoso:feat/pr-branch-lookup
```

## Testing
- Manual parser and stubbed `gh` lookup verification
- `pnpm test` blocked: configured pnpm binary was missing
- `vp check --fix` and `vp build` blocked: `vp` was unavailable