### PR TITLE
fix(useAppWalkthrough): use real app version in shared walkthrough snapshot

### DIFF
--- a/core/App.tsx
+++ b/core/App.tsx
@@ -332,6 +332,7 @@ export default function App() {
     walkthroughSharing,
     walkthroughUnread,
   } = useAppWalkthrough({
+    codiffVersion: launchOptions.codiffVersion,
     preferencesRef,
     state,
     stateGenerationRef,

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -167,6 +167,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
     name: 'Reviewer',
   })),
   getLaunchOptions: vi.fn(async () => ({
+    codiffVersion: '',
     repositoryPathProvided: true,
     walkthrough: false,
   })),
@@ -832,6 +833,7 @@ test('repository reload does not let stale selection override launch source', as
 
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       source: launchSource,
       walkthrough: false,
@@ -938,6 +940,7 @@ test('walkthrough file reload shows files changed since reload as stale', async 
 
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       walkthrough: false,
       walkthroughFile: '/tmp/walkthrough.json',
@@ -1488,6 +1491,7 @@ test('narrative walkthrough stops show pull request descriptions once', async ()
 
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       source,
       walkthrough: true,
@@ -1604,6 +1608,7 @@ test('narrative walkthrough stops do not repeat commit details', async () => {
 
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       source,
       walkthrough: true,
@@ -1699,6 +1704,7 @@ test('a walkthrough file loads even without the walkthrough launch flag', async 
   }));
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       source,
       walkthrough: false,
@@ -1837,6 +1843,7 @@ test('plan mode opens the Markdown editor without loading repository state', asy
       name: 'Current User',
     })),
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       planFile: '/tmp/plan.md',
       planResultFile: '/tmp/result.json',
       repositoryPathProvided: true,
@@ -2142,6 +2149,7 @@ test('plan mode resolves stored comments whose anchors were already removed', as
   } satisfies PlanReview;
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       planFile: '/tmp/plan.md',
       planResultFile: '/tmp/result.json',
       repositoryPathProvided: true,
@@ -2272,6 +2280,7 @@ test('plan mode keeps comments open when their anchors are removed during the cu
   } satisfies PlanReview;
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       planFile: '/tmp/plan.md',
       planResultFile: '/tmp/result.json',
       repositoryPathProvided: true,
@@ -2354,6 +2363,7 @@ test('closing plan mode flushes and returns a closed handoff', async () => {
   window.codiff = createCodiffMock({
     completePlan,
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       planFile: '/tmp/plan.md',
       planResultFile: '/tmp/result.json',
       repositoryPathProvided: true,
@@ -2490,6 +2500,7 @@ test('plan mode recovers from an unreadable review sidecar', async () => {
   const markPlanReady = vi.fn(async () => {});
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       planFile: '/tmp/plan.md',
       planResultFile: '/tmp/result.json',
       repositoryPathProvided: true,
@@ -2538,6 +2549,7 @@ test('a walkthrough file that no longer anchors surfaces a dismissible banner', 
   const source = { ref: 'abc1234', type: 'commit' } satisfies ReviewSource;
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       source,
       walkthrough: false,
@@ -2788,6 +2800,7 @@ test('refreshing all changes re-resolves the branch snapshot', async () => {
 
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       source: { ref: 'main', type: 'branch-working-tree' as const },
       walkthrough: false,
@@ -2990,6 +3003,7 @@ test('regenerating a walkthrough clears refresh-only changed sections', async ()
 
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       walkthrough: true,
     })),
@@ -3129,6 +3143,7 @@ test('drops a walkthrough regeneration when the same source refreshes again', as
 
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       walkthrough: true,
     })),
@@ -3225,6 +3240,7 @@ test('walkthrough launch errors stay on the walkthrough tab without automatic re
 
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       walkthrough: true,
     })),
@@ -3305,6 +3321,7 @@ test('walkthrough progress events replace the loading line without exposing agen
 
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
+      codiffVersion: '',
       repositoryPathProvided: true,
       walkthrough: true,
     })),
@@ -3438,6 +3455,7 @@ test('Pi not-found walkthrough errors show the agent recovery panel', async () =
   window.codiff = createCodiffMock({
     getLaunchOptions: vi.fn(async () => ({
       agentBackend: 'pi' as const,
+      codiffVersion: '',
       repositoryPathProvided: true,
       walkthrough: true,
     })),

--- a/core/__tests__/useAppWalkthrough.test.tsx
+++ b/core/__tests__/useAppWalkthrough.test.tsx
@@ -38,12 +38,14 @@ const createRepositoryState = (): RepositoryState => ({
 });
 
 function AppWalkthroughHarness({
+  codiffVersion = '',
   onController,
   preferencesRef,
   state,
   stateGenerationRef,
   stateRef,
 }: {
+  codiffVersion?: string;
   onController: (controller: AppWalkthroughController) => void;
   preferencesRef: Parameters<typeof useAppWalkthrough>[0]['preferencesRef'];
   state: RepositoryState;
@@ -51,6 +53,7 @@ function AppWalkthroughHarness({
   stateRef: Parameters<typeof useAppWalkthrough>[0]['stateRef'];
 }) {
   const controller = useAppWalkthrough({
+    codiffVersion,
     preferencesRef,
     state,
     stateGenerationRef,

--- a/core/app/hooks/useAppWalkthrough.ts
+++ b/core/app/hooks/useAppWalkthrough.ts
@@ -25,6 +25,7 @@ import type { WalkthroughFileError } from '../components/WalkthroughFileError.ts
 type MainMode = 'commit' | 'review';
 
 type UseAppWalkthroughOptions = {
+  codiffVersion: string;
   preferencesRef: RefObject<CodiffPreferences>;
   state: RepositoryState | null;
   stateGenerationRef: RefObject<number>;
@@ -34,6 +35,7 @@ type UseAppWalkthroughOptions = {
 const emptyFiles: ReadonlyArray<ChangedFile> = [];
 
 export function useAppWalkthrough({
+  codiffVersion,
   preferencesRef,
   state,
   stateGenerationRef,
@@ -279,7 +281,7 @@ export function useAppWalkthrough({
     const snapshot: SharedWalkthroughSnapshot = {
       branch: currentState.branch,
       codeQualityFindings: currentState.codeQualityFindings,
-      codiffVersion: 'dev',
+      codiffVersion,
       exportedAt: new Date().toISOString(),
       files: currentState.files,
       kind: 'codiff-walkthrough-share',
@@ -316,7 +318,7 @@ export function useAppWalkthrough({
       .finally(() => {
         setWalkthroughSharing(false);
       });
-  }, [preferencesRef, shareWalkthroughEnabled, stateRef, walkthroughSharing]);
+  }, [codiffVersion, preferencesRef, shareWalkthroughEnabled, stateRef, walkthroughSharing]);
 
   const plainCommitModel = useMemo(
     () =>

--- a/core/lib/app-constants.ts
+++ b/core/lib/app-constants.ts
@@ -4,6 +4,7 @@ import type { AgentSkillStatus, CodiffLaunchOptions, TerminalHelperStatus } from
 export const HISTORY_PAGE_SIZE = 30;
 
 export const defaultLaunchOptions: CodiffLaunchOptions = {
+  codiffVersion: '',
   repositoryPathProvided: false,
   walkthrough: false,
 };

--- a/core/types.ts
+++ b/core/types.ts
@@ -411,6 +411,8 @@ export type WalkthroughContext = {
 };
 
 export type CodiffLaunchOptions = {
+  /** The running Codiff app version, from the packaged `app.getVersion()`. */
+  codiffVersion: string;
   agentBackend?: 'codex' | 'claude' | 'opencode' | 'pi';
   claudeSessionId?: string;
   codexSessionId?: string;

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -875,7 +875,7 @@ const createWindow = (
     windowIdentities.set(webContentsId, identity);
   }
   windowRepositories.set(webContentsId, identity?.repositoryRoot || repositoryPath);
-  windowLaunchOptions.set(webContentsId, launchOptions);
+  windowLaunchOptions.set(webContentsId, { ...launchOptions, codiffVersion: app.getVersion() });
   const initialRepositoryStatePromise = launchOptions.planFile
     ? null
     : readInitialRepositoryStateWithConfig(repositoryPath, launchOptions);
@@ -1127,7 +1127,10 @@ const focusOrCreateWindow = (
   if (matchingWindow) {
     if (launchOptions.planFile || launchOptions.walkthrough || launchOptions.walkthroughFile) {
       windowRepositories.set(matchingWebContentsId, identity?.repositoryRoot || repositoryPath);
-      windowLaunchOptions.set(matchingWebContentsId, launchOptions);
+      windowLaunchOptions.set(matchingWebContentsId, {
+        ...launchOptions,
+        codiffVersion: app.getVersion(),
+      });
       if (launchOptions.planFile) {
         planInitialVersions.delete(matchingWebContentsId);
         readyPlanWindows.delete(matchingWebContentsId);
@@ -1347,13 +1350,12 @@ ipcMain.handle('codiff:markPlanReady', async (event) => {
   writePlanResult(event.sender.id, 'open');
 });
 
-ipcMain.handle(
-  'codiff:getLaunchOptions',
-  (event) =>
-    windowLaunchOptions.get(event.sender.id) || {
-      repositoryPathProvided: false,
-      walkthrough: false,
-    },
+ipcMain.handle('codiff:getLaunchOptions', (event) =>
+  windowLaunchOptions.get(event.sender.id) || {
+    codiffVersion: app.getVersion(),
+    repositoryPathProvided: false,
+    walkthrough: false,
+  },
 );
 
 ipcMain.handle('codiff:getAgentSkillStatus', (event) => {


### PR DESCRIPTION
## Summary

The shared walkthrough snapshot hardcoded `codiffVersion: 'dev'`, so every published/shareable walkthrough reported version `dev` and lost the real build version.

This change threads the real version from the main process (`app.getVersion()`) into the renderer and uses it for the snapshot.

## Changes

- `electron/main.cjs` — inject `app.getVersion()` into the `codiff:getLaunchOptions` IPC handler and the `windowLaunchOptions` map (matches the existing headless share path).
- `core/types.ts` — add `codiffVersion: string` to `CodiffLaunchOptions`.
- `core/lib/app-constants.ts` — `defaultLaunchOptions` gets a `''` default.
- `core/app/hooks/useAppWalkthrough.ts` — accept `codiffVersion` and use it instead of `'dev'`.
- `core/App.tsx` — pass `launchOptions.codiffVersion` through.

## Validation

- `vp check --fix` — no warnings, lint, or type errors.
- `vp build` — succeeds.

Note: both `nkzw-tech/codiff` and the fork have issues disabled, so no tracking issue was created.