### PR TITLE
Use explicit resource management in tests

### DIFF
--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -271,7 +271,11 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
 });
 
 const createNarrativeWalkthroughFixture = (
-  hunks: ReadonlyArray<{ added: number; path: string; status: ChangedFile['status'] }>,
+  hunks: ReadonlyArray<{
+    added: number;
+    path: string;
+    status: ChangedFile['status'];
+  }>,
 ) =>
   ({
     agent: 'codex',
@@ -287,7 +291,11 @@ const createNarrativeWalkthroughFixture = (
             hunkIds: hunks.map((hunk) => `${hunk.path}:unstaged:h1`),
             hunks: hunks.map((hunk) => ({
               added: hunk.added,
-              anchor: { display: hunk.path, sectionId: `${hunk.path}:unstaged`, side: 'both' },
+              anchor: {
+                display: hunk.path,
+                sectionId: `${hunk.path}:unstaged`,
+                side: 'both',
+              },
               deleted: hunk.path === 'src/app.ts' ? 1 : 0,
               id: `${hunk.path}:unstaged:h1`,
               path: hunk.path,
@@ -341,12 +349,17 @@ const renderAppForOpenFileShortcut = async (file: ChangedFile) => {
     expect(container.querySelector('.codiff-file-header')).not.toBeNull();
   });
 
+  const cleanup = async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  };
+
   return {
-    cleanup: async () => {
-      await act(async () => root.unmount());
-      container.remove();
-    },
+    cleanup,
     openFile,
+    async [Symbol.asyncDispose]() {
+      await cleanup();
+    },
   };
 };
 
@@ -404,7 +417,7 @@ test('stale persisted collapsed sidebar state does not hide the sidebar on launc
   window.localStorage.setItem('codiff:sidebar-collapsed', 'true');
   window.codiff = createCodiffMock();
 
-  const app = await renderReact(<App />);
+  await using app = await renderReact(<App />);
 
   await waitFor(() => {
     expect(app.container.querySelector('.app-shell')?.classList.contains('sidebar-collapsed')).toBe(
@@ -564,28 +577,28 @@ test('repository reload restores the selected file when it still exists', async 
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-      expect(container.querySelector('.codiff-file-header')).not.toBeNull();
-    });
-    await act(async () => {
-      dispatchModK();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    expect(openFile).toHaveBeenCalledWith(secondFile.path);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-    window.sessionStorage.clear();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+      window.sessionStorage.clear();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(container.querySelector('.codiff-file-header')).not.toBeNull();
+  });
+  await act(async () => {
+    dispatchModK();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(openFile).toHaveBeenCalledWith(secondFile.path);
 });
 
 test('repository reload restores the selected file from the previous source', async () => {
@@ -613,28 +626,28 @@ test('repository reload restores the selected file from the previous source', as
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-      expect(container.querySelector('.codiff-file-header')).not.toBeNull();
-    });
-    await act(async () => {
-      dispatchModK();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    expect(openFile).toHaveBeenCalledWith(secondFile.path);
-    expect(getRepositoryState).toHaveBeenCalledWith(source);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(container.querySelector('.codiff-file-header')).not.toBeNull();
+  });
+  await act(async () => {
+    dispatchModK();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(openFile).toHaveBeenCalledWith(secondFile.path);
+  expect(getRepositoryState).toHaveBeenCalledWith(source);
 });
 
 test('repository reload preserves a branch diff source even without a selected file', async () => {
@@ -663,22 +676,22 @@ test('repository reload preserves a branch diff source even without a selected f
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-    });
-    expect(getRepositoryState).toHaveBeenCalledWith(source);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+  });
+  expect(getRepositoryState).toHaveBeenCalledWith(source);
 });
 
 test('branch history keeps branch diff available after selecting uncommitted changes', async () => {
@@ -727,40 +740,36 @@ test('branch history keeps branch diff available after selecting uncommitted cha
       button.textContent?.includes(label),
     );
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-      expect(findButton('Committed only vs main')).toBeTruthy();
-      expect(findButton('All changes vs main')).toBeTruthy();
-    });
-
-    await act(async () => {
-      findButton('Uncommitted')?.click();
-    });
-
-    await waitFor(() => {
-      expect(getRepositoryState).toHaveBeenCalledWith({ type: 'working-tree' });
-      expect(findButton('Committed only vs main')).toBeTruthy();
-    });
-
-    await act(async () => {
-      findButton('Committed only vs main')?.click();
-    });
-
-    await waitFor(() => {
-      expect(getRepositoryState).toHaveBeenCalledWith(branchSource);
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(findButton('Committed only vs main')).toBeTruthy();
+    expect(findButton('All changes vs main')).toBeTruthy();
+  });
+  await act(async () => {
+    findButton('Uncommitted')?.click();
+  });
+  await waitFor(() => {
+    expect(getRepositoryState).toHaveBeenCalledWith({ type: 'working-tree' });
+    expect(findButton('Committed only vs main')).toBeTruthy();
+  });
+  await act(async () => {
+    findButton('Committed only vs main')?.click();
+  });
+  await waitFor(() => {
+    expect(getRepositoryState).toHaveBeenCalledWith(branchSource);
+  });
 });
 
 test('repository reload restores branch diff scope after selecting uncommitted changes', async () => {
@@ -805,28 +814,31 @@ test('repository reload restores branch diff scope after selecting uncommitted c
       button.textContent?.includes(label),
     );
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-      expect(findButton('Committed only vs main')).toBeTruthy();
-    });
-    expect(getRepositoryState).toHaveBeenCalledWith({ type: 'working-tree' });
-    expect(getRepositoryHistory).toHaveBeenCalledWith(expect.any(Number), branchSource);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(findButton('Committed only vs main')).toBeTruthy();
+  });
+  expect(getRepositoryState).toHaveBeenCalledWith({ type: 'working-tree' });
+  expect(getRepositoryHistory).toHaveBeenCalledWith(expect.any(Number), branchSource);
 });
 
 test('repository reload does not let stale selection override launch source', async () => {
-  const launchSource = { ref: 'main', type: 'branch-working-tree' } satisfies ReviewSource;
+  const launchSource = {
+    ref: 'main',
+    type: 'branch-working-tree',
+  } satisfies ReviewSource;
   const staleState = {
     ...repositoryState,
     source: { type: 'working-tree' },
@@ -854,29 +866,35 @@ test('repository reload does not let stale selection override launch source', as
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-    });
-    expect(getRepositoryState).toHaveBeenCalledWith(undefined);
-    expect(getRepositoryState).not.toHaveBeenCalledWith(staleState.source);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+  });
+  expect(getRepositoryState).toHaveBeenCalledWith(undefined);
+  expect(getRepositoryState).not.toHaveBeenCalledWith(staleState.source);
 });
 
 test('repository reload colors only git status glyphs for files changed after reload', async () => {
-  const unchangedFile = createChangedFile('src/unchanged.ts', { fingerprint: 'same' });
-  const changedFileBeforeReload = createChangedFile('src/changed.ts', { fingerprint: 'before' });
-  const changedFileAfterReload = createChangedFile('src/changed.ts', { fingerprint: 'after' });
+  const unchangedFile = createChangedFile('src/unchanged.ts', {
+    fingerprint: 'same',
+  });
+  const changedFileBeforeReload = createChangedFile('src/changed.ts', {
+    fingerprint: 'before',
+  });
+  const changedFileAfterReload = createChangedFile('src/changed.ts', {
+    fingerprint: 'after',
+  });
   const previousState = {
     ...repositoryState,
     files: [unchangedFile, changedFileBeforeReload],
@@ -896,43 +914,52 @@ test('repository reload colors only git status glyphs for files changed after re
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      const shadowRoot = container.querySelector('file-tree-container')?.shadowRoot;
-      const styleText =
-        shadowRoot?.querySelector('style[data-codiff-reload-delta-git-status]')?.textContent ?? '';
-      expect(styleText).toContain('[data-item-path="src/changed.ts"][data-item-git-status]');
-      expect(styleText).not.toContain('[data-item-path="src/unchanged.ts"][data-item-git-status]');
-      expect(styleText).toContain("> [data-item-section='git']");
-      expect(
-        shadowRoot?.querySelector(
-          '[data-item-path="src/changed.ts"][data-item-git-status] > [data-item-section="git"]',
-        ),
-      ).toBeTruthy();
-      expect(
-        shadowRoot?.querySelector(
-          '[data-item-path="src/unchanged.ts"][data-item-git-status] > [data-item-section="git"]',
-        ),
-      ).toBeTruthy();
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    const shadowRoot = container.querySelector('file-tree-container')?.shadowRoot;
+    const styleText =
+      shadowRoot?.querySelector('style[data-codiff-reload-delta-git-status]')?.textContent ?? '';
+    expect(styleText).toContain('[data-item-path="src/changed.ts"][data-item-git-status]');
+    expect(styleText).not.toContain('[data-item-path="src/unchanged.ts"][data-item-git-status]');
+    expect(styleText).toContain("> [data-item-section='git']");
+    expect(
+      shadowRoot?.querySelector(
+        '[data-item-path="src/changed.ts"][data-item-git-status] > [data-item-section="git"]',
+      ),
+    ).toBeTruthy();
+    expect(
+      shadowRoot?.querySelector(
+        '[data-item-path="src/unchanged.ts"][data-item-git-status] > [data-item-section="git"]',
+      ),
+    ).toBeTruthy();
+  });
 });
 
 test('walkthrough file reload keeps uncovered files in support', async () => {
-  const unchangedFile = createChangedFile('src/unchanged.ts', { fingerprint: 'same' });
-  const changedFileBeforeReload = createChangedFile('src/changed.ts', { fingerprint: 'before' });
-  const changedFileAfterReload = createChangedFile('src/changed.ts', { fingerprint: 'after' });
-  const addedFile = createChangedFile('src/added.ts', { fingerprint: 'added', status: 'added' });
+  const unchangedFile = createChangedFile('src/unchanged.ts', {
+    fingerprint: 'same',
+  });
+  const changedFileBeforeReload = createChangedFile('src/changed.ts', {
+    fingerprint: 'before',
+  });
+  const changedFileAfterReload = createChangedFile('src/changed.ts', {
+    fingerprint: 'after',
+  });
+  const addedFile = createChangedFile('src/added.ts', {
+    fingerprint: 'added',
+    status: 'added',
+  });
   const previousState = {
     ...repositoryState,
     files: [unchangedFile, changedFileBeforeReload],
@@ -964,40 +991,42 @@ test('walkthrough file reload keeps uncovered files in support', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.wt-stop-block')).not.toBeNull();
-    });
-
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.wt-upnext')?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await waitFor(() => {
-      expect(container.textContent).toContain('Support');
-      expect(container.textContent).toContain('changed.ts');
-      expect(container.textContent).toContain('added.ts');
-      expect(container.textContent).not.toContain('Regenerate walkthrough');
-      expect(container.textContent).not.toContain('Changed after the walkthrough was generated.');
-      expect(container.textContent).not.toContain('unchanged.tsChanged');
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.wt-stop-block')).not.toBeNull();
+  });
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('.wt-upnext')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(container.textContent).toContain('Support');
+    expect(container.textContent).toContain('changed.ts');
+    expect(container.textContent).toContain('added.ts');
+    expect(container.textContent).not.toContain('Regenerate walkthrough');
+    expect(container.textContent).not.toContain('Changed after the walkthrough was generated.');
+    expect(container.textContent).not.toContain('unchanged.tsChanged');
+  });
 });
 
 test('reload forces a new generated walkthrough when local files changed', async () => {
-  const previousFile = createChangedFile('src/app.ts', { fingerprint: 'before' });
-  const refreshedFile = createChangedFile('src/app.ts', { fingerprint: 'after' });
+  const previousFile = createChangedFile('src/app.ts', {
+    fingerprint: 'before',
+  });
+  const refreshedFile = createChangedFile('src/app.ts', {
+    fingerprint: 'after',
+  });
   const previousState = {
     ...repositoryState,
     files: [previousFile],
@@ -1023,22 +1052,23 @@ test('reload forces a new generated walkthrough when local files changed', async
     getRepositoryState: vi.fn(async () => refreshedState),
   });
 
-  const app = await renderReact(<App />);
-  try {
-    await waitFor(() => {
-      expect(getNarrativeWalkthrough).toHaveBeenCalledWith(refreshedState.source, {
-        force: true,
-      });
-      expect(app.container.querySelector('.wt-stop-block')).not.toBeNull();
+  await using app = await renderReact(<App />);
+
+  await waitFor(() => {
+    expect(getNarrativeWalkthrough).toHaveBeenCalledWith(refreshedState.source, {
+      force: true,
     });
-  } finally {
-    await app.cleanup();
-  }
+    expect(app.container.querySelector('.wt-stop-block')).not.toBeNull();
+  });
 });
 
 test('tree sidebar subtly mutes files currently marked viewed', async () => {
-  const viewedFile = createChangedFile('src/viewed.ts', { fingerprint: 'viewed-current' });
-  const staleViewedFile = createChangedFile('src/stale.ts', { fingerprint: 'stale-current' });
+  const viewedFile = createChangedFile('src/viewed.ts', {
+    fingerprint: 'viewed-current',
+  });
+  const staleViewedFile = createChangedFile('src/stale.ts', {
+    fingerprint: 'stale-current',
+  });
   const nextState = {
     ...repositoryState,
     files: [viewedFile, staleViewedFile],
@@ -1059,31 +1089,31 @@ test('tree sidebar subtly mutes files currently marked viewed', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      const shadowRoot = container.querySelector('file-tree-container')?.shadowRoot;
-      const styleText =
-        shadowRoot?.querySelector('style[data-codiff-viewed-rows]')?.textContent ?? '';
-      expect(styleText).toContain('[data-item-path="src/viewed.ts"]');
-      expect(styleText).not.toContain('[data-item-path="src/stale.ts"]');
-      expect(styleText).not.toContain('color-mix(in srgb, var(--viewed)');
-      expect(styleText).toContain(
-        "[data-item-path=\"src/viewed.ts\"] > [data-item-section='icon'] > :where(:not([data-icon-name='file-tree-icon-chevron']))",
-      );
-      expect(styleText).toContain("> [data-item-section='content']");
-      expect(styleText).toContain('color: var(--muted)');
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    const shadowRoot = container.querySelector('file-tree-container')?.shadowRoot;
+    const styleText =
+      shadowRoot?.querySelector('style[data-codiff-viewed-rows]')?.textContent ?? '';
+    expect(styleText).toContain('[data-item-path="src/viewed.ts"]');
+    expect(styleText).not.toContain('[data-item-path="src/stale.ts"]');
+    expect(styleText).not.toContain('color-mix(in srgb, var(--viewed)');
+    expect(styleText).toContain(
+      "[data-item-path=\"src/viewed.ts\"] > [data-item-section='icon'] > :where(:not([data-icon-name='file-tree-icon-chevron']))",
+    );
+    expect(styleText).toContain("> [data-item-section='content']");
+    expect(styleText).toContain('color: var(--muted)');
+  });
 });
 
 test('before unload saves the current source and selected file for any reload trigger', async () => {
@@ -1103,43 +1133,36 @@ test('before unload saves the current source and selected file for any reload tr
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-    });
-
-    window.dispatchEvent(new Event('beforeunload'));
-
-    const selection = consumeReloadSelection();
-    expect(selection?.source).toEqual(source);
-    expect(getReloadSelectionPath(selection, nextState)).toBe(changedFile.path);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+  });
+  window.dispatchEvent(new Event('beforeunload'));
+  const selection = consumeReloadSelection();
+  expect(selection?.source).toEqual(source);
+  expect(getReloadSelectionPath(selection, nextState)).toBe(changedFile.path);
 });
 
 test('Mod+K opens the selected file in the editor', async () => {
   const changedFile = createChangedFile('src/app.ts');
-  const app = await renderAppForOpenFileShortcut(changedFile);
+  await using app = await renderAppForOpenFileShortcut(changedFile);
 
-  try {
-    await act(async () => {
-      dispatchModK();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    expect(app.openFile).toHaveBeenCalledWith(changedFile.path);
-  } finally {
-    await app.cleanup();
-  }
+  await act(async () => {
+    dispatchModK();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(app.openFile).toHaveBeenCalledWith(changedFile.path);
 });
 
 test('Mod+K does not open deleted files', async () => {
@@ -1147,18 +1170,13 @@ test('Mod+K does not open deleted files', async () => {
     ...createChangedFile('src/removed.ts'),
     status: 'deleted',
   } satisfies ChangedFile;
-  const app = await renderAppForOpenFileShortcut(deletedFile);
+  await using app = await renderAppForOpenFileShortcut(deletedFile);
 
-  try {
-    await act(async () => {
-      dispatchModK();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    expect(app.openFile).not.toHaveBeenCalled();
-  } finally {
-    await app.cleanup();
-  }
+  await act(async () => {
+    dispatchModK();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(app.openFile).not.toHaveBeenCalled();
 });
 
 test('commit messages use the shared source description presentation', async () => {
@@ -1193,50 +1211,50 @@ test('commit messages use the shared source description presentation', async () 
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-      expect(container.querySelector('.codiff-source-description-header')).not.toBeNull();
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.source-description-markdown')?.textContent).toContain(
-        'Detailed commit body.',
-      );
-    });
-
-    const header = container.querySelector<HTMLElement>('.codiff-source-description-header');
-    expect(header?.querySelector('.source-description-title')?.textContent).toBe(
-      commitMetadata.subject,
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(container.querySelector('.codiff-source-description-header')).not.toBeNull();
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.source-description-markdown')?.textContent).toContain(
+      'Detailed commit body.',
     );
-    expect(container.querySelector('.source-description-author-header')?.textContent).toContain(
-      commitMetadata.author.name,
-    );
-    expect(
-      container.querySelector<HTMLImageElement>('.source-description-comment > .avatar.medium')
-        ?.src,
-    ).toBe(historyAvatarUrl);
-    expect(container.querySelector('[aria-label="Preview commit message"]')).not.toBeNull();
-    expect(container.querySelector('.codiff-commit-details-header')).toBeNull();
-    expect(container.querySelector('.commit-details-panel')).toBeNull();
-    expect(container.textContent).not.toContain('Verified signature');
-    expect(container.textContent).not.toContain('Co-authored-by');
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  });
+  const header = container.querySelector<HTMLElement>('.codiff-source-description-header');
+  expect(header?.querySelector('.source-description-title')?.textContent).toBe(
+    commitMetadata.subject,
+  );
+  expect(container.querySelector('.source-description-author-header')?.textContent).toContain(
+    commitMetadata.author.name,
+  );
+  expect(
+    container.querySelector<HTMLImageElement>('.source-description-comment > .avatar.medium')?.src,
+  ).toBe(historyAvatarUrl);
+  expect(container.querySelector('[aria-label="Preview commit message"]')).not.toBeNull();
+  expect(container.querySelector('.codiff-commit-details-header')).toBeNull();
+  expect(container.querySelector('.commit-details-panel')).toBeNull();
+  expect(container.textContent).not.toContain('Verified signature');
+  expect(container.textContent).not.toContain('Co-authored-by');
 });
 
 test('bodyless commits still render the author and profile image', async () => {
   const commitMetadata = createCommitMetadataFixture('');
-  const source = { ref: commitMetadata.ref, type: 'commit' } satisfies ReviewSource;
+  const source = {
+    ref: commitMetadata.ref,
+    type: 'commit',
+  } satisfies ReviewSource;
 
   window.codiff = createCodiffMock({
     getRepositoryState: vi.fn(async () => ({
@@ -1247,31 +1265,26 @@ test('bodyless commits still render the author and profile image', async () => {
     })),
   });
 
-  const app = await renderReact(<App />);
+  await using app = await renderReact(<App />);
 
-  try {
-    await waitFor(() => {
-      expect(
-        app.container.querySelector('.source-description-author-header')?.textContent,
-      ).toContain(commitMetadata.author.name);
-    });
-
-    expect(
-      app.container.querySelector<HTMLImageElement>('.source-description-comment > .avatar.medium')
-        ?.src,
-    ).toBe(commitMetadata.author.gravatarUrl);
-    expect(
-      app.container.querySelector('.source-description-author-header.without-description'),
-    ).not.toBeNull();
-    expect(app.container.querySelector('.source-description-markdown')).toBeNull();
-    expect(
-      app.container
-        .querySelector('.codiff-source-description-header')
-        ?.querySelector('.source-description-title')?.textContent,
-    ).toBe(commitMetadata.subject);
-  } finally {
-    await app.cleanup();
-  }
+  await waitFor(() => {
+    expect(app.container.querySelector('.source-description-author-header')?.textContent).toContain(
+      commitMetadata.author.name,
+    );
+  });
+  expect(
+    app.container.querySelector<HTMLImageElement>('.source-description-comment > .avatar.medium')
+      ?.src,
+  ).toBe(commitMetadata.author.gravatarUrl);
+  expect(
+    app.container.querySelector('.source-description-author-header.without-description'),
+  ).not.toBeNull();
+  expect(app.container.querySelector('.source-description-markdown')).toBeNull();
+  expect(
+    app.container
+      .querySelector('.codiff-source-description-header')
+      ?.querySelector('.source-description-title')?.textContent,
+  ).toBe(commitMetadata.subject);
 });
 
 test('pull request descriptions render as provider-aware Markdown source context', async () => {
@@ -1324,34 +1337,29 @@ test('pull request descriptions render as provider-aware Markdown source context
         source,
       })),
     });
+    await using app = await renderReact(<App />);
 
-    const app = await renderReact(<App />);
-
-    try {
-      await waitFor(() => {
-        expect(app.container.querySelector('.codiff-source-description-header')).not.toBeNull();
-      });
-      const header = app.container.querySelector<HTMLElement>('.codiff-source-description-header');
-      const body = app.container.querySelector<HTMLElement>('.source-description-markdown');
-      expect(body?.textContent).toContain('Intent');
-      expect(body?.textContent).toContain('Ship review context.');
-      expect(header?.querySelector('.codiff-file-path')?.textContent).toBe(label);
-      expect(header?.querySelector('.source-description-title')).toBeNull();
-      if (source.author) {
-        expect(header?.querySelector('.source-description-author')).toBeNull();
-        expect(
-          app.container.querySelector('.source-description-author-header')?.textContent,
-        ).toContain(source.author.name ?? `@${source.author.login}`);
-      } else {
-        expect(header?.querySelector('.source-description-author')).toBeNull();
-      }
-      const toggle = header?.querySelector<HTMLButtonElement>('button.codiff-header-toggle');
-      expect(toggle).not.toBeNull();
-      expect(toggle?.getAttribute('aria-expanded')).toBe('true');
-      expect(toggle?.type).toBe('button');
-    } finally {
-      await app.cleanup();
+    await waitFor(() => {
+      expect(app.container.querySelector('.codiff-source-description-header')).not.toBeNull();
+    });
+    const header = app.container.querySelector<HTMLElement>('.codiff-source-description-header');
+    const body = app.container.querySelector<HTMLElement>('.source-description-markdown');
+    expect(body?.textContent).toContain('Intent');
+    expect(body?.textContent).toContain('Ship review context.');
+    expect(header?.querySelector('.codiff-file-path')?.textContent).toBe(label);
+    expect(header?.querySelector('.source-description-title')).toBeNull();
+    if (source.author) {
+      expect(header?.querySelector('.source-description-author')).toBeNull();
+      expect(
+        app.container.querySelector('.source-description-author-header')?.textContent,
+      ).toContain(source.author.name ?? `@${source.author.login}`);
+    } else {
+      expect(header?.querySelector('.source-description-author')).toBeNull();
     }
+    const toggle = header?.querySelector<HTMLButtonElement>('button.codiff-header-toggle');
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+    expect(toggle?.type).toBe('button');
   }
 });
 
@@ -1372,54 +1380,45 @@ test('pull request description collapse button toggles the markdown body', async
     })),
   });
 
-  const app = await renderReact(<App />);
+  await using app = await renderReact(<App />);
 
-  try {
-    await waitFor(() => {
-      expect(app.container.querySelector('.source-description-markdown')).not.toBeNull();
-    });
-    const repositoryLink = app.container.querySelector<HTMLAnchorElement>(
-      '.review-top-bar-repository',
-    );
-    const sourceLink = app.container.querySelector<HTMLAnchorElement>('.review-top-bar-source');
-    expect(repositoryLink?.href).toBe(source.url);
-    expect(sourceLink?.href).toBe(source.url);
-    expect(sourceLink?.textContent).toBe('PR #12');
-    expect(sourceLink?.querySelector('svg')).not.toBeNull();
-
-    let toggle = app.container.querySelector<HTMLButtonElement>('button.codiff-header-toggle');
-    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+  await waitFor(() => {
+    expect(app.container.querySelector('.source-description-markdown')).not.toBeNull();
+  });
+  const repositoryLink = app.container.querySelector<HTMLAnchorElement>(
+    '.review-top-bar-repository',
+  );
+  const sourceLink = app.container.querySelector<HTMLAnchorElement>('.review-top-bar-source');
+  expect(repositoryLink?.href).toBe(source.url);
+  expect(sourceLink?.href).toBe(source.url);
+  expect(sourceLink?.textContent).toBe('PR #12');
+  expect(sourceLink?.querySelector('svg')).not.toBeNull();
+  let toggle = app.container.querySelector<HTMLButtonElement>('button.codiff-header-toggle');
+  expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+  expect(app.container.querySelector('.source-description-markdown')?.textContent).toContain(
+    'Ship review context.',
+  );
+  await act(async () => {
+    toggle?.click();
+  });
+  await waitFor(() => {
+    toggle = app.container.querySelector<HTMLButtonElement>('button.codiff-header-toggle');
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(app.container.querySelector('.source-description-markdown')).toBeNull();
+  });
+  await act(async () => {
+    toggle?.click();
+  });
+  await waitFor(() => {
+    expect(
+      app.container
+        .querySelector<HTMLButtonElement>('button.codiff-header-toggle')
+        ?.getAttribute('aria-expanded'),
+    ).toBe('true');
     expect(app.container.querySelector('.source-description-markdown')?.textContent).toContain(
       'Ship review context.',
     );
-
-    await act(async () => {
-      toggle?.click();
-    });
-
-    await waitFor(() => {
-      toggle = app.container.querySelector<HTMLButtonElement>('button.codiff-header-toggle');
-      expect(toggle?.getAttribute('aria-expanded')).toBe('false');
-      expect(app.container.querySelector('.source-description-markdown')).toBeNull();
-    });
-
-    await act(async () => {
-      toggle?.click();
-    });
-
-    await waitFor(() => {
-      expect(
-        app.container
-          .querySelector<HTMLButtonElement>('button.codiff-header-toggle')
-          ?.getAttribute('aria-expanded'),
-      ).toBe('true');
-      expect(app.container.querySelector('.source-description-markdown')?.textContent).toContain(
-        'Ship review context.',
-      );
-    });
-  } finally {
-    await app.cleanup();
-  }
+  });
 });
 
 test('missing pull request descriptions do not render placeholder source context', async () => {
@@ -1437,17 +1436,13 @@ test('missing pull request descriptions do not render placeholder source context
     })),
   });
 
-  const app = await renderReact(<App />);
+  await using app = await renderReact(<App />);
 
-  try {
-    await waitFor(() => {
-      expect(app.container.querySelector('.codiff-file-header')).not.toBeNull();
-    });
-    expect(app.container.querySelector('.codiff-source-description-header')).toBeNull();
-    expect(app.container.textContent).not.toContain('PR description');
-  } finally {
-    await app.cleanup();
-  }
+  await waitFor(() => {
+    expect(app.container.querySelector('.codiff-file-header')).not.toBeNull();
+  });
+  expect(app.container.querySelector('.codiff-source-description-header')).toBeNull();
+  expect(app.container.textContent).not.toContain('PR description');
 });
 
 test('title-only pull request source context renders as a collapsed static header', async () => {
@@ -1477,23 +1472,18 @@ test('title-only pull request source context renders as a collapsed static heade
         source,
       })),
     });
+    await using app = await renderReact(<App />);
 
-    const app = await renderReact(<App />);
-
-    try {
-      await waitFor(() => {
-        expect(app.container.querySelector('.codiff-source-description-header')).not.toBeNull();
-      });
-      const header = app.container.querySelector<HTMLElement>('.codiff-source-description-header');
-      expect(header?.classList.contains('collapsed')).toBe(true);
-      expect(header?.querySelector('.source-description-title')?.textContent).toBe(source.title);
-      expect(header?.querySelector('.codiff-header-toggle-static')).not.toBeNull();
-      expect(header?.querySelector('button.codiff-header-toggle')).toBeNull();
-      expect(header?.querySelector('.codiff-chevron-box')).toBeNull();
-      expect(app.container.querySelector('.source-description-markdown')).toBeNull();
-    } finally {
-      await app.cleanup();
-    }
+    await waitFor(() => {
+      expect(app.container.querySelector('.codiff-source-description-header')).not.toBeNull();
+    });
+    const header = app.container.querySelector<HTMLElement>('.codiff-source-description-header');
+    expect(header?.classList.contains('collapsed')).toBe(true);
+    expect(header?.querySelector('.source-description-title')?.textContent).toBe(source.title);
+    expect(header?.querySelector('.codiff-header-toggle-static')).not.toBeNull();
+    expect(header?.querySelector('button.codiff-header-toggle')).toBeNull();
+    expect(header?.querySelector('.codiff-chevron-box')).toBeNull();
+    expect(app.container.querySelector('.source-description-markdown')).toBeNull();
   }
 });
 
@@ -1522,7 +1512,11 @@ test('narrative walkthrough stops show pull request descriptions once', async ()
             hunks: [
               {
                 added: 1,
-                anchor: { display: 'src/app.ts', sectionId: 'src/app.ts:unstaged', side: 'both' },
+                anchor: {
+                  display: 'src/app.ts',
+                  sectionId: 'src/app.ts:unstaged',
+                  side: 'both',
+                },
                 deleted: 1,
                 id: 'src/app.ts:unstaged:h1',
                 path: 'src/app.ts',
@@ -1566,20 +1560,15 @@ test('narrative walkthrough stops show pull request descriptions once', async ()
     })),
   });
 
-  const app = await renderReact(<App />);
+  await using app = await renderReact(<App />);
 
-  try {
-    await waitFor(() => {
-      expect(app.container.querySelector('.wt-stop-block')).not.toBeNull();
-    });
-
-    expect(app.container.querySelectorAll('.codiff-source-description-header')).toHaveLength(1);
-    expect(app.container.querySelectorAll('.source-description-markdown')).toHaveLength(1);
-    expect(app.container.textContent).toContain('Keep context visible in walkthrough');
-    expect(app.container.textContent).toContain('Keep the PR context visible.');
-  } finally {
-    await app.cleanup();
-  }
+  await waitFor(() => {
+    expect(app.container.querySelector('.wt-stop-block')).not.toBeNull();
+  });
+  expect(app.container.querySelectorAll('.codiff-source-description-header')).toHaveLength(1);
+  expect(app.container.querySelectorAll('.source-description-markdown')).toHaveLength(1);
+  expect(app.container.textContent).toContain('Keep context visible in walkthrough');
+  expect(app.container.textContent).toContain('Keep the PR context visible.');
 });
 
 test('narrative walkthrough stops do not repeat commit details', async () => {
@@ -1638,7 +1627,11 @@ test('narrative walkthrough stops do not repeat commit details', async () => {
             hunks: [
               {
                 added: 1,
-                anchor: { display: 'src/app.ts', sectionId: 'src/app.ts:unstaged', side: 'both' },
+                anchor: {
+                  display: 'src/app.ts',
+                  sectionId: 'src/app.ts:unstaged',
+                  side: 'both',
+                },
                 deleted: 1,
                 id: 'src/app.ts:unstaged:h1',
                 path: 'src/app.ts',
@@ -1687,28 +1680,25 @@ test('narrative walkthrough stops do not repeat commit details', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-      expect(container.querySelector('.wt-stop-block')).not.toBeNull();
-    });
-
-    expect(container.querySelector('.codiff-source-description-header')).toBeNull();
-    expect(container.querySelector('.source-description-markdown')).toBeNull();
-    expect(container.querySelector('.wt-stage-title')?.textContent).toContain(
-      'Implementation path',
-    );
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(container.querySelector('.wt-stop-block')).not.toBeNull();
+  });
+  expect(container.querySelector('.codiff-source-description-header')).toBeNull();
+  expect(container.querySelector('.source-description-markdown')).toBeNull();
+  expect(container.querySelector('.wt-stage-title')?.textContent).toContain('Implementation path');
 });
 
 test('a walkthrough file loads even without the walkthrough launch flag', async () => {
@@ -1728,7 +1718,11 @@ test('a walkthrough file loads even without the walkthrough launch flag', async 
             hunks: [
               {
                 added: 1,
-                anchor: { display: 'src/app.ts', sectionId: 'src/app.ts:unstaged', side: 'both' },
+                anchor: {
+                  display: 'src/app.ts',
+                  sectionId: 'src/app.ts:unstaged',
+                  side: 'both',
+                },
                 deleted: 1,
                 id: 'src/app.ts:unstaged:h1',
                 path: 'src/app.ts',
@@ -1778,24 +1772,23 @@ test('a walkthrough file loads even without the walkthrough launch flag', async 
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.wt-stop-block')).not.toBeNull();
-    });
-
-    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
-    expect(container.querySelector('.walkthrough-error')).toBeNull();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.wt-stop-block')).not.toBeNull();
+  });
+  expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
+  expect(container.querySelector('.walkthrough-error')).toBeNull();
 });
 
 test('plan mode opens the Markdown editor without loading repository state', async () => {
@@ -1922,238 +1915,241 @@ test('plan mode opens the Markdown editor without loading repository state', asy
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.plan-shell')).not.toBeNull();
-    });
-    expect(getRepositoryState).not.toHaveBeenCalled();
-    expect(markPlanReady).toHaveBeenCalledTimes(1);
-    expect(container.querySelector('.plan-title')?.textContent).toContain('plan.md');
-    await waitFor(() => {
-      expect(container.querySelector('[data-editor-type="frontmatter"]')).not.toBeNull();
-    });
-    expect(container.querySelector('.mdx-editor-content h2')).toBeNull();
-    expect(container.querySelectorAll('.mdx-editor-content ul > li')).toHaveLength(2);
-    await waitFor(() => {
-      expect(container.querySelector('.cm-content')).not.toBeNull();
-    });
-    expect(container.querySelector('.cm-gutters')).toBeNull();
-    expect(container.querySelector('.cm-content')?.textContent).toContain('vp test');
-    await waitFor(() => {
-      expect(container.querySelector('.plan-comment-thread')?.textContent).toContain(
-        'Keep the rollout steps explicit.',
-      );
-    });
-    const planCommentAvatar = container.querySelector('.plan-comment-thread .avatar.medium');
-    expect(planCommentAvatar?.tagName).toBe('SPAN');
-    expect(planCommentAvatar?.textContent).toBe('RE');
-    const commentTargetButton = container.querySelector<HTMLButtonElement>('.plan-comment-target');
-    expect(commentTargetButton?.textContent).toBe('Heading · Execute this plan');
-    expect(commentTargetButton?.disabled).toBe(false);
-    await act(async () => {
-      commentTargetButton?.click();
-    });
-    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
-    scrollIntoView.mockClear();
-    expect(container.querySelector('[data-mdx-annotation-block~="thread-1"]')).not.toBeNull();
-    expect(container.querySelectorAll('li[data-mdx-comment-block-type="listitem"]')).toHaveLength(
-      2,
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.plan-shell')).not.toBeNull();
+  });
+  expect(getRepositoryState).not.toHaveBeenCalled();
+  expect(markPlanReady).toHaveBeenCalledTimes(1);
+  expect(container.querySelector('.plan-title')?.textContent).toContain('plan.md');
+  await waitFor(() => {
+    expect(container.querySelector('[data-editor-type="frontmatter"]')).not.toBeNull();
+  });
+  expect(container.querySelector('.mdx-editor-content h2')).toBeNull();
+  expect(container.querySelectorAll('.mdx-editor-content ul > li')).toHaveLength(2);
+  await waitFor(() => {
+    expect(container.querySelector('.cm-content')).not.toBeNull();
+  });
+  expect(container.querySelector('.cm-gutters')).toBeNull();
+  expect(container.querySelector('.cm-content')?.textContent).toContain('vp test');
+  await waitFor(() => {
+    expect(container.querySelector('.plan-comment-thread')?.textContent).toContain(
+      'Keep the rollout steps explicit.',
     );
-
-    const planWorkspace = container.querySelector<HTMLElement>('.plan-workspace');
-    const editorContent = container.querySelector<HTMLElement>('.mdx-editor-content');
-    const commentBlock = container.querySelectorAll<HTMLElement>(
-      'li[data-mdx-comment-block-type="listitem"]',
-    )[1];
-    expect(planWorkspace).not.toBeNull();
-    expect(editorContent).not.toBeNull();
-    expect(commentBlock).toBeDefined();
-    planWorkspace!.getBoundingClientRect = () => ({
-      bottom: 700,
-      height: 650,
-      left: 100,
-      right: 1100,
-      toJSON: () => {},
-      top: 50,
-      width: 1000,
-      x: 100,
-      y: 50,
-    });
-    editorContent!.style.paddingRight = '24px';
-    editorContent!.getBoundingClientRect = () => ({
-      bottom: 650,
-      height: 550,
-      left: 120,
-      right: 1020,
-      toJSON: () => {},
-      top: 100,
-      width: 900,
-      x: 120,
-      y: 100,
-    });
-    commentBlock!.getBoundingClientRect = () => ({
-      bottom: 224,
-      height: 24,
-      left: 144,
-      right: 996,
-      toJSON: () => {},
-      top: 200,
-      width: 852,
-      x: 144,
-      y: 200,
-    });
-    await act(async () => {
-      commentBlock!.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
-    });
-    await waitFor(() => {
-      expect(container.querySelector('.plan-comment-affordance')).not.toBeNull();
-    });
-    const commentAffordance = container.querySelector<HTMLElement>('.plan-comment-affordance')!;
-    expect(commentAffordance.dataset.mdxCommentButton).toBe('');
-    expect(commentAffordance.style.getPropertyValue('--plan-comment-left')).toBe('896px');
-    expect(commentAffordance.style.getPropertyValue('--plan-comment-width')).toBe('48px');
-    expect(commentAffordance.querySelector(':scope > .plan-comment-add')).not.toBeNull();
-    await act(async () => {
-      editorContent!.dispatchEvent(
-        new MouseEvent('pointerleave', { relatedTarget: commentAffordance }),
-      );
-    });
+  });
+  const planCommentAvatar = container.querySelector('.plan-comment-thread .avatar.medium');
+  expect(planCommentAvatar?.tagName).toBe('SPAN');
+  expect(planCommentAvatar?.textContent).toBe('RE');
+  const commentTargetButton = container.querySelector<HTMLButtonElement>('.plan-comment-target');
+  expect(commentTargetButton?.textContent).toBe('Heading · Execute this plan');
+  expect(commentTargetButton?.disabled).toBe(false);
+  await act(async () => {
+    commentTargetButton?.click();
+  });
+  expect(scrollIntoView).toHaveBeenCalledWith({
+    behavior: 'smooth',
+    block: 'center',
+  });
+  scrollIntoView.mockClear();
+  expect(container.querySelector('[data-mdx-annotation-block~="thread-1"]')).not.toBeNull();
+  expect(container.querySelectorAll('li[data-mdx-comment-block-type="listitem"]')).toHaveLength(2);
+  const planWorkspace = container.querySelector<HTMLElement>('.plan-workspace');
+  const editorContent = container.querySelector<HTMLElement>('.mdx-editor-content');
+  const commentBlock = container.querySelectorAll<HTMLElement>(
+    'li[data-mdx-comment-block-type="listitem"]',
+  )[1];
+  expect(planWorkspace).not.toBeNull();
+  expect(editorContent).not.toBeNull();
+  expect(commentBlock).toBeDefined();
+  planWorkspace!.getBoundingClientRect = () => ({
+    bottom: 700,
+    height: 650,
+    left: 100,
+    right: 1100,
+    toJSON: () => {},
+    top: 50,
+    width: 1000,
+    x: 100,
+    y: 50,
+  });
+  editorContent!.style.paddingRight = '24px';
+  editorContent!.getBoundingClientRect = () => ({
+    bottom: 650,
+    height: 550,
+    left: 120,
+    right: 1020,
+    toJSON: () => {},
+    top: 100,
+    width: 900,
+    x: 120,
+    y: 100,
+  });
+  commentBlock!.getBoundingClientRect = () => ({
+    bottom: 224,
+    height: 24,
+    left: 144,
+    right: 996,
+    toJSON: () => {},
+    top: 200,
+    width: 852,
+    x: 144,
+    y: 200,
+  });
+  await act(async () => {
+    commentBlock!.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
+  });
+  await waitFor(() => {
     expect(container.querySelector('.plan-comment-affordance')).not.toBeNull();
-    await act(async () => {
-      commentAffordance.dispatchEvent(
-        new MouseEvent('pointerout', { bubbles: true, relatedTarget: editorContent }),
-      );
-    });
-    expect(container.querySelector('.plan-comment-affordance')).not.toBeNull();
-    await act(async () => {
-      commentAffordance.dispatchEvent(
-        new MouseEvent('pointerout', { bubbles: true, relatedTarget: planWorkspace }),
-      );
-    });
-    expect(container.querySelector('.plan-comment-affordance')).toBeNull();
-    await act(async () => {
-      container
-        .querySelectorAll<HTMLElement>('li[data-mdx-comment-block-type="listitem"]')[0]!
-        .dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
-      commentBlock!.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
-    });
-    const addCommentButton = container.querySelector<HTMLButtonElement>('.plan-comment-add');
-    expect(addCommentButton).not.toBeNull();
-    await act(async () => {
-      addCommentButton!.click();
-    });
-    const activeComment = container.querySelector<HTMLElement>('.plan-comment-thread.active');
-    expect(activeComment).not.toBeNull();
-    expect(activeComment!.closest<HTMLElement>('.plan-comment-position')?.style.top).not.toBe(
-      '0px',
+  });
+  const commentAffordance = container.querySelector<HTMLElement>('.plan-comment-affordance')!;
+  expect(commentAffordance.dataset.mdxCommentButton).toBe('');
+  expect(commentAffordance.style.getPropertyValue('--plan-comment-left')).toBe('896px');
+  expect(commentAffordance.style.getPropertyValue('--plan-comment-width')).toBe('48px');
+  expect(commentAffordance.querySelector(':scope > .plan-comment-add')).not.toBeNull();
+  await act(async () => {
+    editorContent!.dispatchEvent(
+      new MouseEvent('pointerleave', { relatedTarget: commentAffordance }),
     );
-    const activeCommentDelete =
-      activeComment!.querySelector<HTMLButtonElement>('.review-comment-delete');
-    expect(activeCommentDelete).not.toBeNull();
-    await act(async () => {
-      activeCommentDelete!.click();
-    });
-
-    const commentRail = container.querySelector<HTMLElement>('.plan-comment-rail-scroll');
-    const commentPosition = container.querySelector<HTMLElement>('.plan-comment-position');
-    const annotatedBlock = container.querySelector<HTMLElement>(
-      '[data-mdx-annotation-block~="thread-1"]',
-    );
-    expect(commentRail).not.toBeNull();
-    expect(commentPosition).not.toBeNull();
-    expect(annotatedBlock).not.toBeNull();
-    commentRail!.style.overflowY = 'auto';
-    commentRail!.getBoundingClientRect = () => ({
-      bottom: 300,
-      height: 200,
-      left: 0,
-      right: 400,
-      toJSON: () => {},
-      top: 100,
-      width: 400,
-      x: 0,
-      y: 100,
-    });
-    commentPosition!.getBoundingClientRect = () => ({
-      bottom: 360,
-      height: 100,
-      left: 0,
-      right: 400,
-      toJSON: () => {},
-      top: 260,
-      width: 400,
-      x: 0,
-      y: 260,
-    });
-    const scrollCommentRail = vi.fn();
-    commentRail!.scrollTo = scrollCommentRail;
-    await act(async () => {
-      annotatedBlock!.click();
-    });
-    await waitFor(() => {
-      expect(scrollCommentRail).toHaveBeenCalledWith({ behavior: 'smooth', top: 68 });
-    });
-    expect(scrollIntoView).not.toHaveBeenCalled();
-
-    const deleteButtons = container.querySelectorAll<HTMLButtonElement>('.review-comment-delete');
-    expect(deleteButtons).toHaveLength(2);
-    await act(async () => {
-      deleteButtons[1]!.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
-      deleteButtons[1]!.click();
-    });
-    expect(scrollIntoView).not.toHaveBeenCalled();
-
-    const shareButton = container.querySelector<HTMLButtonElement>('.plan-share-button');
-    expect(shareButton?.textContent).toContain('Share');
-    await act(async () => {
-      shareButton?.click();
-    });
-    await waitFor(() => {
-      expect(sharePlan).toHaveBeenCalledTimes(1);
-    });
-    expect(sharePlan.mock.calls[0]?.[0].threads).toHaveLength(1);
-    expect(shareButton?.textContent).toContain('Copied');
-
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.plan-done-button')?.click();
-    });
-    await waitFor(() => {
-      expect(completePlan).toHaveBeenCalledTimes(1);
-    });
-    expect(completePlan).toHaveBeenCalledWith(
-      expect.objectContaining({
-        document: {
-          id: 'plan:/tmp/plan.md',
-          path: '/tmp/plan.md',
-          version: 'plan-version',
-        },
-        threads: [
-          expect.objectContaining({
-            id: 'thread-1',
-            messages: [
-              expect.objectContaining({
-                body: 'Keep the rollout steps explicit.',
-              }),
-            ],
-          }),
-        ],
-        version: 1,
+  });
+  expect(container.querySelector('.plan-comment-affordance')).not.toBeNull();
+  await act(async () => {
+    commentAffordance.dispatchEvent(
+      new MouseEvent('pointerout', {
+        bubbles: true,
+        relatedTarget: editorContent,
       }),
-      'done',
     );
-    expect(completePlan.mock.calls[0]?.[0].threads).toHaveLength(1);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
-    container.remove();
-  }
+  });
+  expect(container.querySelector('.plan-comment-affordance')).not.toBeNull();
+  await act(async () => {
+    commentAffordance.dispatchEvent(
+      new MouseEvent('pointerout', {
+        bubbles: true,
+        relatedTarget: planWorkspace,
+      }),
+    );
+  });
+  expect(container.querySelector('.plan-comment-affordance')).toBeNull();
+  await act(async () => {
+    container
+      .querySelectorAll<HTMLElement>('li[data-mdx-comment-block-type="listitem"]')[0]!
+      .dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
+    commentBlock!.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
+  });
+  const addCommentButton = container.querySelector<HTMLButtonElement>('.plan-comment-add');
+  expect(addCommentButton).not.toBeNull();
+  await act(async () => {
+    addCommentButton!.click();
+  });
+  const activeComment = container.querySelector<HTMLElement>('.plan-comment-thread.active');
+  expect(activeComment).not.toBeNull();
+  expect(activeComment!.closest<HTMLElement>('.plan-comment-position')?.style.top).not.toBe('0px');
+  const activeCommentDelete =
+    activeComment!.querySelector<HTMLButtonElement>('.review-comment-delete');
+  expect(activeCommentDelete).not.toBeNull();
+  await act(async () => {
+    activeCommentDelete!.click();
+  });
+  const commentRail = container.querySelector<HTMLElement>('.plan-comment-rail-scroll');
+  const commentPosition = container.querySelector<HTMLElement>('.plan-comment-position');
+  const annotatedBlock = container.querySelector<HTMLElement>(
+    '[data-mdx-annotation-block~="thread-1"]',
+  );
+  expect(commentRail).not.toBeNull();
+  expect(commentPosition).not.toBeNull();
+  expect(annotatedBlock).not.toBeNull();
+  commentRail!.style.overflowY = 'auto';
+  commentRail!.getBoundingClientRect = () => ({
+    bottom: 300,
+    height: 200,
+    left: 0,
+    right: 400,
+    toJSON: () => {},
+    top: 100,
+    width: 400,
+    x: 0,
+    y: 100,
+  });
+  commentPosition!.getBoundingClientRect = () => ({
+    bottom: 360,
+    height: 100,
+    left: 0,
+    right: 400,
+    toJSON: () => {},
+    top: 260,
+    width: 400,
+    x: 0,
+    y: 260,
+  });
+  const scrollCommentRail = vi.fn();
+  commentRail!.scrollTo = scrollCommentRail;
+  await act(async () => {
+    annotatedBlock!.click();
+  });
+  await waitFor(() => {
+    expect(scrollCommentRail).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      top: 68,
+    });
+  });
+  expect(scrollIntoView).not.toHaveBeenCalled();
+  const deleteButtons = container.querySelectorAll<HTMLButtonElement>('.review-comment-delete');
+  expect(deleteButtons).toHaveLength(2);
+  await act(async () => {
+    deleteButtons[1]!.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    deleteButtons[1]!.click();
+  });
+  expect(scrollIntoView).not.toHaveBeenCalled();
+  const shareButton = container.querySelector<HTMLButtonElement>('.plan-share-button');
+  expect(shareButton?.textContent).toContain('Share');
+  await act(async () => {
+    shareButton?.click();
+  });
+  await waitFor(() => {
+    expect(sharePlan).toHaveBeenCalledTimes(1);
+  });
+  expect(sharePlan.mock.calls[0]?.[0].threads).toHaveLength(1);
+  expect(shareButton?.textContent).toContain('Copied');
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('.plan-done-button')?.click();
+  });
+  await waitFor(() => {
+    expect(completePlan).toHaveBeenCalledTimes(1);
+  });
+  expect(completePlan).toHaveBeenCalledWith(
+    expect.objectContaining({
+      document: {
+        id: 'plan:/tmp/plan.md',
+        path: '/tmp/plan.md',
+        version: 'plan-version',
+      },
+      threads: [
+        expect.objectContaining({
+          id: 'thread-1',
+          messages: [
+            expect.objectContaining({
+              body: 'Keep the rollout steps explicit.',
+            }),
+          ],
+        }),
+      ],
+      version: 1,
+    }),
+    'done',
+  );
+  expect(completePlan.mock.calls[0]?.[0].threads).toHaveLength(1);
 });
 
 test('plan mode resolves stored comments whose anchors were already removed', async () => {
@@ -2223,54 +2219,53 @@ test('plan mode resolves stored comments whose anchors were already removed', as
   document.body.append(container);
   const root = createRoot(container);
 
-  try {
-    await act(async () => {
-      root.render(<App />);
-    });
-    await waitFor(() => {
-      expect(savePlanReview).toHaveBeenCalledWith(
-        expect.objectContaining({
-          threads: [
-            expect.objectContaining({
-              id: 'detached-thread',
-              resolution: expect.objectContaining({
-                reason: 'anchor-removed',
-                resolvedAt: expect.any(String),
-              }),
-              status: 'resolved',
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(savePlanReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threads: [
+          expect.objectContaining({
+            id: 'detached-thread',
+            resolution: expect.objectContaining({
+              reason: 'anchor-removed',
+              resolvedAt: expect.any(String),
             }),
-          ],
-        }),
-      );
-    });
-
-    const resolvedSection = container.querySelector<HTMLDetailsElement>('.plan-resolved-comments');
-    expect(resolvedSection?.open).toBe(false);
-    expect(resolvedSection?.querySelector('summary')?.textContent).toBe('Resolved comments (1)');
-    expect(container.querySelector('.plan-comment-thread.resolved')?.textContent).toContain(
-      'Resolved after target removal',
+            status: 'resolved',
+          }),
+        ],
+      }),
     );
-    expect(container.querySelector('[data-mdx-annotation-block~="detached-thread"]')).toBeNull();
-
-    await act(async () => {
-      resolvedSection!.open = true;
-      resolvedSection!.dispatchEvent(new Event('toggle'));
-    });
-    await act(async () => {
-      resolvedSection?.querySelector<HTMLButtonElement>('.review-comment-delete')?.click();
-    });
-    await waitFor(() => {
-      expect(container.querySelector('.plan-resolved-comments')).toBeNull();
-      expect(savePlanReview).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          threads: [],
-        }),
-      );
-    });
-  } finally {
-    await act(async () => root.unmount());
-    container.remove();
-  }
+  });
+  const resolvedSection = container.querySelector<HTMLDetailsElement>('.plan-resolved-comments');
+  expect(resolvedSection?.open).toBe(false);
+  expect(resolvedSection?.querySelector('summary')?.textContent).toBe('Resolved comments (1)');
+  expect(container.querySelector('.plan-comment-thread.resolved')?.textContent).toContain(
+    'Resolved after target removal',
+  );
+  expect(container.querySelector('[data-mdx-annotation-block~="detached-thread"]')).toBeNull();
+  await act(async () => {
+    resolvedSection!.open = true;
+    resolvedSection!.dispatchEvent(new Event('toggle'));
+  });
+  await act(async () => {
+    resolvedSection?.querySelector<HTMLButtonElement>('.review-comment-delete')?.click();
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.plan-resolved-comments')).toBeNull();
+    expect(savePlanReview).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        threads: [],
+      }),
+    );
+  });
 });
 
 test('plan mode keeps comments open when their anchors are removed during the current review', async () => {
@@ -2359,45 +2354,44 @@ test('plan mode keeps comments open when their anchors are removed during the cu
   document.body.append(container);
   const root = createRoot(container);
 
-  try {
-    await act(async () => {
-      root.render(<App />);
-    });
-    await waitFor(() => {
-      expect(container.querySelector('[data-mdx-annotation-block~="live-thread"]')).not.toBeNull();
-      expect(publishMarkdownChange).not.toBeNull();
-    });
-    savePlanReview.mockClear();
-
-    await act(async () => {
-      publishMarkdownChange?.({
-        deleted: false,
-        document: {
-          content: '# Replacement plan\n',
-          id: 'plan:/tmp/plan.md',
-          kind: 'plan',
-          path: '/tmp/plan.md',
-          version: 'next-plan-version',
-        },
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('[data-mdx-annotation-block~="live-thread"]')).not.toBeNull();
+    expect(publishMarkdownChange).not.toBeNull();
+  });
+  savePlanReview.mockClear();
+  await act(async () => {
+    publishMarkdownChange?.({
+      deleted: false,
+      document: {
+        content: '# Replacement plan\n',
         id: 'plan:/tmp/plan.md',
-      });
+        kind: 'plan',
+        path: '/tmp/plan.md',
+        version: 'next-plan-version',
+      },
+      id: 'plan:/tmp/plan.md',
     });
-    await waitFor(() => {
-      expect(container.querySelector('[data-mdx-annotation-block~="live-thread"]')).toBeNull();
-    });
-
-    expect(container.querySelector('.plan-resolved-comments')).toBeNull();
-    expect(container.querySelector('.plan-comment-position .plan-comment-thread')).not.toBeNull();
-    expect(
-      savePlanReview.mock.calls.some(
-        ([review]) =>
-          review.threads.find((thread) => thread.id === 'live-thread')?.status === 'resolved',
-      ),
-    ).toBe(false);
-  } finally {
-    await act(async () => root.unmount());
-    container.remove();
-  }
+  });
+  await waitFor(() => {
+    expect(container.querySelector('[data-mdx-annotation-block~="live-thread"]')).toBeNull();
+  });
+  expect(container.querySelector('.plan-resolved-comments')).toBeNull();
+  expect(container.querySelector('.plan-comment-position .plan-comment-thread')).not.toBeNull();
+  expect(
+    savePlanReview.mock.calls.some(
+      ([review]) =>
+        review.threads.find((thread) => thread.id === 'live-thread')?.status === 'resolved',
+    ),
+  ).toBe(false);
 });
 
 test('closing plan mode flushes and returns a closed handoff', async () => {
@@ -2487,65 +2481,63 @@ test('closing plan mode flushes and returns a closed handoff', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.plan-shell')).not.toBeNull();
-      expect(requestClose).not.toBeNull();
-      expect(container.querySelector('.plan-comment-thread')).not.toBeNull();
-    });
-    await act(async () => {
-      await new Promise((resolveWait) => setTimeout(resolveWait, 75));
-    });
-    savePlanReview.mockClear();
-    blockPlanReviewSave = true;
-    await act(async () => {
-      requestClose?.();
-    });
-    await waitFor(() => {
-      expect(savePlanReview).toHaveBeenCalledTimes(1);
-    });
-    expect(completePlan).not.toHaveBeenCalled();
-    expect(
-      [...container.querySelectorAll<HTMLElement>('[contenteditable]')].map((element) =>
-        element.getAttribute('contenteditable'),
-      ),
-    ).toEqual(['false', 'false']);
-    expect(container.querySelector<HTMLButtonElement>('.review-comment-delete')?.disabled).toBe(
-      true,
-    );
-    await act(async () => {
-      resolvePlanReviewSave?.();
-    });
-    await waitFor(() => {
-      expect(completePlan).toHaveBeenCalledTimes(1);
-    });
-    expect(completePlan).toHaveBeenCalledWith(
-      expect.objectContaining({
-        document: {
-          id: 'plan:/tmp/plan.md',
-          path: '/tmp/plan.md',
-          version: 'plan-version',
-        },
-        threads: [
-          expect.objectContaining({
-            id: 'thread-1',
-          }),
-        ],
-        version: 1,
-      }),
-      'closed',
-    );
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.plan-shell')).not.toBeNull();
+    expect(requestClose).not.toBeNull();
+    expect(container.querySelector('.plan-comment-thread')).not.toBeNull();
+  });
+  await act(async () => {
+    await new Promise((resolveWait) => setTimeout(resolveWait, 75));
+  });
+  savePlanReview.mockClear();
+  blockPlanReviewSave = true;
+  await act(async () => {
+    requestClose?.();
+  });
+  await waitFor(() => {
+    expect(savePlanReview).toHaveBeenCalledTimes(1);
+  });
+  expect(completePlan).not.toHaveBeenCalled();
+  expect(
+    [...container.querySelectorAll<HTMLElement>('[contenteditable]')].map((element) =>
+      element.getAttribute('contenteditable'),
+    ),
+  ).toEqual(['false', 'false']);
+  expect(container.querySelector<HTMLButtonElement>('.review-comment-delete')?.disabled).toBe(true);
+  await act(async () => {
+    resolvePlanReviewSave?.();
+  });
+  await waitFor(() => {
+    expect(completePlan).toHaveBeenCalledTimes(1);
+  });
+  expect(completePlan).toHaveBeenCalledWith(
+    expect.objectContaining({
+      document: {
+        id: 'plan:/tmp/plan.md',
+        path: '/tmp/plan.md',
+        version: 'plan-version',
+      },
+      threads: [
+        expect.objectContaining({
+          id: 'thread-1',
+        }),
+      ],
+      version: 1,
+    }),
+    'closed',
+  );
 });
 
 test('plan mode recovers from an unreadable review sidecar', async () => {
@@ -2574,26 +2566,24 @@ test('plan mode recovers from an unreadable review sidecar', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.plan-shell')).not.toBeNull();
-    });
-    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
-      'Invalid plan review.',
-    );
-    expect(container.querySelector('[contenteditable="true"]')).not.toBeNull();
-    expect(markPlanReady).toHaveBeenCalledTimes(1);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.plan-shell')).not.toBeNull();
+  });
+  expect(container.querySelector('[role="alert"]')?.textContent).toContain('Invalid plan review.');
+  expect(container.querySelector('[contenteditable="true"]')).not.toBeNull();
+  expect(markPlanReady).toHaveBeenCalledTimes(1);
 });
 
 test('a walkthrough file that no longer anchors surfaces a dismissible banner', async () => {
@@ -2620,31 +2610,28 @@ test('a walkthrough file that no longer anchors surfaces a dismissible banner', 
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.walkthrough-outdated-banner.visible')).not.toBeNull();
-    });
-
-    const banner = container.querySelector('.walkthrough-outdated-banner');
-    expect(banner?.textContent).toContain('committed since the walkthrough was authored');
-    expect(banner?.textContent).toContain('Showing history instead.');
-
-    await act(async () => {
-      banner?.querySelector<HTMLButtonElement>('.repository-change-dismiss')?.click();
-    });
-
-    expect(container.querySelector('.walkthrough-outdated-banner.visible')).toBeNull();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.walkthrough-outdated-banner.visible')).not.toBeNull();
+  });
+  const banner = container.querySelector('.walkthrough-outdated-banner');
+  expect(banner?.textContent).toContain('committed since the walkthrough was authored');
+  expect(banner?.textContent).toContain('Showing history instead.');
+  await act(async () => {
+    banner?.querySelector<HTMLButtonElement>('.repository-change-dismiss')?.click();
+  });
+  expect(container.querySelector('.walkthrough-outdated-banner.visible')).toBeNull();
 });
 
 test('repository changes show the update banner without refreshing the working tree', async () => {
@@ -2665,33 +2652,30 @@ test('repository changes show the update banner without refreshing the working t
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-      expect(onRepositoryChanged).not.toBeNull();
-    });
-
-    expect(container.querySelector('.repository-change-banner.visible')).toBeNull();
-    expect(getRepositoryState).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      onRepositoryChanged?.({ root: '/repo' });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    expect(container.querySelector('.repository-change-banner.visible')).not.toBeNull();
-    expect(getRepositoryState).toHaveBeenCalledTimes(1);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(onRepositoryChanged).not.toBeNull();
+  });
+  expect(container.querySelector('.repository-change-banner.visible')).toBeNull();
+  expect(getRepositoryState).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    onRepositoryChanged?.({ root: '/repo' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(container.querySelector('.repository-change-banner.visible')).not.toBeNull();
+  expect(getRepositoryState).toHaveBeenCalledTimes(1);
 });
 
 test('clicking the change banner refreshes the repository in place', async () => {
@@ -2762,45 +2746,41 @@ test('clicking the change banner refreshes the repository in place', async () =>
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-      expect(onRepositoryChanged).not.toBeNull();
-    });
-    expect(container.textContent).not.toContain('added.ts');
-
-    await act(async () => {
-      onRepositoryChanged?.({ root: '/repo' });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    const refreshButton = container.querySelector<HTMLButtonElement>('.repository-change-reload');
-    expect(refreshButton).not.toBeNull();
-    await act(async () => {
-      refreshButton?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    // New file appears without a window reload, and the banner clears.
-    expect(getRepositoryState).toHaveBeenCalledTimes(2);
-    expect(container.textContent).toContain('added.ts');
-    expect(container.querySelector('.repository-change-banner.visible')).toBeNull();
-
-    // The changed file must not appear twice (old + new version).
-    const appOccurrences = container.textContent?.split('app.ts').length ?? 1;
-    expect(appOccurrences - 1).toBeLessThanOrEqual(2);
-    expect(container.textContent).not.toContain('-old\n+new\n');
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(onRepositoryChanged).not.toBeNull();
+  });
+  expect(container.textContent).not.toContain('added.ts');
+  await act(async () => {
+    onRepositoryChanged?.({ root: '/repo' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  const refreshButton = container.querySelector<HTMLButtonElement>('.repository-change-reload');
+  expect(refreshButton).not.toBeNull();
+  await act(async () => {
+    refreshButton?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  // New file appears without a window reload, and the banner clears.
+  expect(getRepositoryState).toHaveBeenCalledTimes(2);
+  expect(container.textContent).toContain('added.ts');
+  expect(container.querySelector('.repository-change-banner.visible')).toBeNull();
+  // The changed file must not appear twice (old + new version).
+  const appOccurrences = container.textContent?.split('app.ts').length ?? 1;
+  expect(appOccurrences - 1).toBeLessThanOrEqual(2);
+  expect(container.textContent).not.toContain('-old\n+new\n');
 });
 
 test('refreshing all changes re-resolves the branch snapshot', async () => {
@@ -2872,67 +2852,63 @@ test('refreshing all changes re-resolves the branch snapshot', async () => {
       button.textContent?.includes(label),
     );
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-      expect(onRepositoryChanged).not.toBeNull();
-    });
-
-    await act(async () => {
-      onRepositoryChanged?.({ root: '/repo' });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await waitFor(() => {
-      expect(container.textContent).toContain('added.ts');
-    });
-    expect(getRepositoryState).toHaveBeenNthCalledWith(2, {
-      ref: 'main',
-      type: 'branch-working-tree',
-    });
-    expect(getRepositoryHistory).toHaveBeenLastCalledWith(expect.any(Number), {
-      ref: 'main',
-      type: 'branch-working-tree',
-    });
-
-    await act(async () => {
-      findButton('History')?.click();
-    });
-    await waitFor(() => {
-      expect(findButton('Committed only vs main')).toBeTruthy();
-    });
-
-    await act(async () => {
-      findButton('Committed only vs main')?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    expect(getRepositoryState).toHaveBeenLastCalledWith({
-      baseRef: refreshedSource.baseRef,
-      headRef: refreshedSource.headRef,
-      ref: refreshedSource.ref,
-      type: 'branch-diff',
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+    expect(onRepositoryChanged).not.toBeNull();
+  });
+  await act(async () => {
+    onRepositoryChanged?.({ root: '/repo' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(container.textContent).toContain('added.ts');
+  });
+  expect(getRepositoryState).toHaveBeenNthCalledWith(2, {
+    ref: 'main',
+    type: 'branch-working-tree',
+  });
+  expect(getRepositoryHistory).toHaveBeenLastCalledWith(expect.any(Number), {
+    ref: 'main',
+    type: 'branch-working-tree',
+  });
+  await act(async () => {
+    findButton('History')?.click();
+  });
+  await waitFor(() => {
+    expect(findButton('Committed only vs main')).toBeTruthy();
+  });
+  await act(async () => {
+    findButton('Committed only vs main')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(getRepositoryState).toHaveBeenLastCalledWith({
+    baseRef: refreshedSource.baseRef,
+    headRef: refreshedSource.headRef,
+    ref: refreshedSource.ref,
+    type: 'branch-diff',
+  });
 });
 
 test('refreshing changed viewed files expands them in place', async () => {
-  const initialFile = createChangedFile('src/viewed.ts', { fingerprint: 'viewed:1' });
+  const initialFile = createChangedFile('src/viewed.ts', {
+    fingerprint: 'viewed:1',
+  });
   const refreshedFile = createChangedFile('src/viewed.ts', {
     fingerprint: 'viewed:2',
     patch: 'diff --git a/src/viewed.ts b/src/viewed.ts\n@@ -1 +1 @@\n-old\n+newer\n',
@@ -2966,44 +2942,41 @@ test('refreshing changed viewed files expands them in place', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      const header = container.querySelector('.codiff-file-header');
-      expect(header).not.toBeNull();
-      expect(header?.classList.contains('collapsed')).toBe(true);
-    });
-
-    await act(async () => {
-      onRepositoryChanged?.({ root: '/repo' });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    const refreshButton = container.querySelector<HTMLButtonElement>('.repository-change-reload');
-    expect(refreshButton).not.toBeNull();
-    await act(async () => {
-      refreshButton?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await waitFor(() => {
-      const header = container.querySelector('.codiff-file-header');
-      expect(header).not.toBeNull();
-      expect(header?.classList.contains('collapsed')).toBe(false);
-      expect(header?.querySelector('.codiff-viewed-button')?.getAttribute('aria-pressed')).toBe(
-        'false',
-      );
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    const header = container.querySelector('.codiff-file-header');
+    expect(header).not.toBeNull();
+    expect(header?.classList.contains('collapsed')).toBe(true);
+  });
+  await act(async () => {
+    onRepositoryChanged?.({ root: '/repo' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  const refreshButton = container.querySelector<HTMLButtonElement>('.repository-change-reload');
+  expect(refreshButton).not.toBeNull();
+  await act(async () => {
+    refreshButton?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    const header = container.querySelector('.codiff-file-header');
+    expect(header).not.toBeNull();
+    expect(header?.classList.contains('collapsed')).toBe(false);
+    expect(header?.querySelector('.codiff-viewed-button')?.getAttribute('aria-pressed')).toBe(
+      'false',
+    );
+  });
 });
 
 test('refreshing changed files automatically regenerates the walkthrough', async () => {
@@ -3084,63 +3057,59 @@ test('refreshing changed files automatically regenerates the walkthrough', async
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.wt-stop-block')).not.toBeNull();
-      expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
-    });
-
-    await act(async () => {
-      onRepositoryChanged?.({ root: '/repo' });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await waitFor(() => {
-      expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(2);
-      expect(container.textContent).toContain('Review the added file.');
-      expect(container.textContent).toContain('added.ts');
-      expect(container.textContent).not.toContain('Regenerate walkthrough');
-      expect(container.textContent).not.toContain('Changed after the walkthrough was generated.');
-    });
-    expect(getNarrativeWalkthrough).toHaveBeenLastCalledWith(repositoryState.source, {
-      force: true,
-      previousWalkthrough: initialWalkthrough,
-    });
-
-    await act(async () => {
-      onRepositoryChanged?.({ root: '/repo' });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await waitFor(() => {
-      expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(3);
-      expect(container.textContent).toContain('Review the later file.');
-      expect(container.textContent).toContain('added.ts');
-      expect(container.textContent).toContain('later.ts');
-    });
-    expect(getNarrativeWalkthrough).toHaveBeenLastCalledWith(repositoryState.source, {
-      force: true,
-      previousWalkthrough: addedWalkthrough,
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.wt-stop-block')).not.toBeNull();
+    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
+  });
+  await act(async () => {
+    onRepositoryChanged?.({ root: '/repo' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain('Review the added file.');
+    expect(container.textContent).toContain('added.ts');
+    expect(container.textContent).not.toContain('Regenerate walkthrough');
+    expect(container.textContent).not.toContain('Changed after the walkthrough was generated.');
+  });
+  expect(getNarrativeWalkthrough).toHaveBeenLastCalledWith(repositoryState.source, {
+    force: true,
+    previousWalkthrough: initialWalkthrough,
+  });
+  await act(async () => {
+    onRepositoryChanged?.({ root: '/repo' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(3);
+    expect(container.textContent).toContain('Review the later file.');
+    expect(container.textContent).toContain('added.ts');
+    expect(container.textContent).toContain('later.ts');
+  });
+  expect(getNarrativeWalkthrough).toHaveBeenLastCalledWith(repositoryState.source, {
+    force: true,
+    previousWalkthrough: addedWalkthrough,
+  });
 });
 
 test('drops automatic walkthrough regeneration when the same source refreshes again', async () => {
@@ -3201,7 +3170,10 @@ test('drops automatic walkthrough regeneration when the same source refreshes ag
   const getNarrativeWalkthrough = vi.fn(() => {
     walkthroughRequests += 1;
     if (walkthroughRequests === 1) {
-      return Promise.resolve({ status: 'ready' as const, walkthrough: initialWalkthrough });
+      return Promise.resolve({
+        status: 'ready' as const,
+        walkthrough: initialWalkthrough,
+      });
     }
     return new Promise<{ status: 'ready'; walkthrough: NarrativeWalkthrough }>((resolve) => {
       if (walkthroughRequests === 2) {
@@ -3242,48 +3214,52 @@ test('drops automatic walkthrough regeneration when the same source refreshes ag
     });
   };
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-    await waitFor(() => {
-      expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
-    });
-
-    await refresh();
-    await waitFor(() => {
-      expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(2);
-      expect(container.querySelector('.wt-stop-block')).toBeNull();
-      expect(container.textContent).toContain('Generating walkthrough');
-      expect(container.textContent).not.toContain('Regenerate walkthrough');
-    });
-
-    await refresh();
-    await waitFor(() => {
-      expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(3);
-    });
-    await act(async () => {
-      resolveFirstRegeneration?.({ status: 'ready', walkthrough: staleRegeneration });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
+  });
+  await refresh();
+  await waitFor(() => {
+    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(2);
     expect(container.querySelector('.wt-stop-block')).toBeNull();
-    expect(container.textContent).not.toContain('Stale regeneration.');
-
-    await act(async () => {
-      resolveSecondRegeneration?.({ status: 'ready', walkthrough: latestRegeneration });
-      await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(container.textContent).toContain('Generating walkthrough');
+    expect(container.textContent).not.toContain('Regenerate walkthrough');
+  });
+  await refresh();
+  await waitFor(() => {
+    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(3);
+  });
+  await act(async () => {
+    resolveFirstRegeneration?.({
+      status: 'ready',
+      walkthrough: staleRegeneration,
     });
-    await waitFor(() => {
-      expect(container.textContent).toContain('Latest regeneration.');
-      expect(container.textContent).toContain('later.ts');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(container.querySelector('.wt-stop-block')).toBeNull();
+  expect(container.textContent).not.toContain('Stale regeneration.');
+  await act(async () => {
+    resolveSecondRegeneration?.({
+      status: 'ready',
+      walkthrough: latestRegeneration,
     });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(container.textContent).toContain('Latest regeneration.');
+    expect(container.textContent).toContain('later.ts');
+  });
 });
 
 test('committing and then editing again clears and regenerates the walkthrough', async () => {
@@ -3310,7 +3286,10 @@ test('committing and then editing again clears and regenerates the walkthrough',
   const getNarrativeWalkthrough = vi.fn(() => {
     walkthroughRequests += 1;
     if (walkthroughRequests === 1) {
-      return Promise.resolve({ status: 'ready' as const, walkthrough: initialWalkthrough });
+      return Promise.resolve({
+        status: 'ready' as const,
+        walkthrough: initialWalkthrough,
+      });
     }
     return new Promise<{ status: 'ready'; walkthrough: NarrativeWalkthrough }>((resolve) => {
       resolveNextWalkthrough = resolve;
@@ -3342,66 +3321,62 @@ test('committing and then editing again clears and regenerates the walkthrough',
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-    await waitFor(() => {
-      expect(container.querySelector('.wt-stop-block')).not.toBeNull();
-    });
-
-    await act(async () => {
-      onRepositoryChanged?.({ root: '/repo' });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await waitFor(() => {
-      expect(container.textContent).toContain('No local changes');
-      expect(container.querySelector('.wt-stop-block')).toBeNull();
-    });
-    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      onRepositoryChanged?.({ root: '/repo' });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await waitFor(() => {
-      expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(2);
-      expect(container.textContent).toContain('Generating walkthrough');
-      expect(container.textContent).not.toContain('Initial walkthrough.');
-      expect(container.querySelector('.wt-stop-block')).toBeNull();
-    });
-    expect(getNarrativeWalkthrough).toHaveBeenLastCalledWith(repositoryState.source, {
-      force: true,
-      previousWalkthrough: undefined,
-    });
-
-    await act(async () => {
-      resolveNextWalkthrough?.({ status: 'ready', walkthrough: nextWalkthrough });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    await waitFor(() => {
-      expect(container.textContent).toContain('Fresh walkthrough.');
-      expect(container.textContent).toContain('next.ts');
-      expect(container.textContent).not.toContain('Regenerate walkthrough');
-      expect(container.textContent).not.toContain('Changed after the walkthrough was generated.');
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.wt-stop-block')).not.toBeNull();
+  });
+  await act(async () => {
+    onRepositoryChanged?.({ root: '/repo' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(container.textContent).toContain('No local changes');
+    expect(container.querySelector('.wt-stop-block')).toBeNull();
+  });
+  expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    onRepositoryChanged?.({ root: '/repo' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('.repository-change-reload')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain('Generating walkthrough');
+    expect(container.textContent).not.toContain('Initial walkthrough.');
+    expect(container.querySelector('.wt-stop-block')).toBeNull();
+  });
+  expect(getNarrativeWalkthrough).toHaveBeenLastCalledWith(repositoryState.source, {
+    force: true,
+    previousWalkthrough: undefined,
+  });
+  await act(async () => {
+    resolveNextWalkthrough?.({ status: 'ready', walkthrough: nextWalkthrough });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(container.textContent).toContain('Fresh walkthrough.');
+    expect(container.textContent).toContain('next.ts');
+    expect(container.textContent).not.toContain('Regenerate walkthrough');
+    expect(container.textContent).not.toContain('Changed after the walkthrough was generated.');
+  });
 });
 
 test('walkthrough launch errors stay on the walkthrough tab without automatic retries', async () => {
@@ -3444,39 +3419,36 @@ test('walkthrough launch errors stay on the walkthrough tab without automatic re
       button.textContent?.includes(label),
     ) as HTMLButtonElement | undefined;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.textContent).toContain('Walkthrough unavailable');
-    });
-
-    expect(getTab('Walkthrough')?.getAttribute('aria-selected')).toBe('true');
-    expect(container.querySelector('.sidebar-walkthrough-status')).not.toBeNull();
-    expect(container.querySelector('.sidebar .file-tree-shell')).toBeNull();
-    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      getTab('Tree')?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    await act(async () => {
-      getTab('Walkthrough')?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
     expect(container.textContent).toContain('Walkthrough unavailable');
-    expect(container.querySelector('.sidebar .file-tree-shell')).toBeNull();
-    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  });
+  expect(getTab('Walkthrough')?.getAttribute('aria-selected')).toBe('true');
+  expect(container.querySelector('.sidebar-walkthrough-status')).not.toBeNull();
+  expect(container.querySelector('.sidebar .file-tree-shell')).toBeNull();
+  expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    getTab('Tree')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await act(async () => {
+    getTab('Walkthrough')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(container.textContent).toContain('Walkthrough unavailable');
+  expect(container.querySelector('.sidebar .file-tree-shell')).toBeNull();
+  expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(1);
 });
 
 test('walkthrough progress events replace the loading line without exposing agent output', async () => {
@@ -3525,38 +3497,38 @@ test('walkthrough progress events replace the loading line without exposing agen
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.textContent).toContain('Generating walkthrough…');
+  });
+  await act(async () => {
+    onProgress?.({ phase: 'agent-generation' });
+  });
+  expect(container.textContent).toContain('Analyzing changes…');
+  expect(container.textContent).not.toContain('Generating walkthrough…');
+  await act(async () => {
+    onProgress?.({ phase: 'response-received' });
+  });
+  expect(container.textContent).toContain('Building walkthrough…');
+  expect(container.querySelector('.wt-generation')).toBeNull();
+  await act(async () => {
+    resolveWalkthrough?.({
+      reason: 'Stopped for test.',
+      status: 'unavailable',
     });
-
-    await waitFor(() => {
-      expect(container.textContent).toContain('Generating walkthrough…');
-    });
-
-    await act(async () => {
-      onProgress?.({ phase: 'agent-generation' });
-    });
-    expect(container.textContent).toContain('Analyzing changes…');
-    expect(container.textContent).not.toContain('Generating walkthrough…');
-
-    await act(async () => {
-      onProgress?.({ phase: 'response-received' });
-    });
-    expect(container.textContent).toContain('Building walkthrough…');
-    expect(container.querySelector('.wt-generation')).toBeNull();
-
-    await act(async () => {
-      resolveWalkthrough?.({ reason: 'Stopped for test.', status: 'unavailable' });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 });
 
 test('history filter matches commits by author name', async () => {
@@ -3595,43 +3567,39 @@ test('history filter matches commits by author name', async () => {
       (element) => element.textContent,
     );
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.loading')).toBeNull();
-    });
-
-    await act(async () => {
-      findButton('History')?.click();
-    });
-
-    await waitFor(() => {
-      expect(historySubjects()).toContain('Fix parser');
-      expect(historySubjects()).toContain('Update docs');
-    });
-
-    const searchInput = container.querySelector<HTMLInputElement>('.sidebar-search');
-    expect(searchInput).toBeTruthy();
-    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
-    await act(async () => {
-      setInputValue?.call(searchInput, 'grace');
-      searchInput?.dispatchEvent(new Event('input', { bubbles: true }));
-    });
-
-    await waitFor(() => {
-      expect(historySubjects()).toContain('Update docs');
-      expect(historySubjects()).not.toContain('Fix parser');
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.loading')).toBeNull();
+  });
+  await act(async () => {
+    findButton('History')?.click();
+  });
+  await waitFor(() => {
+    expect(historySubjects()).toContain('Fix parser');
+    expect(historySubjects()).toContain('Update docs');
+  });
+  const searchInput = container.querySelector<HTMLInputElement>('.sidebar-search');
+  expect(searchInput).toBeTruthy();
+  const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  await act(async () => {
+    setInputValue?.call(searchInput, 'grace');
+    searchInput?.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await waitFor(() => {
+    expect(historySubjects()).toContain('Update docs');
+    expect(historySubjects()).not.toContain('Fix parser');
+  });
 });
 
 test('Pi not-found walkthrough errors show the agent recovery panel', async () => {
@@ -3656,22 +3624,21 @@ test('Pi not-found walkthrough errors show the agent recovery panel', async () =
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<App />);
-    });
-
-    await waitFor(() => {
-      expect(container.textContent).toContain('Pi CLI not found');
-    });
-
-    expect(container.textContent).toContain('Pi CLI was not found.');
-    expect(container.textContent).toContain('Review Files');
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<App />);
+  });
+  await waitFor(() => {
+    expect(container.textContent).toContain('Pi CLI not found');
+  });
+  expect(container.textContent).toContain('Pi CLI was not found.');
+  expect(container.textContent).toContain('Review Files');
 });

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -349,16 +349,11 @@ const renderAppForOpenFileShortcut = async (file: ChangedFile) => {
     expect(container.querySelector('.codiff-file-header')).not.toBeNull();
   });
 
-  const cleanup = async () => {
-    await act(async () => root.unmount());
-    container.remove();
-  };
-
   return {
-    cleanup,
     openFile,
     async [Symbol.asyncDispose]() {
-      await cleanup();
+      await act(async () => root.unmount());
+      container.remove();
     },
   };
 };
@@ -436,8 +431,6 @@ test('stale persisted collapsed sidebar state does not hide the sidebar on launc
     true,
   );
   expect(app.container.querySelector('.review-top-bar')).toBe(topBar);
-
-  await app.cleanup();
 });
 
 test('empty repository state fills the review pane for centered layout', async () => {

--- a/core/__tests__/Avatar.test.tsx
+++ b/core/__tests__/Avatar.test.tsx
@@ -16,74 +16,69 @@ test('Avatar falls back to initials when the image fails to load', async () => {
   const container = document.createElement('div');
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <Avatar name="Christoph Nakazawa" size="medium" url="https://example.com/avatar" />,
-      );
-    });
-
-    const image = container.querySelector('img');
-    expect(image?.getAttribute('src')).toBe('https://example.com/avatar');
-
-    await act(async () => {
-      image?.dispatchEvent(new Event('error', { bubbles: true }));
-    });
-
-    expect(container.querySelector('img')).toBeNull();
-    expect(container.textContent).toBe('CN');
-  } finally {
-    await act(async () => root?.unmount());
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      await act(async () => root?.unmount());
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <Avatar name="Christoph Nakazawa" size="medium" url="https://example.com/avatar" />,
+    );
+  });
+  const image = container.querySelector('img');
+  expect(image?.getAttribute('src')).toBe('https://example.com/avatar');
+  await act(async () => {
+    image?.dispatchEvent(new Event('error', { bubbles: true }));
+  });
+  expect(container.querySelector('img')).toBeNull();
+  expect(container.textContent).toBe('CN');
 });
 
 test('Avatar retries rendering when the avatar URL changes', async () => {
   const container = document.createElement('div');
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<Avatar name="Reviewer" size="medium" url="https://example.com/first" />);
-    });
-
-    await act(async () => {
-      container.querySelector('img')?.dispatchEvent(new Event('error', { bubbles: true }));
-    });
-
-    expect(container.textContent).toBe('RE');
-
-    await act(async () => {
-      root?.render(<Avatar name="Reviewer" size="medium" url="https://example.com/second" />);
-    });
-
-    expect(container.querySelector('img')?.getAttribute('src')).toBe('https://example.com/second');
-  } finally {
-    await act(async () => root?.unmount());
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      await act(async () => root?.unmount());
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Avatar name="Reviewer" size="medium" url="https://example.com/first" />);
+  });
+  await act(async () => {
+    container.querySelector('img')?.dispatchEvent(new Event('error', { bubbles: true }));
+  });
+  expect(container.textContent).toBe('RE');
+  await act(async () => {
+    root?.render(<Avatar name="Reviewer" size="medium" url="https://example.com/second" />);
+  });
+  expect(container.querySelector('img')?.getAttribute('src')).toBe('https://example.com/second');
 });
 
 test('Avatar normalizes and limits initials by grapheme', async () => {
   const container = document.createElement('div');
   let root: Root | null = null;
 
-  try {
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      await act(async () => root?.unmount());
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+  });
+  for (const [name, initials] of [
+    ['E\u0301lodie Durand', 'ÉD'],
+    ['ßa', 'SS'],
+    ['नमस्ते कुमार', 'नकु'],
+  ]) {
     await act(async () => {
-      root = createRoot(container);
+      root?.render(<Avatar name={name} size="medium" />);
     });
-
-    for (const [name, initials] of [
-      ['E\u0301lodie Durand', 'ÉD'],
-      ['ßa', 'SS'],
-      ['नमस्ते कुमार', 'नकु'],
-    ]) {
-      await act(async () => {
-        root?.render(<Avatar name={name} size="medium" />);
-      });
-      expect(container.textContent).toBe(initials);
-    }
-  } finally {
-    await act(async () => root?.unmount());
+    expect(container.textContent).toBe(initials);
   }
 });

--- a/core/__tests__/Button.test.tsx
+++ b/core/__tests__/Button.test.tsx
@@ -21,49 +21,46 @@ const renderButton = async (element: React.ReactNode) => {
     root.render(element);
   });
 
+  const cleanup = async () => {
+    await act(async () => root?.unmount());
+    container.remove();
+  };
+
   return {
-    cleanup: async () => {
-      await act(async () => root?.unmount());
-      container.remove();
-    },
+    cleanup,
     container,
+    async [Symbol.asyncDispose]() {
+      await cleanup();
+    },
   };
 };
 
 test('renders reusable size and variant classes', async () => {
-  const view = await renderButton(
+  await using view = await renderButton(
     <Button className="custom-button" size="icon" variant="destructive">
       Delete
     </Button>,
   );
 
-  try {
-    const button = view.container.querySelector('button');
-    expect(button?.classList.contains('codiff-button')).toBe(true);
-    expect(button?.classList.contains('codiff-button-size-icon')).toBe(true);
-    expect(button?.classList.contains('codiff-button-destructive')).toBe(true);
-    expect(button?.classList.contains('custom-button')).toBe(true);
-    expect(buttonVariants({ variant: 'outline' })).toContain('codiff-button-outline');
-  } finally {
-    await view.cleanup();
-  }
+  const button = view.container.querySelector('button');
+  expect(button?.classList.contains('codiff-button')).toBe(true);
+  expect(button?.classList.contains('codiff-button-size-icon')).toBe(true);
+  expect(button?.classList.contains('codiff-button-destructive')).toBe(true);
+  expect(button?.classList.contains('custom-button')).toBe(true);
+  expect(buttonVariants({ variant: 'outline' })).toContain('codiff-button-outline');
 });
 
 test('supports rendering through a child element', async () => {
-  const view = await renderButton(
+  await using view = await renderButton(
     <Button asChild variant="link">
       <a href="/review">Review</a>
     </Button>,
   );
 
-  try {
-    const link = view.container.querySelector('a');
-    expect(link?.getAttribute('href')).toBe('/review');
-    expect(link?.classList.contains('codiff-button')).toBe(true);
-    expect(view.container.querySelector('button')).toBeNull();
-  } finally {
-    await view.cleanup();
-  }
+  const link = view.container.querySelector('a');
+  expect(link?.getAttribute('href')).toBe('/review');
+  expect(link?.classList.contains('codiff-button')).toBe(true);
+  expect(view.container.querySelector('button')).toBeNull();
 });
 
 test('runs actions in a pending transition', async () => {
@@ -74,47 +71,36 @@ test('runs actions in a pending transition', async () => {
         resolveAction = resolve;
       }),
   );
-  const view = await renderButton(
+  await using view = await renderButton(
     <Button action={action} pendingPlaceholder="Working…">
       Run
     </Button>,
   );
 
-  try {
-    const button = view.container.querySelector<HTMLButtonElement>('button');
-    act(() => button?.click());
-
-    await waitFor(() => {
-      expect(action).toHaveBeenCalledOnce();
-      expect(button?.disabled).toBe(true);
-      expect(button?.getAttribute('aria-busy')).toBe('true');
-      expect(button?.textContent).toBe('Working…');
-    });
-
-    await act(async () => resolveAction?.());
-
-    await waitFor(() => {
-      expect(button?.disabled).toBe(false);
-      expect(button?.hasAttribute('aria-busy')).toBe(false);
-      expect(button?.textContent).toBe('Run');
-    });
-  } finally {
-    await view.cleanup();
-  }
+  const button = view.container.querySelector<HTMLButtonElement>('button');
+  act(() => button?.click());
+  await waitFor(() => {
+    expect(action).toHaveBeenCalledOnce();
+    expect(button?.disabled).toBe(true);
+    expect(button?.getAttribute('aria-busy')).toBe('true');
+    expect(button?.textContent).toBe('Working…');
+  });
+  await act(async () => resolveAction?.());
+  await waitFor(() => {
+    expect(button?.disabled).toBe(false);
+    expect(button?.hasAttribute('aria-busy')).toBe(false);
+    expect(button?.textContent).toBe('Run');
+  });
 });
 
 test('does not run an action when onClick prevents the event', async () => {
   const action = vi.fn();
-  const view = await renderButton(
+  await using view = await renderButton(
     <Button action={action} onClick={(event) => event.preventDefault()}>
       Run
     </Button>,
   );
 
-  try {
-    act(() => view.container.querySelector<HTMLButtonElement>('button')?.click());
-    expect(action).not.toHaveBeenCalled();
-  } finally {
-    await view.cleanup();
-  }
+  act(() => view.container.querySelector<HTMLButtonElement>('button')?.click());
+  expect(action).not.toHaveBeenCalled();
 });

--- a/core/__tests__/Button.test.tsx
+++ b/core/__tests__/Button.test.tsx
@@ -21,16 +21,11 @@ const renderButton = async (element: React.ReactNode) => {
     root.render(element);
   });
 
-  const cleanup = async () => {
-    await act(async () => root?.unmount());
-    container.remove();
-  };
-
   return {
-    cleanup,
     container,
     async [Symbol.asyncDispose]() {
-      await cleanup();
+      await act(async () => root?.unmount());
+      container.remove();
     },
   };
 };

--- a/core/__tests__/FileTree.test.tsx
+++ b/core/__tests__/FileTree.test.tsx
@@ -9,10 +9,12 @@ import { createChangedFile } from './helpers/fixtures.ts';
 import { renderReact, waitFor } from './helpers/react.tsx';
 
 test('review file trees share selection, activation, decorations, and row styling', async () => {
-  const firstFile = createChangedFile('src/first.ts', { fingerprint: 'first-current' });
+  const firstFile = createChangedFile('src/first.ts', {
+    fingerprint: 'first-current',
+  });
   const secondFile = createChangedFile('src/second.ts', { status: 'added' });
   const onActivatePath = vi.fn();
-  const view = await renderReact(
+  await using view = await renderReact(
     <ReviewFileTree
       files={[firstFile, secondFile]}
       onActivatePath={onActivatePath}
@@ -23,47 +25,38 @@ test('review file trees share selection, activation, decorations, and row stylin
     />,
   );
 
-  try {
-    await waitFor(() => {
-      const shadowRoot = view.container.querySelector('file-tree-container')?.shadowRoot;
-      expect(shadowRoot?.querySelector(`[data-item-path="${firstFile.path}"]`)).not.toBeNull();
-      expect(shadowRoot?.querySelector(`[data-item-path="${secondFile.path}"]`)).not.toBeNull();
-    });
-
+  await waitFor(() => {
     const shadowRoot = view.container.querySelector('file-tree-container')?.shadowRoot;
-    expect(shadowRoot).not.toBeNull();
-    const firstRow = shadowRoot?.querySelector<HTMLElement>(`[data-item-path="${firstFile.path}"]`);
-    const secondRow = shadowRoot?.querySelector<HTMLElement>(
-      `[data-item-path="${secondFile.path}"]`,
-    );
-    expect(firstRow?.hasAttribute('data-item-selected')).toBe(true);
-    expect(firstRow?.querySelector("[data-item-section='decoration']")?.textContent).not.toBe('');
-    expect(shadowRoot?.querySelector('style[data-codiff-viewed-rows]')?.textContent).toContain(
-      `[data-item-path="${firstFile.path}"]`,
-    );
+    expect(shadowRoot?.querySelector(`[data-item-path="${firstFile.path}"]`)).not.toBeNull();
+    expect(shadowRoot?.querySelector(`[data-item-path="${secondFile.path}"]`)).not.toBeNull();
+  });
+  const shadowRoot = view.container.querySelector('file-tree-container')?.shadowRoot;
+  expect(shadowRoot).not.toBeNull();
+  const firstRow = shadowRoot?.querySelector<HTMLElement>(`[data-item-path="${firstFile.path}"]`);
+  const secondRow = shadowRoot?.querySelector<HTMLElement>(`[data-item-path="${secondFile.path}"]`);
+  expect(firstRow?.hasAttribute('data-item-selected')).toBe(true);
+  expect(firstRow?.querySelector("[data-item-section='decoration']")?.textContent).not.toBe('');
+  expect(shadowRoot?.querySelector('style[data-codiff-viewed-rows]')?.textContent).toContain(
+    `[data-item-path="${firstFile.path}"]`,
+  );
+  expect(
+    shadowRoot?.querySelector('style[data-codiff-reload-delta-git-status]')?.textContent,
+  ).toContain(`[data-item-path="${secondFile.path}"][data-item-git-status]`);
+  await act(async () => secondRow?.click());
+  expect(onActivatePath).toHaveBeenCalledWith(secondFile.path);
+  await view.rerender(
+    <ReviewFileTree
+      files={[firstFile, secondFile]}
+      onActivatePath={onActivatePath}
+      selectedPath={secondFile.path}
+      showWhitespace={false}
+    />,
+  );
+  await waitFor(() => {
     expect(
-      shadowRoot?.querySelector('style[data-codiff-reload-delta-git-status]')?.textContent,
-    ).toContain(`[data-item-path="${secondFile.path}"][data-item-git-status]`);
-
-    await act(async () => secondRow?.click());
-    expect(onActivatePath).toHaveBeenCalledWith(secondFile.path);
-
-    await view.rerender(
-      <ReviewFileTree
-        files={[firstFile, secondFile]}
-        onActivatePath={onActivatePath}
-        selectedPath={secondFile.path}
-        showWhitespace={false}
-      />,
-    );
-    await waitFor(() => {
-      expect(
-        shadowRoot
-          ?.querySelector(`[data-item-path="${secondFile.path}"]`)
-          ?.getAttribute('aria-selected'),
-      ).toBe('true');
-    });
-  } finally {
-    await view.cleanup();
-  }
+      shadowRoot
+        ?.querySelector(`[data-item-path="${secondFile.path}"]`)
+        ?.getAttribute('aria-selected'),
+    ).toBe('true');
+  });
 });

--- a/core/__tests__/MarkdownDocumentEditor.test.tsx
+++ b/core/__tests__/MarkdownDocumentEditor.test.tsx
@@ -28,28 +28,27 @@ test('unsupported Markdown is never left in a partially editable editor', async 
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<MarkdownDocumentEditor document={markdownDocument} />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('[role="alert"]')).not.toBeNull();
-    });
-    expect(container.querySelector('[contenteditable="true"]')).toBeNull();
-    expect(container.querySelector('.codiff-markdown-editor-source')?.textContent).toBe(
-      markdownDocument.content,
-    );
-
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    expect(saveMarkdownDocument).not.toHaveBeenCalled();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<MarkdownDocumentEditor document={markdownDocument} />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+  });
+  expect(container.querySelector('[contenteditable="true"]')).toBeNull();
+  expect(container.querySelector('.codiff-markdown-editor-source')?.textContent).toBe(
+    markdownDocument.content,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(saveMarkdownDocument).not.toHaveBeenCalled();
 });
 
 test('standard Markdown images remain editable', async () => {
@@ -66,20 +65,20 @@ test('standard Markdown images remain editable', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<MarkdownDocumentEditor document={imageDocument} />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('[contenteditable="true"]')).not.toBeNull();
-    });
-    expect(container.querySelector('[role="alert"]')).toBeNull();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<MarkdownDocumentEditor document={imageDocument} />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('[contenteditable="true"]')).not.toBeNull();
+  });
+  expect(container.querySelector('[role="alert"]')).toBeNull();
 });

--- a/core/__tests__/PullRequestReviewButtons.test.tsx
+++ b/core/__tests__/PullRequestReviewButtons.test.tsx
@@ -45,7 +45,7 @@ vi.mock('@nkzw/mdx-editor', async () => {
 
 test('GitHub comment reviews require inline comments or a review body', async () => {
   const onSubmitReview = vi.fn(async () => {});
-  const view = await renderReact(
+  await using view = await renderReact(
     <PullRequestReviewButtons
       disabled={false}
       hasPendingComments={false}
@@ -54,40 +54,34 @@ test('GitHub comment reviews require inline comments or a review body', async ()
     />,
   );
 
-  try {
-    const submitComments = view.container.querySelector<HTMLButtonElement>(
-      '[aria-label="Submit review comments"]',
-    );
-    const addReviewComment = view.container.querySelector<HTMLButtonElement>(
-      '[aria-label="Add review comment"]',
-    );
-    expect(submitComments?.disabled).toBe(true);
-    expect(addReviewComment?.disabled).toBe(false);
-
-    await act(async () => addReviewComment?.click());
-    const textarea = view.container.querySelector<HTMLTextAreaElement>(
-      'textarea[aria-label="Add review comment"]',
-    );
-    expect(textarea?.placeholder).toBe('Add a review comment…');
-    await setInputValue(textarea!, 'Neutral review feedback.');
-
-    const submitBody = view.container.querySelector<HTMLButtonElement>(
-      '.review-submit-popover-submit.comment',
-    );
-    expect(submitBody?.disabled).toBe(false);
-    await act(async () => submitBody?.click());
-    await waitFor(() => {
-      expect(onSubmitReview).toHaveBeenCalledWith('COMMENT', 'Neutral review feedback.');
-      expect(view.container.querySelector('[aria-label="Comment with comment"]')).toBeNull();
-    });
-  } finally {
-    await view.cleanup();
-  }
+  const submitComments = view.container.querySelector<HTMLButtonElement>(
+    '[aria-label="Submit review comments"]',
+  );
+  const addReviewComment = view.container.querySelector<HTMLButtonElement>(
+    '[aria-label="Add review comment"]',
+  );
+  expect(submitComments?.disabled).toBe(true);
+  expect(addReviewComment?.disabled).toBe(false);
+  await act(async () => addReviewComment?.click());
+  const textarea = view.container.querySelector<HTMLTextAreaElement>(
+    'textarea[aria-label="Add review comment"]',
+  );
+  expect(textarea?.placeholder).toBe('Add a review comment…');
+  await setInputValue(textarea!, 'Neutral review feedback.');
+  const submitBody = view.container.querySelector<HTMLButtonElement>(
+    '.review-submit-popover-submit.comment',
+  );
+  expect(submitBody?.disabled).toBe(false);
+  await act(async () => submitBody?.click());
+  await waitFor(() => {
+    expect(onSubmitReview).toHaveBeenCalledWith('COMMENT', 'Neutral review feedback.');
+    expect(view.container.querySelector('[aria-label="Comment with comment"]')).toBeNull();
+  });
 });
 
 test('GitHub comment reviews submit pending inline comments without a body', async () => {
   const onSubmitReview = vi.fn(async () => {});
-  const view = await renderReact(
+  await using view = await renderReact(
     <PullRequestReviewButtons
       disabled={false}
       hasPendingComments
@@ -96,23 +90,19 @@ test('GitHub comment reviews submit pending inline comments without a body', asy
     />,
   );
 
-  try {
-    const submitComments = view.container.querySelector<HTMLButtonElement>(
-      '[aria-label="Submit review comments"]',
-    );
-    expect(submitComments?.disabled).toBe(false);
-    await act(async () => submitComments?.click());
-    expect(onSubmitReview).toHaveBeenCalledWith('COMMENT');
-  } finally {
-    await view.cleanup();
-  }
+  const submitComments = view.container.querySelector<HTMLButtonElement>(
+    '[aria-label="Submit review comments"]',
+  );
+  expect(submitComments?.disabled).toBe(false);
+  await act(async () => submitComments?.click());
+  expect(onSubmitReview).toHaveBeenCalledWith('COMMENT');
 });
 
 test('GitHub comment reviews preserve the review body after submission fails', async () => {
   const onSubmitReview = vi.fn(async () => {
     throw new Error('GitHub rejected the review.');
   });
-  const view = await renderReact(
+  await using view = await renderReact(
     <PullRequestReviewButtons
       disabled={false}
       hasPendingComments={false}
@@ -121,61 +111,54 @@ test('GitHub comment reviews preserve the review body after submission fails', a
     />,
   );
 
-  try {
-    await act(async () =>
-      view.container.querySelector<HTMLButtonElement>('[aria-label="Add review comment"]')?.click(),
-    );
-    const textarea = view.container.querySelector<HTMLTextAreaElement>(
-      'textarea[aria-label="Add review comment"]',
-    );
-    await setInputValue(textarea!, 'Keep this draft.');
-    await act(async () =>
-      view.container
-        .querySelector<HTMLButtonElement>('.review-submit-popover-submit.comment')
-        ?.click(),
-    );
-
-    await waitFor(() => expect(onSubmitReview).toHaveBeenCalledOnce());
-    expect(textarea?.value).toBe('Keep this draft.');
-    expect(view.container.querySelector('[aria-label="Comment with comment"]')).not.toBeNull();
-  } finally {
-    await view.cleanup();
-  }
+  await act(async () =>
+    view.container.querySelector<HTMLButtonElement>('[aria-label="Add review comment"]')?.click(),
+  );
+  const textarea = view.container.querySelector<HTMLTextAreaElement>(
+    'textarea[aria-label="Add review comment"]',
+  );
+  await setInputValue(textarea!, 'Keep this draft.');
+  await act(async () =>
+    view.container
+      .querySelector<HTMLButtonElement>('.review-submit-popover-submit.comment')
+      ?.click(),
+  );
+  await waitFor(() => expect(onSubmitReview).toHaveBeenCalledOnce());
+  expect(textarea?.value).toBe('Keep this draft.');
+  expect(view.container.querySelector('[aria-label="Comment with comment"]')).not.toBeNull();
 });
 
 test('comment review remains available when decision reviews are provider-blocked', async () => {
-  const view = await renderReact(
+  await using view = await renderReact(
     <PullRequestReviewButtons
       disabled={false}
       hasPendingComments={false}
       onSubmitReview={vi.fn()}
       reviewStatus={{
-        approve: { disabled: true, reason: 'You cannot review your own pull request.' },
-        requestChanges: { disabled: true, reason: 'You cannot review your own pull request.' },
+        approve: {
+          disabled: true,
+          reason: 'You cannot review your own pull request.',
+        },
+        requestChanges: {
+          disabled: true,
+          reason: 'You cannot review your own pull request.',
+        },
       }}
       showCommentReview
     />,
   );
 
-  try {
-    expect(view.container.querySelector('[aria-label="Submit review comments"]')).not.toBeNull();
-    expect(view.container.querySelector('[aria-label="Approve review"]')).toBeNull();
-    expect(view.container.querySelector('[aria-label="Request changes"]')).toBeNull();
-  } finally {
-    await view.cleanup();
-  }
+  expect(view.container.querySelector('[aria-label="Submit review comments"]')).not.toBeNull();
+  expect(view.container.querySelector('[aria-label="Approve review"]')).toBeNull();
+  expect(view.container.querySelector('[aria-label="Request changes"]')).toBeNull();
 });
 
 test('non-GitHub reviews keep the existing review actions', async () => {
-  const view = await renderReact(
+  await using view = await renderReact(
     <PullRequestReviewButtons disabled={false} hasPendingComments onSubmitReview={vi.fn()} />,
   );
 
-  try {
-    expect(view.container.querySelector('[aria-label="Submit review comments"]')).toBeNull();
-    expect(view.container.querySelector('[aria-label="Approve review"]')).not.toBeNull();
-    expect(view.container.querySelector('[aria-label="Request changes"]')).not.toBeNull();
-  } finally {
-    await view.cleanup();
-  }
+  expect(view.container.querySelector('[aria-label="Submit review comments"]')).toBeNull();
+  expect(view.container.querySelector('[aria-label="Approve review"]')).not.toBeNull();
+  expect(view.container.querySelector('[aria-label="Request changes"]')).not.toBeNull();
 });

--- a/core/__tests__/PullRequestReviewButtons.web.test.tsx
+++ b/core/__tests__/PullRequestReviewButtons.web.test.tsx
@@ -62,11 +62,13 @@ const renderReviewButtons = async (disabled = false) => {
     );
   });
 
+  const cleanup = async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  };
+
   return {
-    cleanup: async () => {
-      await act(async () => root.unmount());
-      container.remove();
-    },
+    cleanup,
     container,
     onSubmitReview,
     rerender: async (nextDisabled: boolean) => {
@@ -79,6 +81,9 @@ const renderReviewButtons = async (disabled = false) => {
           />,
         );
       });
+    },
+    async [Symbol.asyncDispose]() {
+      await cleanup();
     },
   };
 };
@@ -95,103 +100,78 @@ const setEditorValue = (editor: HTMLElement, value: string) => {
 };
 
 test('keeps approve and request changes as direct split-button actions', async () => {
-  const view = await renderReviewButtons();
+  await using view = await renderReviewButtons();
 
-  try {
-    const approve = view.container.querySelector<HTMLButtonElement>(
-      '[aria-label="Approve review"]',
-    );
-    const requestChanges = view.container.querySelector<HTMLButtonElement>(
-      '[aria-label="Request changes"]',
-    );
-    const approveControl = approve?.closest('.review-submit-button');
-
-    expect(approveControl?.tagName).toBe('DIV');
-    expect(approveControl?.classList.contains('codiff-button')).toBe(true);
-    expect(approve?.classList.contains('codiff-button')).toBe(false);
-    expect(approveControl?.querySelector('.review-submit-divider')?.textContent?.trim()).toBe('|');
-
-    await act(async () => approve?.click());
-    expect(view.onSubmitReview).toHaveBeenCalledWith('APPROVE');
-
-    await act(async () => requestChanges?.click());
-    expect(view.onSubmitReview).toHaveBeenLastCalledWith('REQUEST_CHANGES');
-  } finally {
-    await view.cleanup();
-  }
+  const approve = view.container.querySelector<HTMLButtonElement>('[aria-label="Approve review"]');
+  const requestChanges = view.container.querySelector<HTMLButtonElement>(
+    '[aria-label="Request changes"]',
+  );
+  const approveControl = approve?.closest('.review-submit-button');
+  expect(approveControl?.tagName).toBe('DIV');
+  expect(approveControl?.classList.contains('codiff-button')).toBe(true);
+  expect(approve?.classList.contains('codiff-button')).toBe(false);
+  expect(approveControl?.querySelector('.review-submit-divider')?.textContent?.trim()).toBe('|');
+  await act(async () => approve?.click());
+  expect(view.onSubmitReview).toHaveBeenCalledWith('APPROVE');
+  await act(async () => requestChanges?.click());
+  expect(view.onSubmitReview).toHaveBeenLastCalledWith('REQUEST_CHANGES');
 });
 
 test('submits MDX review comments with either review outcome', async () => {
-  const view = await renderReviewButtons();
+  await using view = await renderReviewButtons();
 
-  try {
-    for (const review of [
-      {
-        body: 'Looks good to me.',
-        commentLabel: 'Add approval comment',
-        event: 'APPROVE',
-        groupLabel: 'Approve with comment',
-        label: 'Approve',
-      },
-      {
-        body: 'Please address the remaining concern.',
-        commentLabel: 'Add request changes comment',
-        event: 'REQUEST_CHANGES',
-        groupLabel: 'Request Changes with comment',
-        label: 'Request Changes',
-      },
-    ] as const) {
-      const toggle = view.container.querySelector<HTMLButtonElement>(
-        `[aria-label="${review.commentLabel}"]`,
-      );
-      await act(async () => toggle?.click());
-
-      const popover = view.container.querySelector<HTMLElement>(
-        `[aria-label="${review.groupLabel}"]`,
-      );
-      const editor = popover?.querySelector<HTMLElement>(
-        `[contenteditable="true"][aria-label="${review.commentLabel}"]`,
-      );
-      expect(popover).not.toBeNull();
-      expect(editor).not.toBeNull();
-
-      await act(async () => {
-        if (editor) {
-          setEditorValue(editor, review.body);
-        }
-      });
-
-      const submit = [...(popover?.querySelectorAll<HTMLButtonElement>('button') ?? [])].find(
-        (button) => button.textContent?.trim() === review.label,
-      );
-      expect(submit?.disabled).toBe(false);
-      await act(async () => submit?.click());
-
-      expect(view.onSubmitReview).toHaveBeenLastCalledWith(review.event, review.body);
-      expect(view.container.querySelector(`[aria-label="${review.groupLabel}"]`)).toBeNull();
-    }
-  } finally {
-    await view.cleanup();
+  for (const review of [
+    {
+      body: 'Looks good to me.',
+      commentLabel: 'Add approval comment',
+      event: 'APPROVE',
+      groupLabel: 'Approve with comment',
+      label: 'Approve',
+    },
+    {
+      body: 'Please address the remaining concern.',
+      commentLabel: 'Add request changes comment',
+      event: 'REQUEST_CHANGES',
+      groupLabel: 'Request Changes with comment',
+      label: 'Request Changes',
+    },
+  ] as const) {
+    const toggle = view.container.querySelector<HTMLButtonElement>(
+      `[aria-label="${review.commentLabel}"]`,
+    );
+    await act(async () => toggle?.click());
+    const popover = view.container.querySelector<HTMLElement>(
+      `[aria-label="${review.groupLabel}"]`,
+    );
+    const editor = popover?.querySelector<HTMLElement>(
+      `[contenteditable="true"][aria-label="${review.commentLabel}"]`,
+    );
+    expect(popover).not.toBeNull();
+    expect(editor).not.toBeNull();
+    await act(async () => {
+      if (editor) {
+        setEditorValue(editor, review.body);
+      }
+    });
+    const submit = [...(popover?.querySelectorAll<HTMLButtonElement>('button') ?? [])].find(
+      (button) => button.textContent?.trim() === review.label,
+    );
+    expect(submit?.disabled).toBe(false);
+    await act(async () => submit?.click());
+    expect(view.onSubmitReview).toHaveBeenLastCalledWith(review.event, review.body);
+    expect(view.container.querySelector(`[aria-label="${review.groupLabel}"]`)).toBeNull();
   }
 });
 
 test('closes review comment popovers when the actions become disabled', async () => {
-  const view = await renderReviewButtons();
+  await using view = await renderReviewButtons();
 
-  try {
-    await act(async () => {
-      view.container
-        .querySelector<HTMLButtonElement>('[aria-label="Add approval comment"]')
-        ?.click();
-    });
-    expect(view.container.querySelector('[aria-label="Approve with comment"]')).not.toBeNull();
-
-    await view.rerender(true);
-    expect(view.container.querySelector('[aria-label="Approve with comment"]')).toBeNull();
-
-    await view.rerender(false);
-    expect(view.container.querySelector('[aria-label="Approve with comment"]')).toBeNull();
-  } finally {
-    await view.cleanup();
-  }
+  await act(async () => {
+    view.container.querySelector<HTMLButtonElement>('[aria-label="Add approval comment"]')?.click();
+  });
+  expect(view.container.querySelector('[aria-label="Approve with comment"]')).not.toBeNull();
+  await view.rerender(true);
+  expect(view.container.querySelector('[aria-label="Approve with comment"]')).toBeNull();
+  await view.rerender(false);
+  expect(view.container.querySelector('[aria-label="Approve with comment"]')).toBeNull();
 });

--- a/core/__tests__/PullRequestReviewButtons.web.test.tsx
+++ b/core/__tests__/PullRequestReviewButtons.web.test.tsx
@@ -62,13 +62,7 @@ const renderReviewButtons = async (disabled = false) => {
     );
   });
 
-  const cleanup = async () => {
-    await act(async () => root.unmount());
-    container.remove();
-  };
-
   return {
-    cleanup,
     container,
     onSubmitReview,
     rerender: async (nextDisabled: boolean) => {
@@ -83,7 +77,8 @@ const renderReviewButtons = async (disabled = false) => {
       });
     },
     async [Symbol.asyncDispose]() {
-      await cleanup();
+      await act(async () => root.unmount());
+      container.remove();
     },
   };
 };

--- a/core/__tests__/ReadOnlyMarkdownView.test.tsx
+++ b/core/__tests__/ReadOnlyMarkdownView.test.tsx
@@ -23,7 +23,7 @@ test('normalizeReadOnlyMarkdownValue collapses repeated blank lines outside fenc
 });
 
 test('ReadOnlyMarkdownView does not render empty paragraph break blocks', async () => {
-  const view = await renderReact(
+  await using view = await renderReact(
     <ReadOnlyMarkdownView
       ariaLabel="Markdown preview"
       className="markdown-preview"
@@ -32,21 +32,14 @@ test('ReadOnlyMarkdownView does not render empty paragraph break blocks', async 
     />,
   );
 
-  try {
-    await waitFor(() => {
-      expect(view.container.textContent).toContain('First paragraph.');
-      expect(view.container.textContent).toContain('Second paragraph.');
-      expect(view.container.textContent).toContain('Third paragraph.');
-    });
-
-    expect(
-      [
-        ...view.container.querySelectorAll<HTMLElement>(
-          '[data-mdx-comment-block-type="paragraph"]',
-        ),
-      ].some((paragraph) => !paragraph.textContent?.trim() && paragraph.querySelector('br')),
-    ).toBe(false);
-  } finally {
-    await view.cleanup();
-  }
+  await waitFor(() => {
+    expect(view.container.textContent).toContain('First paragraph.');
+    expect(view.container.textContent).toContain('Second paragraph.');
+    expect(view.container.textContent).toContain('Third paragraph.');
+  });
+  expect(
+    [
+      ...view.container.querySelectorAll<HTMLElement>('[data-mdx-comment-block-type="paragraph"]'),
+    ].some((paragraph) => !paragraph.textContent?.trim() && paragraph.querySelector('br')),
+  ).toBe(false);
 });

--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -150,38 +150,28 @@ test('generated files are collapsed by default and can be explicitly expanded pe
       },
     },
   ];
-  const view = await renderReact(<ReviewCodeViewHarness blocks={blocks} files={[]} />);
+  await using view = await renderReact(<ReviewCodeViewHarness blocks={blocks} files={[]} />);
 
-  try {
-    await waitFor(() => {
-      expect(
-        view.container.querySelector('[aria-label="Expand file"]')?.getAttribute('aria-expanded'),
-      ).toBe('false');
-      expect(view.container.querySelector('.codiff-generated-badge')?.textContent).toBe(
-        'Generated',
-      );
-    });
-
-    await view.rerender(
-      <ReviewCodeViewHarness
-        blocks={blocks}
-        expandedGenerated={new Set([reviewKey])}
-        files={[]}
-        itemVersionByKey={{ [reviewKey]: 1 }}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(
-        view.container.querySelector('[aria-label="Collapse file"]')?.getAttribute('aria-expanded'),
-      ).toBe('true');
-      expect(view.container.querySelector('.codiff-generated-badge')?.textContent).toBe(
-        'Generated',
-      );
-    });
-  } finally {
-    await view.cleanup();
-  }
+  await waitFor(() => {
+    expect(
+      view.container.querySelector('[aria-label="Expand file"]')?.getAttribute('aria-expanded'),
+    ).toBe('false');
+    expect(view.container.querySelector('.codiff-generated-badge')?.textContent).toBe('Generated');
+  });
+  await view.rerender(
+    <ReviewCodeViewHarness
+      blocks={blocks}
+      expandedGenerated={new Set([reviewKey])}
+      files={[]}
+      itemVersionByKey={{ [reviewKey]: 1 }}
+    />,
+  );
+  await waitFor(() => {
+    expect(
+      view.container.querySelector('[aria-label="Collapse file"]')?.getAttribute('aria-expanded'),
+    ).toBe('true');
+    expect(view.container.querySelector('.codiff-generated-badge')?.textContent).toBe('Generated');
+  });
 });
 
 test('explicit generated metadata can keep generated-looking paths expanded', async () => {
@@ -189,18 +179,14 @@ test('explicit generated metadata can keep generated-looking paths expanded', as
     ...createChangedFile('src/__generated__/api.ts'),
     generated: false,
   };
-  const view = await renderReact(<ReviewCodeViewHarness files={[file]} />);
+  await using view = await renderReact(<ReviewCodeViewHarness files={[file]} />);
 
-  try {
-    await waitFor(() => {
-      expect(
-        view.container.querySelector('[aria-label="Collapse file"]')?.getAttribute('aria-expanded'),
-      ).toBe('true');
-      expect(view.container.querySelector('.codiff-generated-badge')).toBeNull();
-    });
-  } finally {
-    await view.cleanup();
-  }
+  await waitFor(() => {
+    expect(
+      view.container.querySelector('[aria-label="Collapse file"]')?.getAttribute('aria-expanded'),
+    ).toBe('true');
+    expect(view.container.querySelector('.codiff-generated-badge')).toBeNull();
+  });
 });
 
 test('switching edited Markdown back to a diff flushes and refreshes it first', async () => {
@@ -233,35 +219,33 @@ test('switching edited Markdown back to a diff flushes and refreshes it first', 
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<Harness />);
-    });
-
-    expect(container.querySelector('[aria-label="Edit plan.md"]')).not.toBeNull();
-    const diffButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
-      ({ textContent }) => textContent === 'View as Diff',
-    );
-    expect(diffButton).not.toBeUndefined();
-    expect(diffButton?.classList.contains('codiff-button')).toBe(true);
-
-    await act(async () => {
-      diffButton?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('[aria-label="Edit plan.md"]')).toBeNull();
-    });
-    expect(order).toEqual(['flush', 'refresh']);
-    expect(JSON.stringify(codeViewMock.lastItems)).toContain('# Saved');
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Harness />);
+  });
+  expect(container.querySelector('[aria-label="Edit plan.md"]')).not.toBeNull();
+  const diffButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+    ({ textContent }) => textContent === 'View as Diff',
+  );
+  expect(diffButton).not.toBeUndefined();
+  expect(diffButton?.classList.contains('codiff-button')).toBe(true);
+  await act(async () => {
+    diffButton?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(container.querySelector('[aria-label="Edit plan.md"]')).toBeNull();
+  });
+  expect(order).toEqual(['flush', 'refresh']);
+  expect(JSON.stringify(codeViewMock.lastItems)).toContain('# Saved');
 });
 
 test('combined branch Markdown edits only the final working-tree section', async () => {
@@ -327,34 +311,32 @@ test('combined branch Markdown edits only the final working-tree section', async
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<Harness />);
-    });
-
-    expect(container.querySelector('[aria-label="Edit plan.md"]')).not.toBeNull();
-    const diffButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
-      ({ textContent }) => textContent === 'View as Diff',
-    );
-    expect(diffButton).not.toBeUndefined();
-
-    await act(async () => {
-      diffButton?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('[aria-label="Edit plan.md"]')).toBeNull();
-    });
-    expect(order).toEqual(['flush', 'refresh']);
-    expect(JSON.stringify(codeViewMock.lastItems)).toContain('# Saved');
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Harness />);
+  });
+  expect(container.querySelector('[aria-label="Edit plan.md"]')).not.toBeNull();
+  const diffButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+    ({ textContent }) => textContent === 'View as Diff',
+  );
+  expect(diffButton).not.toBeUndefined();
+  await act(async () => {
+    diffButton?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await waitFor(() => {
+    expect(container.querySelector('[aria-label="Edit plan.md"]')).toBeNull();
+  });
+  expect(order).toEqual(['flush', 'refresh']);
+  expect(JSON.stringify(codeViewMock.lastItems)).toContain('# Saved');
 });
 
 test('combined branch-only Markdown sections remain read-only', async () => {
@@ -371,42 +353,40 @@ test('combined branch-only Markdown sections remain read-only', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          files={[file]}
-          source={{
-            baseRef: 'base123',
-            headRef: 'head123',
-            ref: 'main',
-            type: 'branch-working-tree',
-          }}
-        />,
-      );
-    });
-
-    expect(container.querySelector('[aria-label="Edit plan.md"]')).toBeNull();
-    const markdownButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
-      ({ textContent }) => textContent === 'View as Markdown',
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        files={[file]}
+        source={{
+          baseRef: 'base123',
+          headRef: 'head123',
+          ref: 'main',
+          type: 'branch-working-tree',
+        }}
+      />,
     );
-    expect(markdownButton).not.toBeUndefined();
-
-    await act(async () => {
-      markdownButton?.click();
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('[aria-label="Preview plan.md"]')).not.toBeNull();
-    });
-    expect(container.querySelector('[aria-label="Edit plan.md"]')).toBeNull();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  });
+  expect(container.querySelector('[aria-label="Edit plan.md"]')).toBeNull();
+  const markdownButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+    ({ textContent }) => textContent === 'View as Markdown',
+  );
+  expect(markdownButton).not.toBeUndefined();
+  await act(async () => {
+    markdownButton?.click();
+  });
+  await waitFor(() => {
+    expect(container.querySelector('[aria-label="Preview plan.md"]')).not.toBeNull();
+  });
+  expect(container.querySelector('[aria-label="Edit plan.md"]')).toBeNull();
 });
 
 test('read-only Markdown previews render with the shared Markdown editor', async () => {
@@ -438,32 +418,32 @@ test('read-only Markdown previews render with the shared Markdown editor', async
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          files={[file]}
-          initialMarkdownPreviewSectionIds={new Set([sectionId])}
-          isReadOnly
-        />,
-      );
-    });
-
-    await waitFor(() => {
-      const preview = container.querySelector<HTMLTextAreaElement>(
-        '[aria-label="Preview README.md"]',
-      );
-      expect(preview).not.toBeNull();
-      expect(preview?.readOnly).toBe(true);
-      expect(preview?.value).toBe('# Title\n\nNew paragraph.\n');
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        files={[file]}
+        initialMarkdownPreviewSectionIds={new Set([sectionId])}
+        isReadOnly
+      />,
+    );
+  });
+  await waitFor(() => {
+    const preview = container.querySelector<HTMLTextAreaElement>(
+      '[aria-label="Preview README.md"]',
+    );
+    expect(preview).not.toBeNull();
+    expect(preview?.readOnly).toBe(true);
+    expect(preview?.value).toBe('# Title\n\nNew paragraph.\n');
+  });
 });
 
 test('scroll selection updates do not publish new item versions', async () => {
@@ -473,33 +453,31 @@ test('scroll selection updates do not publish new item versions', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness files={[firstFile, secondFile]} selectedPath={firstFile.path} />,
-      );
-    });
-
-    const firstVersions = codeViewMock.lastItems.map((item) => item.version);
-    expect(codeViewMock.postRenderNodes[0]?.classList.contains('codiff-selected-item')).toBe(true);
-    expect(codeViewMock.postRenderNodes[1]?.classList.contains('codiff-selected-item')).toBe(false);
-
-    await act(async () => {
-      root?.render(
-        <ReviewCodeViewHarness files={[firstFile, secondFile]} selectedPath={secondFile.path} />,
-      );
-    });
-
-    expect(codeViewMock.lastItems.map((item) => item.version)).toEqual(firstVersions);
-    expect(codeViewMock.postRenderNodes[0]?.classList.contains('codiff-selected-item')).toBe(false);
-    expect(codeViewMock.postRenderNodes[1]?.classList.contains('codiff-selected-item')).toBe(true);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness files={[firstFile, secondFile]} selectedPath={firstFile.path} />,
+    );
+  });
+  const firstVersions = codeViewMock.lastItems.map((item) => item.version);
+  expect(codeViewMock.postRenderNodes[0]?.classList.contains('codiff-selected-item')).toBe(true);
+  expect(codeViewMock.postRenderNodes[1]?.classList.contains('codiff-selected-item')).toBe(false);
+  await act(async () => {
+    root?.render(
+      <ReviewCodeViewHarness files={[firstFile, secondFile]} selectedPath={secondFile.path} />,
+    );
+  });
+  expect(codeViewMock.lastItems.map((item) => item.version)).toEqual(firstVersions);
+  expect(codeViewMock.postRenderNodes[0]?.classList.contains('codiff-selected-item')).toBe(false);
+  expect(codeViewMock.postRenderNodes[1]?.classList.contains('codiff-selected-item')).toBe(true);
 });
 
 test('walkthrough header chrome does not leak inline styles onto reused diff nodes', async () => {
@@ -514,30 +492,28 @@ test('walkthrough header chrome does not leak inline styles onto reused diff nod
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<ReviewCodeViewHarness blocks={[headerBlock]} files={[file]} />);
-    });
-
-    expect(
-      codeViewMock.postRenderNodes[0]?.classList.contains('codiff-walkthrough-header-item'),
-    ).toBe(true);
-
-    await act(async () => {
-      root?.render(<ReviewCodeViewHarness files={[file]} />);
-    });
-
-    const reusedNode = codeViewMock.postRenderNodes[0];
-    expect(reusedNode?.classList.contains('codiff-walkthrough-header-item')).toBe(false);
-    expect(container.textContent).not.toContain('Header');
-    expect(container.querySelector('.codiff-file-header')).not.toBeNull();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<ReviewCodeViewHarness blocks={[headerBlock]} files={[file]} />);
+  });
+  expect(
+    codeViewMock.postRenderNodes[0]?.classList.contains('codiff-walkthrough-header-item'),
+  ).toBe(true);
+  await act(async () => {
+    root?.render(<ReviewCodeViewHarness files={[file]} />);
+  });
+  const reusedNode = codeViewMock.postRenderNodes[0];
+  expect(reusedNode?.classList.contains('codiff-walkthrough-header-item')).toBe(false);
+  expect(container.textContent).not.toContain('Header');
+  expect(container.querySelector('.codiff-file-header')).not.toBeNull();
 });
 
 test('header-only walkthrough blocks render and can be scroll targets', async () => {
@@ -545,39 +521,39 @@ test('header-only walkthrough blocks render and can be scroll targets', async ()
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          blocks={[
-            {
-              header: <div>Missing stop</div>,
-              id: 'walkthrough:s1:missing',
-              selected: true,
-            },
-          ]}
-          files={[]}
-          scrollTarget={{ blockId: 'walkthrough:s1:missing', request: 1 }}
-        />,
-      );
-    });
-
-    expect(container.textContent).toContain('Missing stop');
-    await waitFor(() => {
-      expect(codeViewMock.scrollTo).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'walkthrough:s1:missing:walkthrough-header',
-          type: 'item',
-        }),
-      );
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        blocks={[
+          {
+            header: <div>Missing stop</div>,
+            id: 'walkthrough:s1:missing',
+            selected: true,
+          },
+        ]}
+        files={[]}
+        scrollTarget={{ blockId: 'walkthrough:s1:missing', request: 1 }}
+      />,
+    );
+  });
+  expect(container.textContent).toContain('Missing stop');
+  await waitFor(() => {
+    expect(codeViewMock.scrollTo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'walkthrough:s1:missing:walkthrough-header',
+        type: 'item',
+      }),
+    );
+  });
 });
 
 test('focused walkthrough blocks render only global comments visible in the focused patch', async () => {
@@ -604,26 +580,26 @@ test('focused walkthrough blocks render only global comments visible in the focu
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          blocks={[{ file, id: 'walkthrough:s1:0', itemIdPrefix: 'walkthrough:s1:0' }]}
-          comments={[visibleComment, offHunkComment]}
-          files={[file]}
-        />,
-      );
-    });
-
-    const textareas = [...container.querySelectorAll<HTMLTextAreaElement>('textarea')];
-    expect(textareas.map((textarea) => textarea.value)).toEqual([visibleComment.body]);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        blocks={[{ file, id: 'walkthrough:s1:0', itemIdPrefix: 'walkthrough:s1:0' }]}
+        comments={[visibleComment, offHunkComment]}
+        files={[file]}
+      />,
+    );
+  });
+  const textareas = [...container.querySelectorAll<HTMLTextAreaElement>('textarea')];
+  expect(textareas.map((textarea) => textarea.value)).toEqual([visibleComment.body]);
 });
 
 test('focused walkthrough blocks keep cross-side comments when their rendered anchor is visible', async () => {
@@ -646,26 +622,26 @@ test('focused walkthrough blocks keep cross-side comments when their rendered an
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          blocks={[{ file, id: 'walkthrough:s1:0', itemIdPrefix: 'walkthrough:s1:0' }]}
-          comments={[rangedComment]}
-          files={[file]}
-        />,
-      );
-    });
-
-    const textarea = container.querySelector<HTMLTextAreaElement>('textarea');
-    expect(textarea?.value).toBe(rangedComment.body);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        blocks={[{ file, id: 'walkthrough:s1:0', itemIdPrefix: 'walkthrough:s1:0' }]}
+        comments={[rangedComment]}
+        files={[file]}
+      />,
+    );
+  });
+  const textarea = container.querySelector<HTMLTextAreaElement>('textarea');
+  expect(textarea?.value).toBe(rangedComment.body);
 });
 
 test('focused walkthrough blocks resolve active search matches to rendered item ids', async () => {
@@ -678,39 +654,39 @@ test('focused walkthrough blocks resolve active search matches to rendered item 
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          activeSearchMatch={{
-            filePath: file.path,
-            itemId: `diff:${file.sections[0].id}`,
-            lineNumber: 1,
-            side: 'additions',
-          }}
-          blocks={[{ file, id: 'walkthrough:s1:0', itemIdPrefix: 'walkthrough:s1:0' }]}
-          files={[file]}
-        />,
-      );
-    });
-
-    await waitFor(() => {
-      expect(codeViewMock.scrollTo).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: `walkthrough:s1:0:diff:${file.sections[0].id}`,
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        activeSearchMatch={{
+          filePath: file.path,
+          itemId: `diff:${file.sections[0].id}`,
           lineNumber: 1,
           side: 'additions',
-          type: 'line',
-        }),
-      );
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+        }}
+        blocks={[{ file, id: 'walkthrough:s1:0', itemIdPrefix: 'walkthrough:s1:0' }]}
+        files={[file]}
+      />,
+    );
+  });
+  await waitFor(() => {
+    expect(codeViewMock.scrollTo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `walkthrough:s1:0:diff:${file.sections[0].id}`,
+        lineNumber: 1,
+        side: 'additions',
+        type: 'line',
+      }),
+    );
+  });
 });
 
 test('review comment drafts resync clean external updates and reset on comment switch', async () => {
@@ -738,38 +714,38 @@ test('review comment drafts resync clean external updates and reset on comment s
       />,
     );
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      renderComment(baseComment);
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    renderComment(baseComment);
+  });
+  const textarea = () => container.querySelector<HTMLTextAreaElement>('textarea')!;
+  expect(textarea().value).toBe('Original body');
+  await act(async () => {
+    renderComment({ ...baseComment, body: 'Clean external body' });
+  });
+  expect(textarea().value).toBe('Clean external body');
+  await setInputValue(textarea(), 'Unsaved local draft');
+  expect(textarea().value).toBe('Unsaved local draft');
+  await act(async () => {
+    renderComment({ ...baseComment, body: 'Ignored while dirty' });
+  });
+  expect(textarea().value).toBe('Unsaved local draft');
+  await act(async () => {
+    renderComment({
+      ...baseComment,
+      body: 'Second comment body',
+      id: 'comment-2',
     });
-
-    const textarea = () => container.querySelector<HTMLTextAreaElement>('textarea')!;
-    expect(textarea().value).toBe('Original body');
-
-    await act(async () => {
-      renderComment({ ...baseComment, body: 'Clean external body' });
-    });
-    expect(textarea().value).toBe('Clean external body');
-
-    await setInputValue(textarea(), 'Unsaved local draft');
-    expect(textarea().value).toBe('Unsaved local draft');
-
-    await act(async () => {
-      renderComment({ ...baseComment, body: 'Ignored while dirty' });
-    });
-    expect(textarea().value).toBe('Unsaved local draft');
-
-    await act(async () => {
-      renderComment({ ...baseComment, body: 'Second comment body', id: 'comment-2' });
-    });
-    expect(textarea().value).toBe('Second comment body');
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  });
+  expect(textarea().value).toBe('Second comment body');
 });
 
 test('read-only review comments render safe details blocks', async () => {
@@ -785,37 +761,44 @@ test('read-only review comments render safe details blocks', async () => {
     side: 'additions',
   } satisfies ReviewComment;
 
-  const view = await renderReact(
+  await using view = await renderReact(
     <ReviewCodeViewHarness comments={[comment]} files={[file]} supportsReviewCommentActions />,
   );
 
-  try {
-    await waitFor(() => {
-      expect(view.container.querySelector('.review-comment-thread details')).not.toBeNull();
-    });
-    const details = view.container.querySelector<HTMLDetailsElement>(
-      '.review-comment-thread details',
-    );
-    expect(details?.open).toBe(false);
-    expect(details?.querySelector('summary')?.textContent).toBe('Review rationale');
-    expect(view.container.textContent).toContain('AI Code Reviewer');
-  } finally {
-    await view.cleanup();
-  }
+  await waitFor(() => {
+    expect(view.container.querySelector('.review-comment-thread details')).not.toBeNull();
+  });
+  const details = view.container.querySelector<HTMLDetailsElement>(
+    '.review-comment-thread details',
+  );
+  expect(details?.open).toBe(false);
+  expect(details?.querySelector('summary')?.textContent).toBe('Review rationale');
+  expect(view.container.textContent).toContain('AI Code Reviewer');
 });
 
 test('walkthrough hunk viewed state is keyed independently from file path', async () => {
   const filePath = 'src/shared.ts';
-  const firstFile = { ...createChangedFile(filePath), fingerprint: 'first-hunk' };
-  const secondFile = { ...createChangedFile(filePath), fingerprint: 'second-hunk' };
-  const firstIdentity = { fingerprint: firstFile.fingerprint, key: 'walkthrough:s1:h1' };
-  const secondIdentity = { fingerprint: secondFile.fingerprint, key: 'walkthrough:s2:h2' };
+  const firstFile = {
+    ...createChangedFile(filePath),
+    fingerprint: 'first-hunk',
+  };
+  const secondFile = {
+    ...createChangedFile(filePath),
+    fingerprint: 'second-hunk',
+  };
+  const firstIdentity = {
+    fingerprint: firstFile.fingerprint,
+    key: 'walkthrough:s1:h1',
+  };
+  const secondIdentity = {
+    fingerprint: secondFile.fingerprint,
+    key: 'walkthrough:s2:h2',
+  };
 
   function Harness() {
     const [viewed, setViewed] = useState<Record<string, string>>({});
     const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
     const [itemVersionByKey, setItemVersionByKey] = useState<Record<string, number>>({});
-
     const toggleViewed = (
       _file: ChangedFile,
       isViewed: boolean,
@@ -828,7 +811,6 @@ test('walkthrough hunk viewed state is keyed independently from file path', asyn
         [reviewIdentity.key]: (current[reviewIdentity.key] ?? 0) + 1,
       }));
     };
-
     return (
       <>
         <ReviewCodeViewHarness
@@ -855,31 +837,29 @@ test('walkthrough hunk viewed state is keyed independently from file path', asyn
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<Harness />);
-    });
-
-    const viewedButtons = () => [
-      ...container.querySelectorAll<HTMLButtonElement>('.codiff-viewed-button'),
-    ];
-    expect(viewedButtons()).toHaveLength(2);
-
-    await act(async () => {
-      viewedButtons()[0].click();
-    });
-
-    await waitFor(() => {
-      expect(viewedButtons()[0].getAttribute('aria-pressed')).toBe('true');
-      expect(viewedButtons()[1].getAttribute('aria-pressed')).toBe('false');
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Harness />);
+  });
+  const viewedButtons = () => [
+    ...container.querySelectorAll<HTMLButtonElement>('.codiff-viewed-button'),
+  ];
+  expect(viewedButtons()).toHaveLength(2);
+  await act(async () => {
+    viewedButtons()[0].click();
+  });
+  await waitFor(() => {
+    expect(viewedButtons()[0].getAttribute('aria-pressed')).toBe('true');
+    expect(viewedButtons()[1].getAttribute('aria-pressed')).toBe('false');
+  });
 });
 
 test('read-only walkthroughs can opt into the viewed control', async () => {
@@ -889,34 +869,32 @@ test('read-only walkthroughs can opt into the viewed control', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          allowViewedToggle
-          files={[file]}
-          isReadOnly
-          onToggleViewed={onToggleViewed}
-        />,
-      );
-    });
-
-    const viewedButton = container.querySelector<HTMLButtonElement>('.codiff-viewed-button');
-    expect(viewedButton).not.toBeNull();
-    expect(container.querySelector('.codiff-button')).toBeNull();
-
-    await act(async () => {
-      viewedButton?.click();
-    });
-
-    expect(onToggleViewed).toHaveBeenCalledOnce();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        allowViewedToggle
+        files={[file]}
+        isReadOnly
+        onToggleViewed={onToggleViewed}
+      />,
+    );
+  });
+  const viewedButton = container.querySelector<HTMLButtonElement>('.codiff-viewed-button');
+  expect(viewedButton).not.toBeNull();
+  expect(container.querySelector('.codiff-button')).toBeNull();
+  await act(async () => {
+    viewedButton?.click();
+  });
+  expect(onToggleViewed).toHaveBeenCalledOnce();
 });
 
 test('reload scroll target is retried until the selected item renders', async () => {
@@ -924,41 +902,45 @@ test('reload scroll target is retried until the selected item renders', async ()
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          files={[createChangedFile('src/first.ts'), createChangedFile('src/second.ts')]}
-          scrollTarget={{ path: 'src/second.ts', request: 1 }}
-          selectedPath="src/second.ts"
-        />,
-      );
-    });
-
-    await waitFor(() => {
-      expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(1);
-    });
-    expect(codeViewMock.scrollTo).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        behavior: 'instant',
-        id: 'diff:src/second.ts:unstaged',
-        type: 'item',
-      }),
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        files={[createChangedFile('src/first.ts'), createChangedFile('src/second.ts')]}
+        scrollTarget={{ path: 'src/second.ts', request: 1 }}
+        selectedPath="src/second.ts"
+      />,
     );
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  });
+  await waitFor(() => {
+    expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(1);
+  });
+  expect(codeViewMock.scrollTo).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      behavior: 'instant',
+      id: 'diff:src/second.ts:unstaged',
+      type: 'item',
+    }),
+  );
 });
 
 test('scroll targets issue one command per request even before render visibility catches up', async () => {
   const container = document.createElement('div');
   document.body.append(container);
   let root: Root | null = null;
-  const scrollTarget = { behavior: 'smooth' as const, path: 'src/second.ts', request: 1 };
+  const scrollTarget = {
+    behavior: 'smooth' as const,
+    path: 'src/second.ts',
+    request: 1,
+  };
 
   const renderView = () => (
     <ReviewCodeViewHarness
@@ -967,31 +949,28 @@ test('scroll targets issue one command per request even before render visibility
     />
   );
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(renderView());
-    });
-
-    await waitFor(() => {
-      expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(1);
-    });
-
-    await act(async () => {
-      root?.render(renderView());
-    });
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(renderView());
+  });
+  await waitFor(() => {
     expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(1);
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  });
+  await act(async () => {
+    root?.render(renderView());
+  });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(codeViewMock.scrollTo).toHaveBeenCalledTimes(1);
 });
 
 test('hunk navigation skips stale requests when the review view remounts', async () => {
@@ -999,48 +978,45 @@ test('hunk navigation skips stale requests when the review view remounts', async
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          diffStyle="unified"
-          files={[createChangedFile('src/first.ts')]}
-          hunkNavigation={{ direction: 1, request: 1 }}
-        />,
-      );
-    });
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    expect(codeViewMock.scrollTo).not.toHaveBeenCalled();
-
-    await act(async () => {
-      root?.render(
-        <ReviewCodeViewHarness
-          diffStyle="unified"
-          files={[createChangedFile('src/first.ts')]}
-          hunkNavigation={{ direction: 1, request: 2 }}
-        />,
-      );
-    });
-
-    expect(codeViewMock.scrollTo).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'diff:src/first.ts:unstaged',
-        lineNumber: 1,
-        side: 'additions',
-        type: 'line',
-      }),
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        diffStyle="unified"
+        files={[createChangedFile('src/first.ts')]}
+        hunkNavigation={{ direction: 1, request: 1 }}
+      />,
     );
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(codeViewMock.scrollTo).not.toHaveBeenCalled();
+  await act(async () => {
+    root?.render(
+      <ReviewCodeViewHarness
+        diffStyle="unified"
+        files={[createChangedFile('src/first.ts')]}
+        hunkNavigation={{ direction: 1, request: 2 }}
+      />,
+    );
+  });
+  expect(codeViewMock.scrollTo).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: 'diff:src/first.ts:unstaged',
+      lineNumber: 1,
+      side: 'additions',
+      type: 'line',
+    }),
+  );
 });
 
 test('hunk navigation skips pull request description source context', async () => {
@@ -1053,7 +1029,7 @@ test('hunk navigation skips pull request description source context', async () =
     url: 'https://github.com/nkzw-tech/codiff/pull/12',
   } satisfies ReviewSource;
   const file = createChangedFile('src/first.ts');
-  const app = await renderReact(
+  await using app = await renderReact(
     <ReviewCodeViewHarness
       diffStyle="unified"
       files={[file]}
@@ -1062,30 +1038,24 @@ test('hunk navigation skips pull request description source context', async () =
     />,
   );
 
-  try {
-    codeViewMock.scrollTo.mockClear();
-
-    await app.rerender(
-      <ReviewCodeViewHarness
-        diffStyle="unified"
-        files={[file]}
-        hunkNavigation={{ direction: 1, request: 2 }}
-        source={source}
-      />,
-    );
-
-    const target = codeViewMock.scrollTo.mock.lastCall?.[0];
-    expect(target?.id).toBe('diff:src/first.ts:unstaged');
-    expect(target).toEqual(
-      expect.objectContaining({
-        lineNumber: 1,
-        side: 'additions',
-        type: 'line',
-      }),
-    );
-  } finally {
-    await app.cleanup();
-  }
+  codeViewMock.scrollTo.mockClear();
+  await app.rerender(
+    <ReviewCodeViewHarness
+      diffStyle="unified"
+      files={[file]}
+      hunkNavigation={{ direction: 1, request: 2 }}
+      source={source}
+    />,
+  );
+  const target = codeViewMock.scrollTo.mock.lastCall?.[0];
+  expect(target?.id).toBe('diff:src/first.ts:unstaged');
+  expect(target).toEqual(
+    expect.objectContaining({
+      lineNumber: 1,
+      side: 'additions',
+      type: 'line',
+    }),
+  );
 });
 
 test('read-only markdown previews trigger CodeView layout remeasurement after height change', async () => {
@@ -1102,7 +1072,7 @@ test('read-only markdown previews trigger CodeView layout remeasurement after he
     type: 'pull-request',
     url: 'https://github.com/nkzw-tech/codiff/pull/12',
   } satisfies ReviewSource;
-  const app = await renderReact(
+  await using app = await renderReact(
     <ReviewCodeViewHarness
       files={[markdownFile]}
       initialMarkdownPreviewSectionIds={new Set([markdownSectionId])}
@@ -1111,37 +1081,27 @@ test('read-only markdown previews trigger CodeView layout remeasurement after he
     />,
   );
 
-  try {
-    const markdownItemId = `diff:${markdownSectionId}`;
-    const initialMarkdownVersion = getCodeViewItemVersion(markdownItemId);
-
-    const markdownPreview = app.container.querySelector<HTMLElement>(
-      '[aria-label="Preview plan.md"]',
-    );
-    // The source description renders in CodeView's header region, where height
-    // changes are observed by the viewer directly instead of item versions.
-    const sourceDescription = app.container.querySelector<HTMLElement>(
-      '[data-diffs-code-view-header] [aria-label="Preview source description"]',
-    );
-
-    expect(markdownPreview).not.toBeNull();
-    expect(sourceDescription).not.toBeNull();
-    expect(
-      sourceDescription
-        ?.closest('[data-diffs-code-view-header]')
-        ?.closest('[slot="header-custom"]'),
-    ).toBeNull();
-
-    await act(async () => {
-      markdownPreview?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
-    });
-
-    await waitFor(() => {
-      expect(getCodeViewItemVersion(markdownItemId)).not.toBe(initialMarkdownVersion);
-    });
-  } finally {
-    await app.cleanup();
-  }
+  const markdownItemId = `diff:${markdownSectionId}`;
+  const initialMarkdownVersion = getCodeViewItemVersion(markdownItemId);
+  const markdownPreview = app.container.querySelector<HTMLElement>(
+    '[aria-label="Preview plan.md"]',
+  );
+  // The source description renders in CodeView's header region, where height
+  // changes are observed by the viewer directly instead of item versions.
+  const sourceDescription = app.container.querySelector<HTMLElement>(
+    '[data-diffs-code-view-header] [aria-label="Preview source description"]',
+  );
+  expect(markdownPreview).not.toBeNull();
+  expect(sourceDescription).not.toBeNull();
+  expect(
+    sourceDescription?.closest('[data-diffs-code-view-header]')?.closest('[slot="header-custom"]'),
+  ).toBeNull();
+  await act(async () => {
+    markdownPreview?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+  });
+  await waitFor(() => {
+    expect(getCodeViewItemVersion(markdownItemId)).not.toBe(initialMarkdownVersion);
+  });
 });
 
 test('source description remains visible when a review has no diff items', async () => {
@@ -1153,21 +1113,17 @@ test('source description remains visible when a review has no diff items', async
     type: 'pull-request',
     url: 'https://github.com/nkzw-tech/codiff/pull/13',
   } satisfies ReviewSource;
-  const app = await renderReact(<ReviewCodeViewHarness files={[]} isReadOnly source={source} />);
+  await using app = await renderReact(
+    <ReviewCodeViewHarness files={[]} isReadOnly source={source} />,
+  );
 
-  try {
-    const sourceDescription = app.container.querySelector(
-      '[data-diffs-code-view-header] [aria-label="Preview source description"]',
-    );
-    expect(sourceDescription).not.toBeNull();
-    expect(
-      sourceDescription
-        ?.closest('[data-diffs-code-view-header]')
-        ?.closest('[slot="header-custom"]'),
-    ).toBeNull();
-  } finally {
-    await app.cleanup();
-  }
+  const sourceDescription = app.container.querySelector(
+    '[data-diffs-code-view-header] [aria-label="Preview source description"]',
+  );
+  expect(sourceDescription).not.toBeNull();
+  expect(
+    sourceDescription?.closest('[data-diffs-code-view-header]')?.closest('[slot="header-custom"]'),
+  ).toBeNull();
 });
 
 test('hunk navigation orders deletion comments before added rows in unified changes', async () => {
@@ -1198,42 +1154,39 @@ test('hunk navigation orders deletion comments before added rows in unified chan
       />,
     );
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      render(0);
-    });
-    codeViewMock.scrollTo.mockClear();
-
-    await act(async () => {
-      render(1);
-    });
-
-    expect(codeViewMock.scrollTo).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        lineNumber: 1,
-        side: 'deletions',
-        type: 'line',
-      }),
-    );
-
-    await act(async () => {
-      render(2);
-    });
-
-    expect(codeViewMock.scrollTo).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        lineNumber: 1,
-        side: 'additions',
-        type: 'line',
-      }),
-    );
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    render(0);
+  });
+  codeViewMock.scrollTo.mockClear();
+  await act(async () => {
+    render(1);
+  });
+  expect(codeViewMock.scrollTo).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      lineNumber: 1,
+      side: 'deletions',
+      type: 'line',
+    }),
+  );
+  await act(async () => {
+    render(2);
+  });
+  expect(codeViewMock.scrollTo).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      lineNumber: 1,
+      side: 'additions',
+      type: 'line',
+    }),
+  );
 });
 
 test('review comment typing stays local until a comment action commits it', async () => {
@@ -1253,52 +1206,47 @@ test('review comment typing stays local until a comment action commits it', asyn
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewCodeViewHarness
-          comments={[comment]}
-          diffStyle="unified"
-          files={[file]}
-          onAskCodex={onAskCodex}
-          onCommentDraftChange={onCommentDraftChange}
-          onUpdateComment={onUpdateComment}
-        />,
-      );
-    });
-
-    const textarea = container.querySelector<HTMLTextAreaElement>('.review-comment-input');
-    if (!textarea) {
-      throw new Error('Expected review comment textarea.');
-    }
-
-    await setInputValue(textarea, 'Please check this.');
-
-    expect(onUpdateComment).not.toHaveBeenCalled();
-    expect(onCommentDraftChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ body: 'Please check this.', id: 'comment-1' }),
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewCodeViewHarness
+        comments={[comment]}
+        diffStyle="unified"
+        files={[file]}
+        onAskCodex={onAskCodex}
+        onCommentDraftChange={onCommentDraftChange}
+        onUpdateComment={onUpdateComment}
+      />,
     );
-
-    const askButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
-      (button) => button.textContent === 'Ask',
-    );
-    if (!askButton) {
-      throw new Error('Expected Ask button.');
-    }
-
-    await act(async () => {
-      askButton.click();
-    });
-
-    expect(onUpdateComment).toHaveBeenCalledWith('comment-1', 'Please check this.');
-    expect(onAskCodex).toHaveBeenCalledWith('comment-1');
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
+  });
+  const textarea = container.querySelector<HTMLTextAreaElement>('.review-comment-input');
+  if (!textarea) {
+    throw new Error('Expected review comment textarea.');
   }
+  await setInputValue(textarea, 'Please check this.');
+  expect(onUpdateComment).not.toHaveBeenCalled();
+  expect(onCommentDraftChange).toHaveBeenLastCalledWith(
+    expect.objectContaining({ body: 'Please check this.', id: 'comment-1' }),
+  );
+  const askButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+    (button) => button.textContent === 'Ask',
+  );
+  if (!askButton) {
+    throw new Error('Expected Ask button.');
+  }
+  await act(async () => {
+    askButton.click();
+  });
+  expect(onUpdateComment).toHaveBeenCalledWith('comment-1', 'Please check this.');
+  expect(onAskCodex).toHaveBeenCalledWith('comment-1');
 });
 
 test('a Codex reply does not repeatedly invalidate the diff item layout', async () => {
@@ -1314,31 +1262,27 @@ test('a Codex reply does not repeatedly invalidate the diff item layout', async 
   markdownEditorMock.heightByAriaLabel.set('Comment on src/comment.ts New line 1', 100);
   markdownEditorMock.heightByAriaLabel.set('Codex reply', 320);
   markdownEditorMock.heightReportLimit = 6;
-  const view = await renderReact(<ReviewCodeViewHarness comments={[comment]} files={[file]} />);
+  await using view = await renderReact(
+    <ReviewCodeViewHarness comments={[comment]} files={[file]} />,
+  );
 
-  try {
-    const renderCountBeforeReply = codeViewMock.renderCount;
-
-    await view.rerender(
-      <ReviewCodeViewHarness
-        comments={[
-          {
-            ...comment,
-            codexReply: {
-              body: 'This reply is tall enough to use a different markdown measurement.',
-              status: 'ready',
-            },
+  const renderCountBeforeReply = codeViewMock.renderCount;
+  await view.rerender(
+    <ReviewCodeViewHarness
+      comments={[
+        {
+          ...comment,
+          codexReply: {
+            body: 'This reply is tall enough to use a different markdown measurement.',
+            status: 'ready',
           },
-        ]}
-        files={[file]}
-      />,
-    );
-
-    expect(view.container.querySelector('[aria-label="Codex reply"]')).not.toBeNull();
-    expect(codeViewMock.renderCount).toBe(renderCountBeforeReply + 1);
-  } finally {
-    await view.cleanup();
-  }
+        },
+      ]}
+      files={[file]}
+    />,
+  );
+  expect(view.container.querySelector('[aria-label="Codex reply"]')).not.toBeNull();
+  expect(codeViewMock.renderCount).toBe(renderCountBeforeReply + 1);
 });
 
 test('failed pull request comments keep their draft and can be retried', async () => {
@@ -1358,7 +1302,7 @@ test('failed pull request comments keep their draft and can be retried', async (
   } satisfies ReviewComment;
   const onSubmitComment = vi.fn();
   const onUpdateComment = vi.fn();
-  const view = await renderReact(
+  await using view = await renderReact(
     <ReviewCodeViewHarness
       comments={[comment]}
       files={[file]}
@@ -1368,30 +1312,23 @@ test('failed pull request comments keep their draft and can be retried', async (
     />,
   );
 
-  try {
-    const textarea = view.container.querySelector<HTMLTextAreaElement>('.review-comment-input');
-    expect(textarea?.value).toBe('Keep this comment.');
-    expect(view.container.querySelector('.review-comment-error')?.textContent).toBe(
-      comment.remoteSubmit.error,
-    );
-
-    const commentButton = [...view.container.querySelectorAll<HTMLButtonElement>('button')].find(
-      (button) => button.textContent === 'Comment',
-    );
-    if (!commentButton) {
-      throw new Error('Expected Comment button.');
-    }
-
-    await act(async () => {
-      commentButton.click();
-    });
-
-    expect(onUpdateComment).not.toHaveBeenCalled();
-    expect(onSubmitComment).toHaveBeenCalledWith(comment.id);
-    expect(textarea?.value).toBe(comment.body);
-  } finally {
-    await view.cleanup();
+  const textarea = view.container.querySelector<HTMLTextAreaElement>('.review-comment-input');
+  expect(textarea?.value).toBe('Keep this comment.');
+  expect(view.container.querySelector('.review-comment-error')?.textContent).toBe(
+    comment.remoteSubmit.error,
+  );
+  const commentButton = [...view.container.querySelectorAll<HTMLButtonElement>('button')].find(
+    (button) => button.textContent === 'Comment',
+  );
+  if (!commentButton) {
+    throw new Error('Expected Comment button.');
   }
+  await act(async () => {
+    commentButton.click();
+  });
+  expect(onUpdateComment).not.toHaveBeenCalled();
+  expect(onSubmitComment).toHaveBeenCalledWith(comment.id);
+  expect(textarea?.value).toBe(comment.body);
 });
 
 test('working-tree share comments support the Comment button and Mod+Enter', async () => {
@@ -1406,7 +1343,7 @@ test('working-tree share comments support the Comment button and Mod+Enter', asy
     side: 'additions',
   } satisfies ReviewComment;
   const onSubmitComment = vi.fn();
-  const view = await renderReact(
+  await using view = await renderReact(
     <ReviewCodeViewHarness
       comments={[comment]}
       files={[file]}
@@ -1415,33 +1352,32 @@ test('working-tree share comments support the Comment button and Mod+Enter', asy
     />,
   );
 
-  try {
-    const commentButton = [...view.container.querySelectorAll<HTMLButtonElement>('button')].find(
-      (button) => button.textContent === 'Comment',
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      platform.mockRestore();
+      await view.cleanup();
+    },
+  };
+  const commentButton = [...view.container.querySelectorAll<HTMLButtonElement>('button')].find(
+    (button) => button.textContent === 'Comment',
+  );
+  expect(commentButton).not.toBeNull();
+  await act(async () => commentButton?.click());
+  expect(onSubmitComment).toHaveBeenLastCalledWith(comment.id);
+  onSubmitComment.mockClear();
+  const textarea = view.container.querySelector<HTMLTextAreaElement>('.review-comment-input');
+  expect(textarea).not.toBeNull();
+  await act(async () => {
+    textarea?.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        bubbles: true,
+        cancelable: true,
+        key: 'Enter',
+        metaKey: true,
+      }),
     );
-    expect(commentButton).not.toBeNull();
-
-    await act(async () => commentButton?.click());
-    expect(onSubmitComment).toHaveBeenLastCalledWith(comment.id);
-
-    onSubmitComment.mockClear();
-    const textarea = view.container.querySelector<HTMLTextAreaElement>('.review-comment-input');
-    expect(textarea).not.toBeNull();
-    await act(async () => {
-      textarea?.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          bubbles: true,
-          cancelable: true,
-          key: 'Enter',
-          metaKey: true,
-        }),
-      );
-    });
-    expect(onSubmitComment).toHaveBeenCalledWith(comment.id);
-  } finally {
-    platform.mockRestore();
-    await view.cleanup();
-  }
+  });
+  expect(onSubmitComment).toHaveBeenCalledWith(comment.id);
 });
 
 test('file comments can be created for GitLab merge requests but not GitHub pull requests', async () => {
@@ -1457,7 +1393,7 @@ test('file comments can be created for GitLab merge requests but not GitHub pull
     type: 'pull-request',
     url: 'https://github.com/example/project/pull/1',
   } satisfies ReviewSource;
-  const view = await renderReact(
+  await using view = await renderReact(
     <ReviewCodeViewHarness
       files={[file]}
       onCreateComment={onCreateComment}
@@ -1466,37 +1402,31 @@ test('file comments can be created for GitLab merge requests but not GitHub pull
     />,
   );
 
-  try {
-    const fileCommentButton = view.container.querySelector<HTMLButtonElement>(
-      '.codiff-file-comment-button',
-    );
-    expect(fileCommentButton).not.toBeNull();
-    expect(fileCommentButton?.classList.contains('codiff-button')).toBe(true);
-
-    await act(async () => fileCommentButton?.click());
-    expect(onCreateComment).toHaveBeenCalledWith({
-      anchor: 'file',
-      filePath: 'src/comment.ts',
-      sectionId: 'src/comment.ts:unstaged',
-    });
-
-    await view.rerender(
-      <ReviewCodeViewHarness
-        files={[file]}
-        onCreateComment={onCreateComment}
-        source={gitHubSource}
-        supportsReviewCommentActions
-      />,
-    );
-    expect(view.container.querySelector('.codiff-file-comment-button')).toBeNull();
-  } finally {
-    await view.cleanup();
-  }
+  const fileCommentButton = view.container.querySelector<HTMLButtonElement>(
+    '.codiff-file-comment-button',
+  );
+  expect(fileCommentButton).not.toBeNull();
+  expect(fileCommentButton?.classList.contains('codiff-button')).toBe(true);
+  await act(async () => fileCommentButton?.click());
+  expect(onCreateComment).toHaveBeenCalledWith({
+    anchor: 'file',
+    filePath: 'src/comment.ts',
+    sectionId: 'src/comment.ts:unstaged',
+  });
+  await view.rerender(
+    <ReviewCodeViewHarness
+      files={[file]}
+      onCreateComment={onCreateComment}
+      source={gitHubSource}
+      supportsReviewCommentActions
+    />,
+  );
+  expect(view.container.querySelector('.codiff-file-comment-button')).toBeNull();
 });
 
 test('file-level review comments render as measured file annotations', async () => {
   const file = createChangedFile('src/comment.ts');
-  const view = await renderReact(
+  await using view = await renderReact(
     <ReviewCodeViewHarness
       comments={[
         {
@@ -1519,31 +1449,27 @@ test('file-level review comments render as measured file annotations', async () 
     />,
   );
 
-  try {
-    const fileComments = view.container.querySelector('.review-comment-thread');
-    expect(fileComments?.textContent).toContain('Review this file as a whole.');
-    expect(fileComments?.closest('.codiff-file-header')).toBeNull();
-    const item = codeViewMock.lastItems.find(
-      (candidate) => candidate.id === 'diff:src/comment.ts:unstaged',
-    ) as
-      | {
-          annotations?: ReadonlyArray<{
-            lineNumber: number;
-            metadata: { commentIds?: ReadonlyArray<string>; type: string };
-          }>;
-        }
-      | undefined;
-    expect(item?.annotations).toContainEqual({
-      lineNumber: 0,
-      metadata: {
-        commentIds: ['gitlab:file'],
-        type: 'review-comment',
-      },
-      side: 'additions',
-    });
-  } finally {
-    await view.cleanup();
-  }
+  const fileComments = view.container.querySelector('.review-comment-thread');
+  expect(fileComments?.textContent).toContain('Review this file as a whole.');
+  expect(fileComments?.closest('.codiff-file-header')).toBeNull();
+  const item = codeViewMock.lastItems.find(
+    (candidate) => candidate.id === 'diff:src/comment.ts:unstaged',
+  ) as
+    | {
+        annotations?: ReadonlyArray<{
+          lineNumber: number;
+          metadata: { commentIds?: ReadonlyArray<string>; type: string };
+        }>;
+      }
+    | undefined;
+  expect(item?.annotations).toContainEqual({
+    lineNumber: 0,
+    metadata: {
+      commentIds: ['gitlab:file'],
+      type: 'review-comment',
+    },
+    side: 'additions',
+  });
 });
 
 test('code quality findings render as additions annotations', async () => {
@@ -1557,7 +1483,7 @@ test('code quality findings render as additions annotations', async () => {
     severity: 'major',
     status: 'new',
   } satisfies PullRequestCodeQualityFinding;
-  const view = await renderReact(
+  await using view = await renderReact(
     <ReviewCodeViewHarness
       codeQualityFindings={[
         finding,
@@ -1569,40 +1495,35 @@ test('code quality findings render as additions annotations', async () => {
     />,
   );
 
-  try {
-    const renderedFinding = view.container.querySelector<HTMLElement>('.code-quality-finding');
-    expect(renderedFinding?.dataset.severity).toBe('major');
-    expect(renderedFinding?.dataset.status).toBe('new');
-    expect(renderedFinding?.textContent).toContain('Code Quality');
-    expect(renderedFinding?.textContent).toContain('Major');
-    expect(renderedFinding?.textContent).toContain('New');
-    expect(renderedFinding?.textContent).toContain(finding.description);
-    expect(renderedFinding?.textContent).toContain('eslint');
-
-    const item = codeViewMock.lastItems.find(
-      (candidate) => candidate.id === 'diff:src/app.ts:unstaged',
-    ) as
-      | {
-          annotations?: ReadonlyArray<{
-            lineNumber: number;
-            metadata: { finding?: PullRequestCodeQualityFinding; type: string };
-            side: string;
-          }>;
-        }
-      | undefined;
-    expect(item?.annotations?.filter(({ metadata }) => metadata.type === 'code-quality')).toEqual([
-      {
-        lineNumber: 1,
-        metadata: {
-          finding,
-          type: 'code-quality',
-        },
-        side: 'additions',
+  const renderedFinding = view.container.querySelector<HTMLElement>('.code-quality-finding');
+  expect(renderedFinding?.dataset.severity).toBe('major');
+  expect(renderedFinding?.dataset.status).toBe('new');
+  expect(renderedFinding?.textContent).toContain('Code Quality');
+  expect(renderedFinding?.textContent).toContain('Major');
+  expect(renderedFinding?.textContent).toContain('New');
+  expect(renderedFinding?.textContent).toContain(finding.description);
+  expect(renderedFinding?.textContent).toContain('eslint');
+  const item = codeViewMock.lastItems.find(
+    (candidate) => candidate.id === 'diff:src/app.ts:unstaged',
+  ) as
+    | {
+        annotations?: ReadonlyArray<{
+          lineNumber: number;
+          metadata: { finding?: PullRequestCodeQualityFinding; type: string };
+          side: string;
+        }>;
+      }
+    | undefined;
+  expect(item?.annotations?.filter(({ metadata }) => metadata.type === 'code-quality')).toEqual([
+    {
+      lineNumber: 1,
+      metadata: {
+        finding,
+        type: 'code-quality',
       },
-    ]);
-  } finally {
-    await view.cleanup();
-  }
+      side: 'additions',
+    },
+  ]);
 });
 
 test('Enter on a focused review control is not converted into a hunk comment', async () => {
@@ -1623,40 +1544,42 @@ test('Enter on a focused review control is not converted into a hunk comment', a
       />,
     );
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      render(0);
-    });
-    await act(async () => {
-      render(1);
-    });
-
-    const openButton = container.querySelector<HTMLButtonElement>('.codiff-button');
-    if (!openButton) {
-      throw new Error('Expected the open file button.');
-    }
-
-    openButton.focus();
-    const event = new KeyboardEvent('keydown', {
-      bubbles: true,
-      cancelable: true,
-      key: 'Enter',
-    });
-    openButton.dispatchEvent(event);
-
-    expect(event.defaultPrevented).toBe(false);
-    expect(onCreateComment).not.toHaveBeenCalled();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    render(0);
+  });
+  await act(async () => {
+    render(1);
+  });
+  const openButton = container.querySelector<HTMLButtonElement>('.codiff-button');
+  if (!openButton) {
+    throw new Error('Expected the open file button.');
   }
+  openButton.focus();
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key: 'Enter',
+  });
+  openButton.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(false);
+  expect(onCreateComment).not.toHaveBeenCalled();
 });
 
 type ReviewLineClickHandler = (
-  line: { annotationSide: 'additions' | 'deletions'; event: unknown; lineNumber: number },
+  line: {
+    annotationSide: 'additions' | 'deletions';
+    event: unknown;
+    lineNumber: number;
+  },
   context: { item: unknown },
 ) => void;
 
@@ -1695,75 +1618,74 @@ test('line content clicks create review comments unless text is selected', async
   document.body.append(selectionHost);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<ReviewCodeViewHarness files={[file]} onCreateComment={onCreateComment} />);
-    });
-
-    const { item, onGutterUtilityClick, onLineClick, onLineSelectionEnd } =
-      getReviewCodeViewHandlers();
-    const range = { end: 1, side: 'additions' as const, start: 1 };
-
-    await act(async () => {
-      onLineClick(
-        { annotationSide: 'additions', event: nonInteractivePointerEvent, lineNumber: 1 },
-        { item },
-      );
-    });
-
-    expect(onCreateComment).toHaveBeenCalledTimes(1);
-    expect(onCreateComment).toHaveBeenLastCalledWith({
-      filePath: 'src/click.ts',
-      lineNumber: 1,
-      sectionId: 'src/click.ts:unstaged',
-      side: 'additions',
-    });
-
-    const selection = window.getSelection();
-    const textSelection = document.createRange();
-    textSelection.selectNodeContents(selectionHost);
-    selection?.removeAllRanges();
-    selection?.addRange(textSelection);
-
-    await act(async () => {
-      onLineClick(
-        { annotationSide: 'additions', event: nonInteractivePointerEvent, lineNumber: 1 },
-        { item },
-      );
-    });
-
-    expect(onCreateComment).toHaveBeenCalledTimes(1);
-    selection?.removeAllRanges();
-
-    await act(async () => {
-      onLineSelectionEnd(range, { item });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    expect(onCreateComment).toHaveBeenCalledTimes(2);
-    expect(onCreateComment).toHaveBeenLastCalledWith({
-      filePath: 'src/click.ts',
-      lineNumber: 1,
-      sectionId: 'src/click.ts:unstaged',
-      side: 'additions',
-    });
-
-    await act(async () => {
-      onGutterUtilityClick(range, { item });
-      // The pointer-up after a gutter drag also ends a line selection; only
-      // the gutter callback may create the comment.
-      onLineSelectionEnd(range, { item });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    expect(onCreateComment).toHaveBeenCalledTimes(3);
-  } finally {
-    window.getSelection()?.removeAllRanges();
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-    selectionHost.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      window.getSelection()?.removeAllRanges();
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+      selectionHost.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<ReviewCodeViewHarness files={[file]} onCreateComment={onCreateComment} />);
+  });
+  const { item, onGutterUtilityClick, onLineClick, onLineSelectionEnd } =
+    getReviewCodeViewHandlers();
+  const range = { end: 1, side: 'additions' as const, start: 1 };
+  await act(async () => {
+    onLineClick(
+      {
+        annotationSide: 'additions',
+        event: nonInteractivePointerEvent,
+        lineNumber: 1,
+      },
+      { item },
+    );
+  });
+  expect(onCreateComment).toHaveBeenCalledTimes(1);
+  expect(onCreateComment).toHaveBeenLastCalledWith({
+    filePath: 'src/click.ts',
+    lineNumber: 1,
+    sectionId: 'src/click.ts:unstaged',
+    side: 'additions',
+  });
+  const selection = window.getSelection();
+  const textSelection = document.createRange();
+  textSelection.selectNodeContents(selectionHost);
+  selection?.removeAllRanges();
+  selection?.addRange(textSelection);
+  await act(async () => {
+    onLineClick(
+      {
+        annotationSide: 'additions',
+        event: nonInteractivePointerEvent,
+        lineNumber: 1,
+      },
+      { item },
+    );
+  });
+  expect(onCreateComment).toHaveBeenCalledTimes(1);
+  selection?.removeAllRanges();
+  await act(async () => {
+    onLineSelectionEnd(range, { item });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(onCreateComment).toHaveBeenCalledTimes(2);
+  expect(onCreateComment).toHaveBeenLastCalledWith({
+    filePath: 'src/click.ts',
+    lineNumber: 1,
+    sectionId: 'src/click.ts:unstaged',
+    side: 'additions',
+  });
+  await act(async () => {
+    onGutterUtilityClick(range, { item });
+    // The pointer-up after a gutter drag also ends a line selection; only
+    // the gutter callback may create the comment.
+    onLineSelectionEnd(range, { item });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(onCreateComment).toHaveBeenCalledTimes(3);
 });

--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -1355,7 +1355,6 @@ test('working-tree share comments support the Comment button and Mod+Enter', asy
   await using _resource = {
     async [Symbol.asyncDispose]() {
       platform.mockRestore();
-      await view.cleanup();
     },
   };
   const commentButton = [...view.container.querySelectorAll<HTMLButtonElement>('button')].find(

--- a/core/__tests__/SharedPlanApp.test.tsx
+++ b/core/__tests__/SharedPlanApp.test.tsx
@@ -53,33 +53,33 @@ test('read-only comments can reveal attached targets', async () => {
   document.body.append(container);
   const root = createRoot(container);
 
-  try {
-    await act(async () => {
-      root.render(
-        <PlanCommentCard
-          active={false}
-          detached={false}
-          onActivate={() => {}}
-          onBodyChange={() => {}}
-          onDelete={() => {}}
-          onEmptyBlur={() => {}}
-          onHeightChange={() => {}}
-          onReveal={onReveal}
-          readOnly
-          showDelete={false}
-          thread={thread}
-        />,
-      );
-    });
-
-    const target = container.querySelector<HTMLButtonElement>('.plan-comment-target');
-    expect(target?.disabled).toBe(false);
-    await act(async () => target?.click());
-    expect(onReveal).toHaveBeenCalledOnce();
-  } finally {
-    await act(async () => root.unmount());
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root.render(
+      <PlanCommentCard
+        active={false}
+        detached={false}
+        onActivate={() => {}}
+        onBodyChange={() => {}}
+        onDelete={() => {}}
+        onEmptyBlur={() => {}}
+        onHeightChange={() => {}}
+        onReveal={onReveal}
+        readOnly
+        showDelete={false}
+        thread={thread}
+      />,
+    );
+  });
+  const target = container.querySelector<HTMLButtonElement>('.plan-comment-target');
+  expect(target?.disabled).toBe(false);
+  await act(async () => target?.click());
+  expect(onReveal).toHaveBeenCalledOnce();
 });
 
 test('shared plans render Markdown and comments read-only', async () => {
@@ -161,55 +161,54 @@ test('shared plans render Markdown and comments read-only', async () => {
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<PlanReviewSurface onDeleteShare={onDeleteShare} snapshot={snapshot} />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.mdx-editor-content h1')?.textContent).toBe(
-        'Ship plan sharing',
-      );
-      expect(container.querySelector('.plan-comment-thread')?.textContent).toContain(
-        'Do not regress walkthrough sharing.',
-      );
-    });
-
-    expect(container.querySelector('.plan-title')?.textContent).toBe('Ship plan sharing');
-    expect(container.querySelector('.plan-header.workspace-top-bar')).not.toBeNull();
-    expect(container.querySelector('.codiff-file-path')?.textContent).toBe('plan.md');
-    expect(
-      container.querySelector('.codiff-header-toggle-static .codiff-file-path')?.textContent,
-    ).toBe('plan.md');
-    expect(container.querySelector('button[aria-label="Download plan"] svg')).not.toBeNull();
-    const deleteShare = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Delete shared plan"]',
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<PlanReviewSurface onDeleteShare={onDeleteShare} snapshot={snapshot} />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.mdx-editor-content h1')?.textContent).toBe(
+      'Ship plan sharing',
     );
-    expect(deleteShare?.closest('.plan-file-actions')).not.toBeNull();
-    await act(async () => deleteShare?.click());
-    expect(confirmDelete).toHaveBeenCalledWith('Delete this shared plan? This cannot be undone.');
-    expect(onDeleteShare).not.toHaveBeenCalled();
-    confirmDelete.mockReturnValue(true);
-    await act(async () => deleteShare?.click());
-    await waitFor(() => expect(onDeleteShare).toHaveBeenCalledOnce());
-    expect(
-      [...container.querySelectorAll<HTMLElement>('[contenteditable]')].every(
-        (element) => element.getAttribute('contenteditable') === 'false',
-      ),
-    ).toBe(true);
-    expect(container.querySelector('.review-comment-delete')).toBeNull();
-    expect(container.querySelector('.plan-comment-affordance')).toBeNull();
-    const target = container.querySelector('.plan-comment-target');
-    expect(target?.closest('.plan-comment-heading')).not.toBeNull();
-    expect(target?.closest('.review-comment-header')).not.toBeNull();
-    expect(container.querySelector('.plan-comment-thread-title')).toBeNull();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+    expect(container.querySelector('.plan-comment-thread')?.textContent).toContain(
+      'Do not regress walkthrough sharing.',
+    );
+  });
+  expect(container.querySelector('.plan-title')?.textContent).toBe('Ship plan sharing');
+  expect(container.querySelector('.plan-header.workspace-top-bar')).not.toBeNull();
+  expect(container.querySelector('.codiff-file-path')?.textContent).toBe('plan.md');
+  expect(
+    container.querySelector('.codiff-header-toggle-static .codiff-file-path')?.textContent,
+  ).toBe('plan.md');
+  expect(container.querySelector('button[aria-label="Download plan"] svg')).not.toBeNull();
+  const deleteShare = container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Delete shared plan"]',
+  );
+  expect(deleteShare?.closest('.plan-file-actions')).not.toBeNull();
+  await act(async () => deleteShare?.click());
+  expect(confirmDelete).toHaveBeenCalledWith('Delete this shared plan? This cannot be undone.');
+  expect(onDeleteShare).not.toHaveBeenCalled();
+  confirmDelete.mockReturnValue(true);
+  await act(async () => deleteShare?.click());
+  await waitFor(() => expect(onDeleteShare).toHaveBeenCalledOnce());
+  expect(
+    [...container.querySelectorAll<HTMLElement>('[contenteditable]')].every(
+      (element) => element.getAttribute('contenteditable') === 'false',
+    ),
+  ).toBe(true);
+  expect(container.querySelector('.review-comment-delete')).toBeNull();
+  expect(container.querySelector('.plan-comment-affordance')).toBeNull();
+  const target = container.querySelector('.plan-comment-target');
+  expect(target?.closest('.plan-comment-heading')).not.toBeNull();
+  expect(target?.closest('.review-comment-header')).not.toBeNull();
+  expect(container.querySelector('.plan-comment-thread-title')).toBeNull();
 });
 
 test('shared plans collapse resolved comments without rendering their annotations', async () => {
@@ -264,25 +263,25 @@ test('shared plans collapse resolved comments without rendering their annotation
   document.body.append(container);
   const root = createRoot(container);
 
-  try {
-    await act(async () => {
-      root.render(<PlanReviewSurface snapshot={snapshot} />);
-    });
-    await waitFor(() => {
-      expect(container.querySelector('.plan-resolved-comments')).not.toBeNull();
-    });
-
-    const resolvedSection = container.querySelector<HTMLDetailsElement>('.plan-resolved-comments');
-    expect(resolvedSection?.open).toBe(false);
-    expect(resolvedSection?.querySelector('summary')?.textContent).toBe('Resolved comments (1)');
-    expect(resolvedSection?.querySelector('.plan-comment-thread.resolved')?.textContent).toContain(
-      'Resolved after target removal',
-    );
-    expect(container.querySelector('[data-mdx-annotation-block~="resolved-thread"]')).toBeNull();
-  } finally {
-    await act(async () => root.unmount());
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root.render(<PlanReviewSurface snapshot={snapshot} />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.plan-resolved-comments')).not.toBeNull();
+  });
+  const resolvedSection = container.querySelector<HTMLDetailsElement>('.plan-resolved-comments');
+  expect(resolvedSection?.open).toBe(false);
+  expect(resolvedSection?.querySelector('summary')?.textContent).toBe('Resolved comments (1)');
+  expect(resolvedSection?.querySelector('.plan-comment-thread.resolved')?.textContent).toContain(
+    'Resolved after target removal',
+  );
+  expect(container.querySelector('[data-mdx-annotation-block~="resolved-thread"]')).toBeNull();
 });
 
 test('shared plans do not render active HTML from documents or comments', async () => {
@@ -335,22 +334,22 @@ test('shared plans do not render active HTML from documents or comments', async 
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<PlanReviewSurface snapshot={snapshot} />);
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.mdx-editor-content h1')?.textContent).toBe('Safe plan');
-    });
-    expect(container.querySelector('button[onclick]')).toBeNull();
-    expect(container.querySelector('iframe')).toBeNull();
-    expect(container.querySelector('img[onerror]')).toBeNull();
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<PlanReviewSurface snapshot={snapshot} />);
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.mdx-editor-content h1')?.textContent).toBe('Safe plan');
+  });
+  expect(container.querySelector('button[onclick]')).toBeNull();
+  expect(container.querySelector('iframe')).toBeNull();
+  expect(container.querySelector('img[onerror]')).toBeNull();
 });

--- a/core/__tests__/SharedWalkthroughApp.test.tsx
+++ b/core/__tests__/SharedWalkthroughApp.test.tsx
@@ -178,156 +178,143 @@ test('shared walkthroughs switch between walkthrough and tree review modes', asy
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(
-        <ReviewSurface
-          commenting={commenting}
-          onDeleteShare={onDeleteShare}
-          providerLabel="GitLab"
-          repositoryUrl="/cloudflare/voidzero/codiff-web"
-          snapshot={snapshot}
-          title="Review shared walkthrough"
-        />,
-      );
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.walkthrough-list')).not.toBeNull();
-    });
-
-    const searchInput = container.querySelector<HTMLInputElement>('.sidebar-search');
-    expect(searchInput).not.toBeNull();
-    const deleteShare = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Delete shared walkthrough"]',
-    );
-    expect(deleteShare?.closest('.review-top-bar-actions')).not.toBeNull();
-    await act(async () => deleteShare?.click());
-    expect(confirmDelete).toHaveBeenCalledWith(
-      'Delete this shared walkthrough? This cannot be undone.',
-    );
-    expect(onDeleteShare).not.toHaveBeenCalled();
-    confirmDelete.mockReturnValue(true);
-    await act(async () => deleteShare?.click());
-    await waitFor(() => expect(onDeleteShare).toHaveBeenCalledOnce());
-    expect(searchInput?.placeholder).toBe('Filter files');
-    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
-
-    const tablist = container.querySelector('[role="tablist"]');
-    expect(tablist?.classList.contains('review-mode-control')).toBe(true);
-    const topBar = tablist?.closest('.review-top-bar');
-    expect(topBar).not.toBeNull();
-    expect(topBar?.textContent).not.toContain('Review shared walkthrough');
-    expect(topBar?.textContent).not.toContain('·');
-    const repositoryLink = container.querySelector<HTMLAnchorElement>('.review-top-bar-repository');
-    expect(repositoryLink?.getAttribute('href')).toBe('/cloudflare/voidzero/codiff-web');
-    expect(repositoryLink?.textContent).toContain('cloudflare/voidzero/codiff-web');
-    expect(repositoryLink?.closest('.review-top-bar-left')).not.toBeNull();
-    const branchBadge = container.querySelector<HTMLElement>('.review-top-bar-branch');
-    expect(branchBadge?.textContent).toBe('main');
-    expect(branchBadge?.closest('.review-top-bar-right')).not.toBeNull();
-    expect(topBar?.textContent).not.toContain('(main)');
-    const sourceLink = container.querySelector<HTMLAnchorElement>('.review-top-bar-source');
-    expect(sourceLink?.getAttribute('href')).toBe(
-      'https://gitlab.example.com/cloudflare/voidzero/codiff-web/-/merge_requests/31',
-    );
-    expect(sourceLink?.textContent).toBe('MR #31');
-    expect(sourceLink?.querySelector('svg')).not.toBeNull();
-    expect(sourceLink?.closest('.review-top-bar-right')).not.toBeNull();
-    expect(container.querySelector('.review-top-bar-actions a')).toBeNull();
-    expect(deleteShare?.closest('.review-top-bar-right')).not.toBeNull();
-    const tabs = tablist?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [];
-    expect(tabs).toHaveLength(3);
-    expect(tabs[0]?.textContent).toBe('Walkthrough');
-    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
-    expect(tabs[1]?.textContent).toBe('Tree');
-    expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');
-    expect(tabs[2]?.textContent).toBe('Comments');
-
-    await act(async () => {
-      tabs[1]?.click();
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.file-tree-shell')).not.toBeNull();
-      expect(container.querySelector('.walkthrough-list')).toBeNull();
-    });
-    expect(container.querySelector('.codiff-markdown-preview')).toBeNull();
-    expect(
-      [...container.querySelectorAll<HTMLButtonElement>('button')].some(
-        ({ textContent }) => textContent === 'View as Markdown',
-      ),
-    ).toBe(true);
-    expect(tabs[0]?.getAttribute('aria-selected')).toBe('false');
-    expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
-
-    const sidebarToggle = container.querySelector<HTMLButtonElement>(
-      '.review-top-bar .sidebar-toggle-button',
-    );
-    expect(sidebarToggle?.getAttribute('aria-label')).toBe('Collapse sidebar');
-    await act(async () => {
-      window.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          bubbles: true,
-          ctrlKey: !navigator.platform.toLowerCase().includes('mac'),
-          key: 'b',
-          metaKey: navigator.platform.toLowerCase().includes('mac'),
-          shiftKey: true,
-        }),
-      );
-    });
-    expect(container.querySelector('.app-shell')?.classList.contains('sidebar-collapsed')).toBe(
-      true,
-    );
-    expect(container.querySelector('.review-top-bar')).not.toBeNull();
-    expect(sidebarToggle?.getAttribute('aria-label')).toBe('Expand sidebar');
-    await act(async () => sidebarToggle?.click());
-    expect(container.querySelector('.app-shell')?.classList.contains('sidebar-collapsed')).toBe(
-      false,
-    );
-
-    await act(async () => {
-      if (!searchInput) {
-        return;
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
       }
-      setInputValue?.call(searchInput, 'does-not-exist');
-      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.empty-panel')?.textContent).toContain('No matching files');
-      expect(container.querySelector('.empty-panel')?.textContent).toContain('does-not-exist');
-    });
-
-    await act(async () => {
-      if (!searchInput) {
-        return;
-      }
-      setInputValue?.call(searchInput, 'readme');
-      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.empty-panel')).toBeNull();
-      expect(container.textContent).toContain('README.md');
-      expect(container.textContent).not.toContain('src/app.ts');
-    });
-
-    await act(async () => {
-      tabs[0]?.click();
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.walkthrough-list')).not.toBeNull();
-      expect(container.querySelector('.file-tree-shell')).toBeNull();
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <ReviewSurface
+        commenting={commenting}
+        onDeleteShare={onDeleteShare}
+        providerLabel="GitLab"
+        repositoryUrl="/cloudflare/voidzero/codiff-web"
+        snapshot={snapshot}
+        title="Review shared walkthrough"
+      />,
+    );
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.walkthrough-list')).not.toBeNull();
+  });
+  const searchInput = container.querySelector<HTMLInputElement>('.sidebar-search');
+  expect(searchInput).not.toBeNull();
+  const deleteShare = container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Delete shared walkthrough"]',
+  );
+  expect(deleteShare?.closest('.review-top-bar-actions')).not.toBeNull();
+  await act(async () => deleteShare?.click());
+  expect(confirmDelete).toHaveBeenCalledWith(
+    'Delete this shared walkthrough? This cannot be undone.',
+  );
+  expect(onDeleteShare).not.toHaveBeenCalled();
+  confirmDelete.mockReturnValue(true);
+  await act(async () => deleteShare?.click());
+  await waitFor(() => expect(onDeleteShare).toHaveBeenCalledOnce());
+  expect(searchInput?.placeholder).toBe('Filter files');
+  const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  const tablist = container.querySelector('[role="tablist"]');
+  expect(tablist?.classList.contains('review-mode-control')).toBe(true);
+  const topBar = tablist?.closest('.review-top-bar');
+  expect(topBar).not.toBeNull();
+  expect(topBar?.textContent).not.toContain('Review shared walkthrough');
+  expect(topBar?.textContent).not.toContain('·');
+  const repositoryLink = container.querySelector<HTMLAnchorElement>('.review-top-bar-repository');
+  expect(repositoryLink?.getAttribute('href')).toBe('/cloudflare/voidzero/codiff-web');
+  expect(repositoryLink?.textContent).toContain('cloudflare/voidzero/codiff-web');
+  expect(repositoryLink?.closest('.review-top-bar-left')).not.toBeNull();
+  const branchBadge = container.querySelector<HTMLElement>('.review-top-bar-branch');
+  expect(branchBadge?.textContent).toBe('main');
+  expect(branchBadge?.closest('.review-top-bar-right')).not.toBeNull();
+  expect(topBar?.textContent).not.toContain('(main)');
+  const sourceLink = container.querySelector<HTMLAnchorElement>('.review-top-bar-source');
+  expect(sourceLink?.getAttribute('href')).toBe(
+    'https://gitlab.example.com/cloudflare/voidzero/codiff-web/-/merge_requests/31',
+  );
+  expect(sourceLink?.textContent).toBe('MR #31');
+  expect(sourceLink?.querySelector('svg')).not.toBeNull();
+  expect(sourceLink?.closest('.review-top-bar-right')).not.toBeNull();
+  expect(container.querySelector('.review-top-bar-actions a')).toBeNull();
+  expect(deleteShare?.closest('.review-top-bar-right')).not.toBeNull();
+  const tabs = tablist?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [];
+  expect(tabs).toHaveLength(3);
+  expect(tabs[0]?.textContent).toBe('Walkthrough');
+  expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+  expect(tabs[1]?.textContent).toBe('Tree');
+  expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');
+  expect(tabs[2]?.textContent).toBe('Comments');
+  await act(async () => {
+    tabs[1]?.click();
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.file-tree-shell')).not.toBeNull();
+    expect(container.querySelector('.walkthrough-list')).toBeNull();
+  });
+  expect(container.querySelector('.codiff-markdown-preview')).toBeNull();
+  expect(
+    [...container.querySelectorAll<HTMLButtonElement>('button')].some(
+      ({ textContent }) => textContent === 'View as Markdown',
+    ),
+  ).toBe(true);
+  expect(tabs[0]?.getAttribute('aria-selected')).toBe('false');
+  expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
+  const sidebarToggle = container.querySelector<HTMLButtonElement>(
+    '.review-top-bar .sidebar-toggle-button',
+  );
+  expect(sidebarToggle?.getAttribute('aria-label')).toBe('Collapse sidebar');
+  await act(async () => {
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        bubbles: true,
+        ctrlKey: !navigator.platform.toLowerCase().includes('mac'),
+        key: 'b',
+        metaKey: navigator.platform.toLowerCase().includes('mac'),
+        shiftKey: true,
+      }),
+    );
+  });
+  expect(container.querySelector('.app-shell')?.classList.contains('sidebar-collapsed')).toBe(true);
+  expect(container.querySelector('.review-top-bar')).not.toBeNull();
+  expect(sidebarToggle?.getAttribute('aria-label')).toBe('Expand sidebar');
+  await act(async () => sidebarToggle?.click());
+  expect(container.querySelector('.app-shell')?.classList.contains('sidebar-collapsed')).toBe(
+    false,
+  );
+  await act(async () => {
+    if (!searchInput) {
+      return;
     }
-    container.remove();
-  }
+    setInputValue?.call(searchInput, 'does-not-exist');
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.empty-panel')?.textContent).toContain('No matching files');
+    expect(container.querySelector('.empty-panel')?.textContent).toContain('does-not-exist');
+  });
+  await act(async () => {
+    if (!searchInput) {
+      return;
+    }
+    setInputValue?.call(searchInput, 'readme');
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.empty-panel')).toBeNull();
+    expect(container.textContent).toContain('README.md');
+    expect(container.textContent).not.toContain('src/app.ts');
+  });
+  await act(async () => {
+    tabs[0]?.click();
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.walkthrough-list')).not.toBeNull();
+    expect(container.querySelector('.file-tree-shell')).toBeNull();
+  });
 });
 
 test('shared walkthroughs initially preview Markdown when other files are generated', async () => {
@@ -375,53 +362,46 @@ test('shared walkthroughs initially preview Markdown when other files are genera
   document.body.append(container);
   let root: Root | null = null;
 
-  try {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<ReviewSurface snapshot={snapshot} />);
-    });
-
-    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    await act(async () => {
-      tabs[1]?.click();
-    });
-
-    await waitFor(() => {
-      const preview = container.querySelector('.codiff-markdown-preview');
-      expect(preview).not.toBeNull();
-      expect(preview?.textContent).toContain('Shared Markdown');
-      expect(preview?.textContent).toContain('Rendered in the shared walkthrough.');
-    });
-
-    const diffButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
-      ({ textContent }) => textContent === 'View as Diff',
-    );
-    expect(diffButton).not.toBeUndefined();
-
-    await act(async () => {
-      diffButton?.click();
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.codiff-markdown-preview')).toBeNull();
-    });
-
-    const markdownButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
-      ({ textContent }) => textContent === 'View as Markdown',
-    );
-    expect(markdownButton).not.toBeUndefined();
-
-    await act(async () => {
-      markdownButton?.click();
-    });
-
-    await waitFor(() => {
-      expect(container.querySelector('.codiff-markdown-preview')).not.toBeNull();
-    });
-  } finally {
-    if (root) {
-      await act(async () => root?.unmount());
-    }
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<ReviewSurface snapshot={snapshot} />);
+  });
+  const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+  await act(async () => {
+    tabs[1]?.click();
+  });
+  await waitFor(() => {
+    const preview = container.querySelector('.codiff-markdown-preview');
+    expect(preview).not.toBeNull();
+    expect(preview?.textContent).toContain('Shared Markdown');
+    expect(preview?.textContent).toContain('Rendered in the shared walkthrough.');
+  });
+  const diffButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+    ({ textContent }) => textContent === 'View as Diff',
+  );
+  expect(diffButton).not.toBeUndefined();
+  await act(async () => {
+    diffButton?.click();
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.codiff-markdown-preview')).toBeNull();
+  });
+  const markdownButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+    ({ textContent }) => textContent === 'View as Markdown',
+  );
+  expect(markdownButton).not.toBeUndefined();
+  await act(async () => {
+    markdownButton?.click();
+  });
+  await waitFor(() => {
+    expect(container.querySelector('.codiff-markdown-preview')).not.toBeNull();
+  });
 });

--- a/core/__tests__/WalkthroughProgress.test.tsx
+++ b/core/__tests__/WalkthroughProgress.test.tsx
@@ -35,62 +35,56 @@ test('reserves timer space, reveals 3s without shifting, and resets for each sta
   document.body.append(container);
   let root: Root | null = createRoot(container);
 
-  try {
-    await act(async () => {
-      root?.render(<WalkthroughProgress phase={null} responseLabelIndex={0} stageRevision={0} />);
-    });
-
-    const timer = () => container.querySelector<HTMLElement>('.walkthrough-progress-timer');
-    expect(container.textContent).toContain('Generating walkthrough…');
-    expect(timer()?.textContent).toBe('0s');
-    expect(timer()?.classList.contains('visible')).toBe(false);
-
-    await act(async () => {
-      vi.advanceTimersByTime(3000);
-    });
-    expect(timer()?.textContent).toBe('3s');
-    expect(timer()?.classList.contains('visible')).toBe(true);
-
-    await act(async () => {
-      root?.render(
-        <WalkthroughProgress phase="agent-generation" responseLabelIndex={0} stageRevision={1} />,
-      );
-    });
-    expect(container.textContent).toContain('Analyzing changes…');
-    expect(timer()?.textContent).toBe('0s');
-    expect(timer()?.classList.contains('visible')).toBe(false);
-
-    await act(async () => {
-      vi.advanceTimersByTime(3000);
-    });
-    expect(timer()?.textContent).toBe('3s');
-
-    await act(async () => {
-      root?.render(
-        <WalkthroughProgress phase="agent-generation" responseLabelIndex={0} stageRevision={1} />,
-      );
-    });
-    expect(container.textContent).toContain('Analyzing changes…');
-    expect(timer()?.textContent).toBe('3s');
-    expect(timer()?.classList.contains('visible')).toBe(true);
-
-    await act(async () => {
-      root?.render(
-        <WalkthroughProgress phase="response-received" responseLabelIndex={4} stageRevision={2} />,
-      );
-    });
-    expect(container.textContent).toContain('Creating walkthrough…');
-    expect(timer()?.textContent).toBe('0s');
-    expect(timer()?.classList.contains('visible')).toBe(false);
-
-    await act(async () => {
-      vi.advanceTimersByTime(3000);
-    });
-    expect(timer()?.textContent).toBe('3s');
-    expect(timer()?.classList.contains('visible')).toBe(true);
-  } finally {
-    await act(async () => root?.unmount());
-    root = null;
-    container.remove();
-  }
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      await act(async () => root?.unmount());
+      root = null;
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root?.render(<WalkthroughProgress phase={null} responseLabelIndex={0} stageRevision={0} />);
+  });
+  const timer = () => container.querySelector<HTMLElement>('.walkthrough-progress-timer');
+  expect(container.textContent).toContain('Generating walkthrough…');
+  expect(timer()?.textContent).toBe('0s');
+  expect(timer()?.classList.contains('visible')).toBe(false);
+  await act(async () => {
+    vi.advanceTimersByTime(3000);
+  });
+  expect(timer()?.textContent).toBe('3s');
+  expect(timer()?.classList.contains('visible')).toBe(true);
+  await act(async () => {
+    root?.render(
+      <WalkthroughProgress phase="agent-generation" responseLabelIndex={0} stageRevision={1} />,
+    );
+  });
+  expect(container.textContent).toContain('Analyzing changes…');
+  expect(timer()?.textContent).toBe('0s');
+  expect(timer()?.classList.contains('visible')).toBe(false);
+  await act(async () => {
+    vi.advanceTimersByTime(3000);
+  });
+  expect(timer()?.textContent).toBe('3s');
+  await act(async () => {
+    root?.render(
+      <WalkthroughProgress phase="agent-generation" responseLabelIndex={0} stageRevision={1} />,
+    );
+  });
+  expect(container.textContent).toContain('Analyzing changes…');
+  expect(timer()?.textContent).toBe('3s');
+  expect(timer()?.classList.contains('visible')).toBe(true);
+  await act(async () => {
+    root?.render(
+      <WalkthroughProgress phase="response-received" responseLabelIndex={4} stageRevision={2} />,
+    );
+  });
+  expect(container.textContent).toContain('Creating walkthrough…');
+  expect(timer()?.textContent).toBe('0s');
+  expect(timer()?.classList.contains('visible')).toBe(false);
+  await act(async () => {
+    vi.advanceTimersByTime(3000);
+  });
+  expect(timer()?.textContent).toBe('3s');
+  expect(timer()?.classList.contains('visible')).toBe(true);
 });

--- a/core/__tests__/app-command-hooks.test.tsx
+++ b/core/__tests__/app-command-hooks.test.tsx
@@ -74,7 +74,7 @@ test('app commands register the complete command set and delegate dynamic action
   const onToggleViewed = vi.fn();
   const onToggleWordWrap = vi.fn();
   let commands: ReturnType<typeof useAppCommands> = [];
-  const view = await renderReact(
+  await using _view = await renderReact(
     <AppCommandsHarness
       onCommands={(nextCommands) => (commands = nextCommands)}
       options={{
@@ -95,61 +95,53 @@ test('app commands register the complete command set and delegate dynamic action
     />,
   );
 
-  try {
-    expect(commands.map((command) => command.id)).toEqual([
-      'file-filter',
-      'diff-search',
-      'sidebar-tree',
-      'sidebar-history',
-      'sidebar-walkthrough',
-      'copy-comments',
-      'copy-comments-and-close',
-      'toggle-viewed',
-      'open-file',
-      'toggle-sidebar',
-      'toggle-outdated-comments',
-      'toggle-diff-layout',
-      'toggle-word-wrap',
-      'increase-code-font-size',
-      'decrease-code-font-size',
-      'reset-code-font-size',
-      'open-config-file',
-      'reload',
-    ]);
-
-    const command = (id: string) => {
-      const match = commands.find((candidate) => candidate.id === id);
-      if (!match) {
-        throw new Error(`Missing command: ${id}`);
-      }
-      return match;
-    };
-
-    command('file-filter').execute();
-    command('diff-search').execute();
-    command('sidebar-history').execute();
-    command('open-file').execute();
-    command('toggle-sidebar').execute();
-    command('toggle-word-wrap').execute();
-    command('reload').execute();
-    command('toggle-viewed').execute();
-
-    expect(focusFileFilter).toHaveBeenCalledOnce();
-    expect(onOpenDiffSearch).toHaveBeenCalledOnce();
-    expect(changeSidebarMode).toHaveBeenCalledWith('history');
-    expect(onOpenSelectedFile).toHaveBeenCalledOnce();
-    expect(onToggleSidebar).toHaveBeenCalledOnce();
-    expect(onToggleWordWrap).toHaveBeenCalledOnce();
-    expect(onRefreshRepository).toHaveBeenCalledOnce();
-    expect(command('open-file').description?.()).toBe(file.path);
-    expect(onToggleViewed).toHaveBeenCalledWith(file, true, target.reviewIdentity);
-
-    expect(command('toggle-word-wrap').description?.()).toBe('Enable Word Wrap');
-    preferencesRef.current.wordWrap = true;
-    expect(command('toggle-word-wrap').description?.()).toBe('Disable Word Wrap');
-  } finally {
-    await view.cleanup();
-  }
+  expect(commands.map((command) => command.id)).toEqual([
+    'file-filter',
+    'diff-search',
+    'sidebar-tree',
+    'sidebar-history',
+    'sidebar-walkthrough',
+    'copy-comments',
+    'copy-comments-and-close',
+    'toggle-viewed',
+    'open-file',
+    'toggle-sidebar',
+    'toggle-outdated-comments',
+    'toggle-diff-layout',
+    'toggle-word-wrap',
+    'increase-code-font-size',
+    'decrease-code-font-size',
+    'reset-code-font-size',
+    'open-config-file',
+    'reload',
+  ]);
+  const command = (id: string) => {
+    const match = commands.find((candidate) => candidate.id === id);
+    if (!match) {
+      throw new Error(`Missing command: ${id}`);
+    }
+    return match;
+  };
+  command('file-filter').execute();
+  command('diff-search').execute();
+  command('sidebar-history').execute();
+  command('open-file').execute();
+  command('toggle-sidebar').execute();
+  command('toggle-word-wrap').execute();
+  command('reload').execute();
+  command('toggle-viewed').execute();
+  expect(focusFileFilter).toHaveBeenCalledOnce();
+  expect(onOpenDiffSearch).toHaveBeenCalledOnce();
+  expect(changeSidebarMode).toHaveBeenCalledWith('history');
+  expect(onOpenSelectedFile).toHaveBeenCalledOnce();
+  expect(onToggleSidebar).toHaveBeenCalledOnce();
+  expect(onToggleWordWrap).toHaveBeenCalledOnce();
+  expect(onRefreshRepository).toHaveBeenCalledOnce();
+  expect(command('open-file').description?.()).toBe(file.path);
+  expect(onToggleViewed).toHaveBeenCalledWith(file, true, target.reviewIdentity);
+  expect(command('toggle-word-wrap').description?.()).toBe('Enable Word Wrap');
+  preferencesRef.current.wordWrap = true;
+  expect(command('toggle-word-wrap').description?.()).toBe('Disable Word Wrap');
 });
 
 const keyboardKeymap = {
@@ -192,7 +184,7 @@ test('app keyboard shortcuts route commands and respect native input and walkthr
     }
     return state;
   };
-  const view = await renderReact(
+  await using _view = await renderReact(
     <AppKeyboardShortcutsHarness
       onState={(nextState) => (state = nextState)}
       options={{
@@ -209,49 +201,41 @@ test('app keyboard shortcuts route commands and respect native input and walkthr
     />,
   );
 
-  try {
-    await act(async () => {
-      expect(dispatchKey('keydown', 'c').defaultPrevented).toBe(true);
-    });
-    expect(getState().commandBarVisible).toBe(true);
-
-    await act(async () => {
-      getState().closeCommandBar();
-      dispatchKey('keydown', 'b');
-      dispatchKey('keydown', 'f');
-      dispatchKey('keydown', 'o');
-      dispatchKey('keydown', 'l');
-      dispatchKey('keydown', 'n');
-    });
-    expect(getState().commandBarVisible).toBe(false);
-    expect(onToggleSidebar).toHaveBeenCalledOnce();
-    expect(onOpenDiffSearch).toHaveBeenCalledOnce();
-    expect(onOpenSelectedFile).toHaveBeenCalledOnce();
-    expect(onFocusFileFilter).toHaveBeenCalledOnce();
-    expect(navigateHunks).not.toHaveBeenCalled();
-
-    deferHunkNavigation = false;
-    await act(async () => {
-      dispatchKey('keydown', 'n');
-      dispatchKey('keydown', 'p');
-    });
-    expect(navigateHunks.mock.calls).toEqual([[1], [-1]]);
-
-    const input = document.createElement('input');
-    document.body.append(input);
-    await act(async () => {
-      dispatchKey('keydown', 'z', input);
-    });
-    expect(onToggleWordWrap).not.toHaveBeenCalled();
-
-    await act(async () => {
-      dispatchKey('keydown', 'z');
-    });
-    expect(onToggleWordWrap).toHaveBeenCalledOnce();
-    input.remove();
-  } finally {
-    await view.cleanup();
-  }
+  await act(async () => {
+    expect(dispatchKey('keydown', 'c').defaultPrevented).toBe(true);
+  });
+  expect(getState().commandBarVisible).toBe(true);
+  await act(async () => {
+    getState().closeCommandBar();
+    dispatchKey('keydown', 'b');
+    dispatchKey('keydown', 'f');
+    dispatchKey('keydown', 'o');
+    dispatchKey('keydown', 'l');
+    dispatchKey('keydown', 'n');
+  });
+  expect(getState().commandBarVisible).toBe(false);
+  expect(onToggleSidebar).toHaveBeenCalledOnce();
+  expect(onOpenDiffSearch).toHaveBeenCalledOnce();
+  expect(onOpenSelectedFile).toHaveBeenCalledOnce();
+  expect(onFocusFileFilter).toHaveBeenCalledOnce();
+  expect(navigateHunks).not.toHaveBeenCalled();
+  deferHunkNavigation = false;
+  await act(async () => {
+    dispatchKey('keydown', 'n');
+    dispatchKey('keydown', 'p');
+  });
+  expect(navigateHunks.mock.calls).toEqual([[1], [-1]]);
+  const input = document.createElement('input');
+  document.body.append(input);
+  await act(async () => {
+    dispatchKey('keydown', 'z', input);
+  });
+  expect(onToggleWordWrap).not.toHaveBeenCalled();
+  await act(async () => {
+    dispatchKey('keydown', 'z');
+  });
+  expect(onToggleWordWrap).toHaveBeenCalledOnce();
+  input.remove();
 });
 
 test('shortcut help remains visible only while its key chord is held', async () => {
@@ -262,7 +246,7 @@ test('shortcut help remains visible only while its key chord is held', async () 
     }
     return state;
   };
-  const view = await renderReact(
+  await using _view = await renderReact(
     <AppKeyboardShortcutsHarness
       onState={(nextState) => (state = nextState)}
       options={{
@@ -279,23 +263,17 @@ test('shortcut help remains visible only while its key chord is held', async () 
     />,
   );
 
-  try {
-    await act(async () => {
-      dispatchKey('keydown', '?');
-    });
-    expect(getState().shortcutsHelpVisible).toBe(true);
-
-    await act(async () => {
-      dispatchKey('keyup', '?');
-    });
-    expect(getState().shortcutsHelpVisible).toBe(false);
-
-    await act(async () => {
-      dispatchKey('keydown', '?');
-      window.dispatchEvent(new Event('blur'));
-    });
-    expect(getState().shortcutsHelpVisible).toBe(false);
-  } finally {
-    await view.cleanup();
-  }
+  await act(async () => {
+    dispatchKey('keydown', '?');
+  });
+  expect(getState().shortcutsHelpVisible).toBe(true);
+  await act(async () => {
+    dispatchKey('keyup', '?');
+  });
+  expect(getState().shortcutsHelpVisible).toBe(false);
+  await act(async () => {
+    dispatchKey('keydown', '?');
+    window.dispatchEvent(new Event('blur'));
+  });
+  expect(getState().shortcutsHelpVisible).toBe(false);
 });

--- a/core/__tests__/app-review-comment-hooks.test.tsx
+++ b/core/__tests__/app-review-comment-hooks.test.tsx
@@ -62,20 +62,22 @@ function AppReviewCommentsHarness({
 const renderAppReviewComments = async (state: RepositoryState) => {
   const onCommentFileChange = vi.fn();
   const stateRef: { current: AppReviewComments | null } = { current: null };
-  const view = await renderReact(
-    <AppReviewCommentsHarness
-      onCommentFileChange={onCommentFileChange}
-      onState={(comments) => (stateRef.current = comments)}
-      state={state}
-    />,
-  );
   const getState = () => {
     if (!stateRef.current) {
       throw new Error('App review comments did not render.');
     }
     return stateRef.current;
   };
-  return { getState, onCommentFileChange, view };
+  return Object.assign(
+    await renderReact(
+      <AppReviewCommentsHarness
+        onCommentFileChange={onCommentFileChange}
+        onState={(comments) => (stateRef.current = comments)}
+        state={state}
+      />,
+    ),
+    { getState, onCommentFileChange },
+  );
 };
 
 afterEach(() => {
@@ -88,36 +90,32 @@ test('app review comments request and store assistant replies', async () => {
     status: 'ready' as const,
   }));
   window.codiff = { askReviewAssistant } as unknown as Window['codiff'];
-  const { getState, onCommentFileChange, view } = await renderAppReviewComments(workingTreeState);
+  await using view = await renderAppReviewComments(workingTreeState);
+  const { getState, onCommentFileChange } = view;
 
-  try {
-    await act(async () => {
-      getState().setReviewComments([comment]);
+  await act(async () => {
+    getState().setReviewComments([comment]);
+  });
+  await act(async () => {
+    getState().askCodex(comment.id);
+  });
+  expect(askReviewAssistant).toHaveBeenCalledWith({
+    comment: {
+      body: comment.body,
+      filePath: comment.filePath,
+      lineNumber: comment.lineNumber,
+      sectionId: comment.sectionId,
+      side: comment.side,
+    },
+    source: workingTreeState.source,
+  });
+  await waitFor(() => {
+    expect(getState().reviewComments[0]?.codexReply).toEqual({
+      body: 'Use the shared parser.',
+      status: 'ready',
     });
-    await act(async () => {
-      getState().askCodex(comment.id);
-    });
-
-    expect(askReviewAssistant).toHaveBeenCalledWith({
-      comment: {
-        body: comment.body,
-        filePath: comment.filePath,
-        lineNumber: comment.lineNumber,
-        sectionId: comment.sectionId,
-        side: comment.side,
-      },
-      source: workingTreeState.source,
-    });
-    await waitFor(() => {
-      expect(getState().reviewComments[0]?.codexReply).toEqual({
-        body: 'Use the shared parser.',
-        status: 'ready',
-      });
-    });
-    expect(onCommentFileChange).toHaveBeenCalledTimes(2);
-  } finally {
-    await view.cleanup();
-  }
+  });
+  expect(onCommentFileChange).toHaveBeenCalledTimes(2);
 });
 
 test('app review comments submit a draft and replace it with the remote comment', async () => {
@@ -135,78 +133,70 @@ test('app review comments submit a draft and replace it with the remote comment'
     url: 'https://github.com/nkzw-tech/codiff/pull/42#discussion_r1',
   }));
   window.codiff = { submitPullRequestComment } as unknown as Window['codiff'];
-  const { getState, onCommentFileChange, view } = await renderAppReviewComments(pullRequestState);
+  await using view = await renderAppReviewComments(pullRequestState);
+  const { getState, onCommentFileChange } = view;
 
-  try {
-    await act(async () => {
-      getState().setReviewComments([comment]);
-    });
-    await act(async () => {
-      getState().submitPullRequestComment(comment.id);
-    });
-
-    expect(submitPullRequestComment).toHaveBeenCalledWith({
-      comment: {
+  await act(async () => {
+    getState().setReviewComments([comment]);
+  });
+  await act(async () => {
+    getState().submitPullRequestComment(comment.id);
+  });
+  expect(submitPullRequestComment).toHaveBeenCalledWith({
+    comment: {
+      body: comment.body,
+      filePath: comment.filePath,
+      lineNumber: comment.lineNumber,
+      side: comment.side,
+    },
+    source: pullRequestState.source,
+  });
+  await waitFor(() => {
+    expect(getState().reviewComments).toEqual([
+      {
+        author: {
+          login: 'reviewer',
+          name: 'Reviewer',
+        },
         body: comment.body,
         filePath: comment.filePath,
+        id: 'remote-comment',
+        isReadOnly: true,
         lineNumber: comment.lineNumber,
+        sectionId: comment.sectionId,
         side: comment.side,
+        submittedAt: '2026-07-15T00:00:00.000Z',
+        url: 'https://github.com/nkzw-tech/codiff/pull/42#discussion_r1',
       },
-      source: pullRequestState.source,
-    });
-    await waitFor(() => {
-      expect(getState().reviewComments).toEqual([
-        {
-          author: {
-            login: 'reviewer',
-            name: 'Reviewer',
-          },
-          body: comment.body,
-          filePath: comment.filePath,
-          id: 'remote-comment',
-          isReadOnly: true,
-          lineNumber: comment.lineNumber,
-          sectionId: comment.sectionId,
-          side: comment.side,
-          submittedAt: '2026-07-15T00:00:00.000Z',
-          url: 'https://github.com/nkzw-tech/codiff/pull/42#discussion_r1',
-        },
-      ]);
-    });
-    expect(onCommentFileChange).toHaveBeenCalledTimes(2);
-  } finally {
-    await view.cleanup();
-  }
+    ]);
+  });
+  expect(onCommentFileChange).toHaveBeenCalledTimes(2);
 });
 
 test('app review comments submit and clear pending review drafts', async () => {
   const submitPullRequestReview = vi.fn(async () => {});
   window.codiff = { submitPullRequestReview } as unknown as Window['codiff'];
-  const { getState, view } = await renderAppReviewComments(pullRequestState);
+  await using view = await renderAppReviewComments(pullRequestState);
+  const { getState } = view;
 
-  try {
-    await act(async () => {
-      getState().setReviewComments([comment]);
-    });
-    await act(async () => {
-      await getState().submitPullRequestReview('COMMENT');
-    });
-
-    expect(submitPullRequestReview).toHaveBeenCalledWith({
-      comments: [
-        {
-          body: comment.body,
-          filePath: comment.filePath,
-          lineNumber: comment.lineNumber,
-          side: comment.side,
-        },
-      ],
-      event: 'COMMENT',
-      source: pullRequestState.source,
-    });
-    expect(getState().reviewComments).toEqual([]);
-    expect(getState().pullRequestReviewSubmitting).toBeNull();
-  } finally {
-    await view.cleanup();
-  }
+  await act(async () => {
+    getState().setReviewComments([comment]);
+  });
+  await act(async () => {
+    await getState().submitPullRequestReview('COMMENT');
+  });
+  expect(submitPullRequestReview).toHaveBeenCalledWith({
+    comments: [
+      {
+        body: comment.body,
+        filePath: comment.filePath,
+        lineNumber: comment.lineNumber,
+        side: comment.side,
+      },
+    ],
+    event: 'COMMENT',
+    source: pullRequestState.source,
+  });
+  expect(getState().reviewComments).toEqual([]);
+  expect(getState().pullRequestReviewSubmitting).toBeNull();
 });

--- a/core/__tests__/app-review-comment-hooks.test.tsx
+++ b/core/__tests__/app-review-comment-hooks.test.tsx
@@ -68,16 +68,17 @@ const renderAppReviewComments = async (state: RepositoryState) => {
     }
     return stateRef.current;
   };
-  return Object.assign(
-    await renderReact(
+  return {
+    ...(await renderReact(
       <AppReviewCommentsHarness
         onCommentFileChange={onCommentFileChange}
         onState={(comments) => (stateRef.current = comments)}
         state={state}
       />,
-    ),
-    { getState, onCommentFileChange },
-  );
+    )),
+    getState,
+    onCommentFileChange,
+  };
 };
 
 afterEach(() => {

--- a/core/__tests__/codiff-cli.test.ts
+++ b/core/__tests__/codiff-cli.test.ts
@@ -64,7 +64,7 @@ afterAll(async () => {
 });
 
 const withCwd = async <T>(cwd: string, callback: () => T | Promise<T>) => {
-  await using _workingDirectory = createTemporaryWorkingDirectory(cwd);
+  using _workingDirectory = createTemporaryWorkingDirectory(cwd);
   return await callback();
 };
 

--- a/core/__tests__/codiff-cli.test.ts
+++ b/core/__tests__/codiff-cli.test.ts
@@ -24,6 +24,11 @@ import type { PlanReview } from '../types.ts';
 import { createFakeCommandLogger, createFakeOpenLogger } from './helpers/cli.ts';
 import { removeGitTestDirectory } from './helpers/git.ts';
 import { getGitTestEnvironment } from './helpers/git.ts';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+  createTemporaryWorkingDirectory,
+} from './helpers/resources.ts';
 
 const execFileAsync = promisify(execFile);
 
@@ -59,50 +64,29 @@ afterAll(async () => {
 });
 
 const withCwd = async <T>(cwd: string, callback: () => T | Promise<T>) => {
-  const previousCwd = process.cwd();
-  try {
-    process.chdir(cwd);
-    return await callback();
-  } finally {
-    process.chdir(previousCwd);
-  }
+  await using _workingDirectory = createTemporaryWorkingDirectory(cwd);
+  return await callback();
 };
 
 const withFakeGitHubCli = async <T>(
   response: Record<string, unknown>,
   callback: (argsPath: string) => T | Promise<T>,
 ) => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-cli-gh-'));
-  const argsPath = join(directory, 'args.txt');
-  const commandPath = join(directory, 'gh');
-  const previousArgsPath = process.env.CODIFF_TEST_GH_ARGS;
-  const previousPath = process.env.PATH;
-  const previousResponse = process.env.CODIFF_TEST_GH_RESPONSE;
+  await using directory = await createTemporaryDirectory('codiff-cli-gh-');
+  const argsPath = join(directory.path, 'args.txt');
+  const commandPath = join(directory.path, 'gh');
 
-  try {
-    await writeFile(
-      commandPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$CODIFF_TEST_GH_ARGS"\ndone\nprintf "%s\\n" "$CODIFF_TEST_GH_RESPONSE"\n',
-    );
-    await chmod(commandPath, 0o755);
-    process.env.CODIFF_TEST_GH_ARGS = argsPath;
-    process.env.CODIFF_TEST_GH_RESPONSE = JSON.stringify(response);
-    process.env.PATH = `${directory}:${previousPath ?? ''}`;
-    return await callback(argsPath);
-  } finally {
-    if (previousArgsPath == null) {
-      delete process.env.CODIFF_TEST_GH_ARGS;
-    } else {
-      process.env.CODIFF_TEST_GH_ARGS = previousArgsPath;
-    }
-    if (previousResponse == null) {
-      delete process.env.CODIFF_TEST_GH_RESPONSE;
-    } else {
-      process.env.CODIFF_TEST_GH_RESPONSE = previousResponse;
-    }
-    process.env.PATH = previousPath;
-    await removeGitTestDirectory(directory);
-  }
+  await writeFile(
+    commandPath,
+    '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$CODIFF_TEST_GH_ARGS"\ndone\nprintf "%s\\n" "$CODIFF_TEST_GH_RESPONSE"\n',
+  );
+  await chmod(commandPath, 0o755);
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_TEST_GH_ARGS: argsPath,
+    CODIFF_TEST_GH_RESPONSE: JSON.stringify(response),
+    PATH: `${directory.path}:${process.env.PATH ?? ''}`,
+  });
+  return await callback(argsPath);
 };
 
 test('parseArguments treats a hash positional as a commit ref', () => {
@@ -203,55 +187,47 @@ test('parseArguments treats hex-like refs as commits before branches', async () 
 });
 
 test('parseArguments keeps existing hash-like paths as repository paths', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-cli-'));
-  const repositoryPath = join(directory, 'deadbeef');
+  await using directory = await createTemporaryDirectory('codiff-cli-');
+  const repositoryPath = join(directory.path, 'deadbeef');
 
-  try {
-    await mkdir(repositoryPath);
+  await mkdir(repositoryPath);
 
-    expect(parseArguments([repositoryPath])).toEqual({
-      commitRef: null,
-      help: false,
-      pullRequestNumber: null,
-      pullRequestUrl: null,
-      requestedPath: repositoryPath,
-      version: false,
-      walkthrough: false,
-    });
-  } finally {
-    await removeGitTestDirectory(directory);
-  }
+  expect(parseArguments([repositoryPath])).toEqual({
+    commitRef: null,
+    help: false,
+    pullRequestNumber: null,
+    pullRequestUrl: null,
+    requestedPath: repositoryPath,
+    version: false,
+    walkthrough: false,
+  });
 });
 
 test.sequential('parseArguments does not inspect Git refs for plan working directories', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-arguments-'));
-  const fakeBin = join(directory, 'bin');
-  const gitMarker = join(directory, 'git-invoked');
-  const planFile = join(directory, 'plan.md');
-  const workspace = join(directory, 'workspace');
-  const previousPath = process.env.PATH;
+  await using directory = await createTemporaryDirectory('codiff-plan-arguments-');
+  const fakeBin = join(directory.path, 'bin');
+  const gitMarker = join(directory.path, 'git-invoked');
+  const planFile = join(directory.path, 'plan.md');
+  const workspace = join(directory.path, 'workspace');
 
-  try {
-    await mkdir(fakeBin);
-    await mkdir(workspace);
-    await writeFile(planFile, '# Plan\n');
-    await writeFile(join(fakeBin, 'git'), `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`);
-    await chmod(join(fakeBin, 'git'), 0o755);
-    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
-    const realWorkspace = await realpath(workspace);
+  await mkdir(fakeBin);
+  await mkdir(workspace);
+  await writeFile(planFile, '# Plan\n');
+  await writeFile(join(fakeBin, 'git'), `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`);
+  await chmod(join(fakeBin, 'git'), 0o755);
+  await using _environment = createTemporaryEnvironment({
+    PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+  });
+  const realWorkspace = await realpath(workspace);
 
-    await withCwd(directory, () => {
-      expect(parseArguments(['--plan', planFile, 'workspace'])).toMatchObject({
-        commitRef: null,
-        planFilePath: planFile,
-        requestedPath: realWorkspace,
-      });
+  await withCwd(directory.path, () => {
+    expect(parseArguments(['--plan', planFile, 'workspace'])).toMatchObject({
+      commitRef: null,
+      planFilePath: planFile,
+      requestedPath: realWorkspace,
     });
-    expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
-  } finally {
-    process.env.PATH = previousPath;
-    await removeGitTestDirectory(directory);
-  }
+  });
+  expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
 });
 
 test('parseArguments treats GitHub pull request URLs as review sources', () => {
@@ -421,39 +397,33 @@ test('parseArguments accepts nested GitLab merge request URLs', () => {
 });
 
 test('resolvePullRequestUrl builds GitHub PR URLs from the origin remote', async () => {
-  const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-cli-'));
+  await using directory = await createTemporaryDirectory('codiff-cli-');
+  const repositoryPath = directory.path;
 
-  try {
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['remote', 'add', 'upstream', 'https://github.com/other/repo.git']);
-    await git(repositoryPath, ['remote', 'add', 'origin', 'git@github.com:nkzw-tech/codiff.git']);
+  await git(repositoryPath, ['init']);
+  await git(repositoryPath, ['remote', 'add', 'upstream', 'https://github.com/other/repo.git']);
+  await git(repositoryPath, ['remote', 'add', 'origin', 'git@github.com:nkzw-tech/codiff.git']);
 
-    expect(resolvePullRequestUrl(repositoryPath, 75)).toBe(
-      'https://github.com/nkzw-tech/codiff/pull/75',
-    );
-  } finally {
-    await removeGitTestDirectory(repositoryPath);
-  }
+  expect(resolvePullRequestUrl(repositoryPath, 75)).toBe(
+    'https://github.com/nkzw-tech/codiff/pull/75',
+  );
 });
 
 test('resolvePullRequestUrl builds GitLab MR URLs from an arbitrary GitLab remote', async () => {
-  const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-cli-'));
+  await using directory = await createTemporaryDirectory('codiff-cli-');
+  const repositoryPath = directory.path;
 
-  try {
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, [
-      'remote',
-      'add',
-      'origin',
-      'git@gitlab.example.com:group/subgroup/project.git',
-    ]);
+  await git(repositoryPath, ['init']);
+  await git(repositoryPath, [
+    'remote',
+    'add',
+    'origin',
+    'git@gitlab.example.com:group/subgroup/project.git',
+  ]);
 
-    expect(resolvePullRequestUrl(repositoryPath, 23, 'gitlab')).toBe(
-      'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
-    );
-  } finally {
-    await removeGitTestDirectory(repositoryPath);
-  }
+  expect(resolvePullRequestUrl(repositoryPath, 23, 'gitlab')).toBe(
+    'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
+  );
 });
 
 test.sequential('PR branch lookup preserves the canonical GitHub URL returned by gh', async () => {
@@ -500,365 +470,320 @@ test.sequential('PR branch lookup rejects merged pull requests', async () => {
 });
 
 test('packaged terminal helper forwards --commit HEAD to Electron', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
   const repositoryPath = join(logger.directory, 'repo');
 
-  try {
-    await mkdir(repositoryPath);
+  await mkdir(repositoryPath);
 
-    await execFileAsync(resolve('bin/codiff-app'), ['--commit', 'HEAD', repositoryPath], {
-      env: logger.env,
-    });
+  await execFileAsync(resolve('bin/codiff-app'), ['--commit', 'HEAD', repositoryPath], {
+    env: logger.env,
+  });
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--commit',
-      'HEAD',
-      repositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--commit',
+    'HEAD',
+    repositoryPath,
+  ]);
 });
 
 test('packaged terminal helper resolves GitHub PR branches to canonical URLs', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
   const ghArgsPath = join(logger.directory, 'gh-args.txt');
   const ghPath = join(logger.directory, 'bin', 'gh');
   const repositoryPath = join(logger.directory, 'repo');
 
-  try {
-    await mkdir(repositoryPath);
-    await writeFile(
-      ghPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$GH_ARGS_FILE"\ndone\nprintf "%s\\n" "https://github.com/nkzw-tech/codiff/pull/129"\n',
-    );
-    await chmod(ghPath, 0o755);
+  await mkdir(repositoryPath);
+  await writeFile(
+    ghPath,
+    '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$GH_ARGS_FILE"\ndone\nprintf "%s\\n" "https://github.com/nkzw-tech/codiff/pull/129"\n',
+  );
+  await chmod(ghPath, 0o755);
 
-    await execFileAsync(
-      resolve('bin/codiff-app'),
-      ['pr', 'iminoso:feat/pr-branch-lookup', repositoryPath],
-      {
-        env: {
-          ...logger.env,
-          GH_ARGS_FILE: ghArgsPath,
-        },
+  await execFileAsync(
+    resolve('bin/codiff-app'),
+    ['pr', 'iminoso:feat/pr-branch-lookup', repositoryPath],
+    {
+      env: {
+        ...logger.env,
+        GH_ARGS_FILE: ghArgsPath,
       },
-    );
+    },
+  );
 
-    expect(await readFile(ghArgsPath, 'utf8')).toBe(
-      [
-        'pr',
-        'view',
-        'iminoso:feat/pr-branch-lookup',
-        '--json',
-        'state,url',
-        '--jq',
-        'select(.state == "OPEN") | .url',
-        '',
-      ].join('\n'),
-    );
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      'https://github.com/nkzw-tech/codiff/pull/129',
-      repositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await readFile(ghArgsPath, 'utf8')).toBe(
+    [
+      'pr',
+      'view',
+      'iminoso:feat/pr-branch-lookup',
+      '--json',
+      'state,url',
+      '--jq',
+      'select(.state == "OPEN") | .url',
+      '',
+    ].join('\n'),
+  );
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    'https://github.com/nkzw-tech/codiff/pull/129',
+    repositoryPath,
+  ]);
 });
 
 test('packaged terminal helper forwards GitLab MR markers to Electron', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
 
-  try {
-    await execFileAsync(resolve('bin/codiff-app'), ['mr', '23'], {
-      env: logger.env,
-    });
+  await execFileAsync(resolve('bin/codiff-app'), ['mr', '23'], {
+    env: logger.env,
+  });
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      'mr',
-      '23',
-      process.cwd(),
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    'mr',
+    '23',
+    process.cwd(),
+  ]);
 });
 
 test('packaged terminal helper forwards HEAD^1 to Electron as a commit', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
 
-  try {
-    await execFileAsync(resolve('bin/codiff-app'), ['HEAD^1'], {
-      env: logger.env,
-    });
+  await execFileAsync(resolve('bin/codiff-app'), ['HEAD^1'], {
+    env: logger.env,
+  });
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--commit',
-      'HEAD^1',
-      process.cwd(),
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--commit',
+    'HEAD^1',
+    process.cwd(),
+  ]);
 });
 
 test('packaged terminal helper forwards branch names to Electron as branches', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
 
-  try {
-    await execFileAsync(resolve('bin/codiff-app'), ['feature'], {
-      cwd: refRepositoryPath,
-      env: logger.env,
-    });
+  await execFileAsync(resolve('bin/codiff-app'), ['feature'], {
+    cwd: refRepositoryPath,
+    env: logger.env,
+  });
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--branch',
-      'feature',
-      refRepositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--branch',
+    'feature',
+    refRepositoryPath,
+  ]);
 });
 
 test('packaged terminal helper forwards missing branch names to Electron as branches', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
 
-  try {
-    await execFileAsync(resolve('bin/codiff-app'), ['definitely-missing-branch'], {
-      cwd: refRepositoryPath,
-      env: logger.env,
-    });
+  await execFileAsync(resolve('bin/codiff-app'), ['definitely-missing-branch'], {
+    cwd: refRepositoryPath,
+    env: logger.env,
+  });
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--branch',
-      'definitely-missing-branch',
-      refRepositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--branch',
+    'definitely-missing-branch',
+    refRepositoryPath,
+  ]);
 });
 
 test('packaged terminal helper forwards hex refs to Electron as commits', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
 
-  try {
-    await execFileAsync(resolve('bin/codiff-app'), [refRepositoryShortHash], {
-      cwd: refRepositoryPath,
-      env: logger.env,
-    });
+  await execFileAsync(resolve('bin/codiff-app'), [refRepositoryShortHash], {
+    cwd: refRepositoryPath,
+    env: logger.env,
+  });
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--commit',
-      refRepositoryShortHash,
-      refRepositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--commit',
+    refRepositoryShortHash,
+    refRepositoryPath,
+  ]);
 });
 
 test('packaged terminal helper forwards relative repository paths as absolute paths', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
   const repositoryPath = join(logger.directory, 'repo');
 
-  try {
-    await mkdir(join(repositoryPath, 'sub'), { recursive: true });
-    const actualRepositoryPath = await realpath(repositoryPath);
+  await mkdir(join(repositoryPath, 'sub'), { recursive: true });
+  const actualRepositoryPath = await realpath(repositoryPath);
 
-    const runHelper = async (args: ReadonlyArray<string>) => {
-      await logger.reset();
-      await execFileAsync(resolve('bin/codiff-app'), args, {
-        cwd: repositoryPath,
-        env: logger.env,
-      });
-      return logger.readArgs();
-    };
+  const runHelper = async (args: ReadonlyArray<string>) => {
+    await logger.reset();
+    await execFileAsync(resolve('bin/codiff-app'), args, {
+      cwd: repositoryPath,
+      env: logger.env,
+    });
+    return logger.readArgs();
+  };
 
-    expect(await runHelper(['.'])).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      `${actualRepositoryPath}/.`,
-    ]);
-    expect(await runHelper(['sub'])).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      join(actualRepositoryPath, 'sub'),
-    ]);
-    expect(await runHelper(['-w', '.'])).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--walkthrough',
-      `${actualRepositoryPath}/.`,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await runHelper(['.'])).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    `${actualRepositoryPath}/.`,
+  ]);
+  expect(await runHelper(['sub'])).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    join(actualRepositoryPath, 'sub'),
+  ]);
+  expect(await runHelper(['-w', '.'])).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--walkthrough',
+    `${actualRepositoryPath}/.`,
+  ]);
 });
 
 test('packaged terminal helper forwards Codex walkthrough seed options', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
   const repositoryPath = join(logger.directory, 'repo');
   const contextPath = join(logger.directory, 'seed.json');
 
-  try {
-    await mkdir(repositoryPath);
-    await writeFile(contextPath, '{}');
+  await mkdir(repositoryPath);
+  await writeFile(contextPath, '{}');
 
-    await execFileAsync(
-      resolve('bin/codiff-app'),
-      [
-        '-w',
-        '--codex-session',
-        '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
-        '--walkthrough-context',
-        contextPath,
-        repositoryPath,
-      ],
-      {
-        env: logger.env,
-      },
-    );
-
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
+  await execFileAsync(
+    resolve('bin/codiff-app'),
+    [
+      '-w',
       '--codex-session',
       '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
       '--walkthrough-context',
       contextPath,
-      '--walkthrough',
       repositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+    ],
+    {
+      env: logger.env,
+    },
+  );
+
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--codex-session',
+    '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
+    '--walkthrough-context',
+    contextPath,
+    '--walkthrough',
+    repositoryPath,
+  ]);
 });
 
 test('packaged terminal helper forwards pre-authored walkthrough files', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
   const repositoryPath = join(logger.directory, 'repo');
   const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
-  try {
-    await mkdir(repositoryPath);
-    await writeFile(walkthroughFile, '{}');
+  await mkdir(repositoryPath);
+  await writeFile(walkthroughFile, '{}');
 
-    await execFileAsync(
-      resolve('bin/codiff-app'),
-      [
-        '-w',
-        '--agent',
-        'claude',
-        '--walkthrough-file',
-        walkthroughFile,
-        '--claude-session',
-        '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
-        repositoryPath,
-      ],
-      {
-        env: logger.env,
-      },
-    );
-
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--claude-session',
-      '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
+  await execFileAsync(
+    resolve('bin/codiff-app'),
+    [
+      '-w',
       '--agent',
       'claude',
       '--walkthrough-file',
       walkthroughFile,
-      '--walkthrough',
+      '--claude-session',
+      '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
       repositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+    ],
+    {
+      env: logger.env,
+    },
+  );
+
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--claude-session',
+    '019e5e57-e7d6-7392-9ad1-ad959319d2fb',
+    '--agent',
+    'claude',
+    '--walkthrough-file',
+    walkthroughFile,
+    '--walkthrough',
+    repositoryPath,
+  ]);
 });
 
 test('packaged terminal helper forwards a plan handoff and result file', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
   const repositoryPath = join(logger.directory, 'repo');
   const planFile = join(logger.directory, 'plan.md');
   const resultFile = join(logger.directory, 'result.json');
 
-  try {
-    await mkdir(repositoryPath);
-    await writeFile(planFile, '# Plan\n');
-    await writeFile(resultFile, '{"status":"done"}\n');
+  await mkdir(repositoryPath);
+  await writeFile(planFile, '# Plan\n');
+  await writeFile(resultFile, '{"status":"done"}\n');
 
-    const { stdout } = await execFileAsync(
-      resolve('bin/codiff-app'),
-      ['--plan-file', planFile, '--plan-result-file', resultFile, repositoryPath],
-      {
-        env: logger.env,
-      },
-    );
+  const { stdout } = await execFileAsync(
+    resolve('bin/codiff-app'),
+    ['--plan-file', planFile, '--plan-result-file', resultFile, repositoryPath],
+    {
+      env: logger.env,
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--plan-file',
-      planFile,
-      '--plan-result-file',
-      resultFile,
-      repositoryPath,
-    ]);
-    expect(stdout).toBe('CODIFF_PLAN_RESULT {"status":"done"}\n');
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--plan-file',
+    planFile,
+    '--plan-result-file',
+    resultFile,
+    repositoryPath,
+  ]);
+  expect(stdout).toBe('CODIFF_PLAN_RESULT {"status":"done"}\n');
 });
 
 test('packaged terminal helper waits for an open plan to finish', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
   const repositoryPath = join(logger.directory, 'repo');
   const planFile = join(logger.directory, 'plan.md');
   const resultFile = join(logger.directory, 'result.json');
   const openPath = join(logger.directory, 'bin', 'open');
 
-  try {
-    await mkdir(repositoryPath);
-    await writeFile(planFile, '# Plan\n');
-    await writeFile(
-      openPath,
-      `#!/bin/sh
+  await mkdir(repositoryPath);
+  await writeFile(planFile, '# Plan\n');
+  await writeFile(
+    openPath,
+    `#!/bin/sh
 result_file=""
 previous=""
 for arg in "$@"; do
   printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"
   if [ "$previous" = "--plan-result-file" ]; then
-    result_file="$arg"
+  result_file="$arg"
   fi
   previous="$arg"
 done
@@ -869,35 +794,32 @@ done
 app_pid=$!
 printf '{"pid":%s,"status":"open"}\\n' "$app_pid" > "$result_file"
 `,
-    );
-    await chmod(openPath, 0o755);
+  );
+  await chmod(openPath, 0o755);
 
-    const { stdout } = await execFileAsync(
-      resolve('bin/codiff-app'),
-      ['--plan-file', planFile, '--plan-result-file', resultFile, repositoryPath],
-      {
-        env: logger.env,
-      },
-    );
+  const { stdout } = await execFileAsync(
+    resolve('bin/codiff-app'),
+    ['--plan-file', planFile, '--plan-result-file', resultFile, repositoryPath],
+    {
+      env: logger.env,
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--plan-file',
-      planFile,
-      '--plan-result-file',
-      resultFile,
-      repositoryPath,
-    ]);
-    expect(stdout).toBe('CODIFF_PLAN_RESULT {"documentChanged":true,"status":"closed"}\n');
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--plan-file',
+    planFile,
+    '--plan-result-file',
+    resultFile,
+    repositoryPath,
+  ]);
+  expect(stdout).toBe('CODIFF_PLAN_RESULT {"documentChanged":true,"status":"closed"}\n');
 });
 
 test('Codex skill launcher uses the session cwd as the repository target', async () => {
-  const logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
+  await using logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
   const home = join(logger.directory, 'home');
   const repositoryPath = join(logger.directory, 'repo');
   const sessionDirectory = join(home, '.codex', 'sessions', '2026', '05', '25');
@@ -905,82 +827,74 @@ test('Codex skill launcher uses the session cwd as the repository target', async
   const sessionPath = join(sessionDirectory, `rollout-${sessionId}.jsonl`);
   const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
-  try {
-    await mkdir(repositoryPath, { recursive: true });
-    await mkdir(sessionDirectory, { recursive: true });
-    await writeFile(walkthroughFile, '{}');
-    await writeFile(sessionPath, '');
-    await truncate(sessionPath, 17 * 1024 * 1024);
-    await appendFile(
-      sessionPath,
-      `\n${JSON.stringify({
-        payload: { cwd: repositoryPath },
-        type: 'turn_context',
-      })}\n`,
-    );
+  await mkdir(repositoryPath, { recursive: true });
+  await mkdir(sessionDirectory, { recursive: true });
+  await writeFile(walkthroughFile, '{}');
+  await writeFile(sessionPath, '');
+  await truncate(sessionPath, 17 * 1024 * 1024);
+  await appendFile(
+    sessionPath,
+    `\n${JSON.stringify({
+      payload: { cwd: repositoryPath },
+      type: 'turn_context',
+    })}\n`,
+  );
 
-    await execFileAsync(
-      process.execPath,
-      [resolve('codex/skills/codiff/scripts/open-codiff.mjs'), '--file', walkthroughFile, 'HEAD'],
-      {
-        cwd: resolve('codex/skills/codiff'),
-        env: {
-          ...logger.env,
-          CODEX_HOME: join(home, '.codex'),
-          CODEX_THREAD_ID: sessionId,
-          CODIFF_COMMAND: logger.commandPath,
-        },
+  await execFileAsync(
+    process.execPath,
+    [resolve('codex/skills/codiff/scripts/open-codiff.mjs'), '--file', walkthroughFile, 'HEAD'],
+    {
+      cwd: resolve('codex/skills/codiff'),
+      env: {
+        ...logger.env,
+        CODEX_HOME: join(home, '.codex'),
+        CODEX_THREAD_ID: sessionId,
+        CODIFF_COMMAND: logger.commandPath,
       },
-    );
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '-w',
-      '--agent',
-      'codex',
-      '--walkthrough-file',
-      walkthroughFile,
-      '--codex-session',
-      sessionId,
-      'HEAD',
-      repositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-w',
+    '--agent',
+    'codex',
+    '--walkthrough-file',
+    walkthroughFile,
+    '--codex-session',
+    sessionId,
+    'HEAD',
+    repositoryPath,
+  ]);
 });
 
 test('Codex skill launcher opens a blocking plan handoff', async () => {
-  const logger = await createFakeCommandLogger('codiff-plan-launcher-', 'codiff');
+  await using logger = await createFakeCommandLogger('codiff-plan-launcher-', 'codiff');
   const repositoryPath = join(logger.directory, 'repo');
   const planFile = join(logger.directory, 'plan.md');
 
-  try {
-    await mkdir(repositoryPath, { recursive: true });
-    await writeFile(planFile, '# Plan\n');
+  await mkdir(repositoryPath, { recursive: true });
+  await writeFile(planFile, '# Plan\n');
 
-    await execFileAsync(
-      process.execPath,
-      [resolve('codex/skills/codiff/scripts/open-codiff.mjs'), '--plan', planFile],
-      {
-        cwd: resolve('codex/skills/codiff'),
-        env: {
-          ...logger.env,
-          CODEX_SESSION_CWD: repositoryPath,
-          CODEX_THREAD_ID: '',
-          CODIFF_COMMAND: logger.commandPath,
-        },
+  await execFileAsync(
+    process.execPath,
+    [resolve('codex/skills/codiff/scripts/open-codiff.mjs'), '--plan', planFile],
+    {
+      cwd: resolve('codex/skills/codiff'),
+      env: {
+        ...logger.env,
+        CODEX_SESSION_CWD: repositoryPath,
+        CODEX_THREAD_ID: '',
+        CODIFF_COMMAND: logger.commandPath,
       },
-    );
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual(['--plan', planFile, '--agent', 'codex']);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual(['--plan', planFile, '--agent', 'codex']);
 });
 
 test('Codex skill launcher resolves handled plan comments', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-comments-'));
-  const reviewPath = join(directory, 'review.json');
+  await using directory = await createTemporaryDirectory('codiff-plan-comments-');
+  const reviewPath = join(directory.path, 'review.json');
   const author = {
     email: 'reviewer@example.com',
     id: 'reviewer@example.com',
@@ -1021,199 +935,179 @@ test('Codex skill launcher resolves handled plan comments', async () => {
     version: 1 as const,
   } satisfies PlanReview;
 
-  try {
-    await writeFile(reviewPath, `${JSON.stringify(review)}\n`);
-    const { stdout } = await execFileAsync(
-      process.execPath,
-      [
-        resolve('codex/skills/codiff/scripts/open-codiff.mjs'),
-        '--resolve-plan-comments',
-        reviewPath,
-        'thread-1',
-        'missing-thread',
-      ],
-      { cwd: resolve('codex/skills/codiff') },
-    );
+  await writeFile(reviewPath, `${JSON.stringify(review)}\n`);
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      resolve('codex/skills/codiff/scripts/open-codiff.mjs'),
+      '--resolve-plan-comments',
+      reviewPath,
+      'thread-1',
+      'missing-thread',
+    ],
+    { cwd: resolve('codex/skills/codiff') },
+  );
 
-    expect(stdout).toBe(
-      'CODIFF_PLAN_COMMENTS_RESOLVED {"missingIds":["missing-thread"],"resolvedIds":["thread-1"]}\n',
-    );
-    const savedReview = JSON.parse(await readFile(reviewPath, 'utf8')) as PlanReview;
-    expect(savedReview.threads).toEqual([
-      expect.objectContaining({
-        id: 'thread-1',
-        resolution: expect.objectContaining({
-          reason: 'agent-handled',
-          resolvedAt: expect.any(String),
-        }),
-        status: 'resolved',
+  expect(stdout).toBe(
+    'CODIFF_PLAN_COMMENTS_RESOLVED {"missingIds":["missing-thread"],"resolvedIds":["thread-1"]}\n',
+  );
+  const savedReview = JSON.parse(await readFile(reviewPath, 'utf8')) as PlanReview;
+  expect(savedReview.threads).toEqual([
+    expect.objectContaining({
+      id: 'thread-1',
+      resolution: expect.objectContaining({
+        reason: 'agent-handled',
+        resolvedAt: expect.any(String),
       }),
-      review.threads[1],
-    ]);
-  } finally {
-    await removeGitTestDirectory(directory);
-  }
+      status: 'resolved',
+    }),
+    review.threads[1],
+  ]);
 });
 
 test('Codex skill launcher delegates plan shares without opening Electron', async () => {
-  const logger = await createFakeCommandLogger('codiff-plan-share-launcher-', 'share-codiff');
+  await using logger = await createFakeCommandLogger('codiff-plan-share-launcher-', 'share-codiff');
   const repositoryPath = join(logger.directory, 'repo');
   const planFile = join(logger.directory, 'plan.md');
   const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
 
-  try {
-    await mkdir(repositoryPath, { recursive: true });
-    await writeFile(planFile, '# Plan\n');
+  await mkdir(repositoryPath, { recursive: true });
+  await writeFile(planFile, '# Plan\n');
 
-    await execFileAsync(
-      process.execPath,
-      [resolve('codex/skills/codiff/scripts/open-codiff.mjs'), '--plan', planFile, '--share'],
-      {
-        cwd: resolve('codex/skills/codiff'),
-        env: {
-          ...logger.env,
-          CODEX_SESSION_CWD: repositoryPath,
-          CODEX_THREAD_ID: sessionId,
-          CODIFF_SHARE_COMMAND: logger.commandPath,
-        },
+  await execFileAsync(
+    process.execPath,
+    [resolve('codex/skills/codiff/scripts/open-codiff.mjs'), '--plan', planFile, '--share'],
+    {
+      cwd: resolve('codex/skills/codiff'),
+      env: {
+        ...logger.env,
+        CODEX_SESSION_CWD: repositoryPath,
+        CODEX_THREAD_ID: sessionId,
+        CODIFF_SHARE_COMMAND: logger.commandPath,
       },
-    );
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '--plan',
-      planFile,
-      '--agent',
-      'codex',
-      '--codex-session',
-      sessionId,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '--plan',
+    planFile,
+    '--agent',
+    'codex',
+    '--codex-session',
+    sessionId,
+  ]);
 });
 
 test('Codex skill launcher falls back to the source repo when run from the skill directory', async () => {
-  const logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
+  await using logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
   const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
-  try {
-    await writeFile(walkthroughFile, '{}');
+  await writeFile(walkthroughFile, '{}');
 
-    await execFileAsync(
-      process.execPath,
-      [resolve('codex/skills/codiff/scripts/open-codiff.mjs'), '--file', walkthroughFile],
-      {
-        cwd: resolve('codex/skills/codiff'),
-        env: {
-          ...logger.env,
-          CODEX_HOME: join(logger.directory, 'home', '.codex'),
-          CODEX_THREAD_ID: '',
-          CODIFF_COMMAND: logger.commandPath,
-        },
+  await execFileAsync(
+    process.execPath,
+    [resolve('codex/skills/codiff/scripts/open-codiff.mjs'), '--file', walkthroughFile],
+    {
+      cwd: resolve('codex/skills/codiff'),
+      env: {
+        ...logger.env,
+        CODEX_HOME: join(logger.directory, 'home', '.codex'),
+        CODEX_THREAD_ID: '',
+        CODIFF_COMMAND: logger.commandPath,
       },
-    );
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '-w',
-      '--agent',
-      'codex',
-      '--walkthrough-file',
-      walkthroughFile,
-      resolve('.'),
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-w',
+    '--agent',
+    'codex',
+    '--walkthrough-file',
+    walkthroughFile,
+    resolve('.'),
+  ]);
 });
 
 test('Codex skill launcher does not override explicit repository targets', async () => {
-  const logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
+  await using logger = await createFakeCommandLogger('codiff-skill-launcher-', 'codiff');
   const sessionRepositoryPath = join(logger.directory, 'session-repo');
   const explicitRepositoryPath = join(logger.directory, 'explicit-repo');
   const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
-  try {
-    await mkdir(sessionRepositoryPath, { recursive: true });
-    await mkdir(explicitRepositoryPath, { recursive: true });
-    await writeFile(walkthroughFile, '{}');
+  await mkdir(sessionRepositoryPath, { recursive: true });
+  await mkdir(explicitRepositoryPath, { recursive: true });
+  await writeFile(walkthroughFile, '{}');
 
-    await execFileAsync(
-      process.execPath,
-      [
-        resolve('codex/skills/codiff/scripts/open-codiff.mjs'),
-        '--file',
-        walkthroughFile,
-        explicitRepositoryPath,
-      ],
-      {
-        cwd: resolve('codex/skills/codiff'),
-        env: {
-          ...logger.env,
-          CODEX_SESSION_CWD: sessionRepositoryPath,
-          CODEX_THREAD_ID: '',
-          CODIFF_COMMAND: logger.commandPath,
-        },
-      },
-    );
-
-    expect(await logger.readArgs()).toEqual([
-      '-w',
-      '--agent',
-      'codex',
-      '--walkthrough-file',
+  await execFileAsync(
+    process.execPath,
+    [
+      resolve('codex/skills/codiff/scripts/open-codiff.mjs'),
+      '--file',
       walkthroughFile,
       explicitRepositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+    ],
+    {
+      cwd: resolve('codex/skills/codiff'),
+      env: {
+        ...logger.env,
+        CODEX_SESSION_CWD: sessionRepositoryPath,
+        CODEX_THREAD_ID: '',
+        CODIFF_COMMAND: logger.commandPath,
+      },
+    },
+  );
+
+  expect(await logger.readArgs()).toEqual([
+    '-w',
+    '--agent',
+    'codex',
+    '--walkthrough-file',
+    walkthroughFile,
+    explicitRepositoryPath,
+  ]);
 });
 
 test('Codex skill launcher delegates share requests without opening Electron', async () => {
-  const logger = await createFakeCommandLogger('codiff-share-launcher-', 'share-codiff');
+  await using logger = await createFakeCommandLogger('codiff-share-launcher-', 'share-codiff');
   const repositoryPath = join(logger.directory, 'repo');
   const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
-  try {
-    await mkdir(repositoryPath, { recursive: true });
-    await writeFile(walkthroughFile, '{}');
+  await mkdir(repositoryPath, { recursive: true });
+  await writeFile(walkthroughFile, '{}');
 
-    await execFileAsync(
-      process.execPath,
-      [
-        resolve('codex/skills/codiff/scripts/open-codiff.mjs'),
-        '--share',
-        '--open',
-        '--file',
-        walkthroughFile,
-        'HEAD',
-      ],
-      {
-        cwd: resolve('codex/skills/codiff'),
-        env: {
-          ...logger.env,
-          CODEX_SESSION_CWD: repositoryPath,
-          CODEX_THREAD_ID: '',
-          CODIFF_SHARE_COMMAND: logger.commandPath,
-        },
-      },
-    );
-
-    expect(await logger.readArgs()).toEqual([
+  await execFileAsync(
+    process.execPath,
+    [
+      resolve('codex/skills/codiff/scripts/open-codiff.mjs'),
+      '--share',
+      '--open',
       '--file',
       walkthroughFile,
-      '--agent',
-      'codex',
-      '--open',
       'HEAD',
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+    ],
+    {
+      cwd: resolve('codex/skills/codiff'),
+      env: {
+        ...logger.env,
+        CODEX_SESSION_CWD: repositoryPath,
+        CODEX_THREAD_ID: '',
+        CODIFF_SHARE_COMMAND: logger.commandPath,
+      },
+    },
+  );
+
+  expect(await logger.readArgs()).toEqual([
+    '--file',
+    walkthroughFile,
+    '--agent',
+    'codex',
+    '--open',
+    'HEAD',
+  ]);
 });
 
 test('Claude skill launcher uses the session cwd and forwards --agent claude', async () => {
-  const logger = await createFakeCommandLogger('codiff-claude-launcher-', 'codiff');
+  await using logger = await createFakeCommandLogger('codiff-claude-launcher-', 'codiff');
   const home = join(logger.directory, 'home');
   const repositoryPath = join(logger.directory, 'repo');
   const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
@@ -1221,46 +1115,42 @@ test('Claude skill launcher uses the session cwd and forwards --agent claude', a
   const sessionPath = join(projectDirectory, `${sessionId}.jsonl`);
   const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
-  try {
-    await mkdir(repositoryPath, { recursive: true });
-    await mkdir(projectDirectory, { recursive: true });
-    await writeFile(walkthroughFile, '{}');
-    await writeFile(sessionPath, '');
-    await truncate(sessionPath, 17 * 1024 * 1024);
-    await appendFile(sessionPath, `\n${JSON.stringify({ cwd: repositoryPath })}\n`);
+  await mkdir(repositoryPath, { recursive: true });
+  await mkdir(projectDirectory, { recursive: true });
+  await writeFile(walkthroughFile, '{}');
+  await writeFile(sessionPath, '');
+  await truncate(sessionPath, 17 * 1024 * 1024);
+  await appendFile(sessionPath, `\n${JSON.stringify({ cwd: repositoryPath })}\n`);
 
-    await execFileAsync(
-      process.execPath,
-      [resolve('claude/skills/codiff/scripts/open-codiff.mjs'), '--file', walkthroughFile, 'HEAD'],
-      {
-        cwd: resolve('claude/skills/codiff'),
-        env: {
-          ...logger.env,
-          CLAUDE_CONFIG_DIR: join(home, '.claude'),
-          CLAUDE_SESSION_ID: sessionId,
-          CODIFF_COMMAND: logger.commandPath,
-        },
+  await execFileAsync(
+    process.execPath,
+    [resolve('claude/skills/codiff/scripts/open-codiff.mjs'), '--file', walkthroughFile, 'HEAD'],
+    {
+      cwd: resolve('claude/skills/codiff'),
+      env: {
+        ...logger.env,
+        CLAUDE_CONFIG_DIR: join(home, '.claude'),
+        CLAUDE_SESSION_ID: sessionId,
+        CODIFF_COMMAND: logger.commandPath,
       },
-    );
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '-w',
-      '--agent',
-      'claude',
-      '--walkthrough-file',
-      walkthroughFile,
-      '--claude-session',
-      sessionId,
-      'HEAD',
-      repositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-w',
+    '--agent',
+    'claude',
+    '--walkthrough-file',
+    walkthroughFile,
+    '--claude-session',
+    sessionId,
+    'HEAD',
+    repositoryPath,
+  ]);
 });
 
 test('Pi skill launcher resolves the current session and forwards --agent pi', async () => {
-  const logger = await createFakeCommandLogger('codiff-pi-launcher-', 'codiff');
+  await using logger = await createFakeCommandLogger('codiff-pi-launcher-', 'codiff');
   const home = join(logger.directory, 'home');
   const repositoryPath = join(logger.directory, 'repo');
   const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
@@ -1268,48 +1158,44 @@ test('Pi skill launcher resolves the current session and forwards --agent pi', a
   const sessionPath = join(sessionDirectory, `2026-06-10_${sessionId}.jsonl`);
   const walkthroughFile = join(logger.directory, 'walkthrough.json');
 
-  try {
-    await mkdir(repositoryPath, { recursive: true });
-    const realRepositoryPath = await realpath(repositoryPath);
-    await mkdir(sessionDirectory, { recursive: true });
-    await writeFile(walkthroughFile, '{}');
-    await writeFile(
-      sessionPath,
-      `${JSON.stringify({ cwd: realRepositoryPath, id: sessionId, type: 'session' })}\n`,
-    );
-    await truncate(sessionPath, 17 * 1024 * 1024);
+  await mkdir(repositoryPath, { recursive: true });
+  const realRepositoryPath = await realpath(repositoryPath);
+  await mkdir(sessionDirectory, { recursive: true });
+  await writeFile(walkthroughFile, '{}');
+  await writeFile(
+    sessionPath,
+    `${JSON.stringify({ cwd: realRepositoryPath, id: sessionId, type: 'session' })}\n`,
+  );
+  await truncate(sessionPath, 17 * 1024 * 1024);
 
-    await execFileAsync(
-      process.execPath,
-      [resolve('pi/skills/codiff/scripts/open-codiff.mjs'), '--file', walkthroughFile, 'HEAD'],
-      {
-        cwd: repositoryPath,
-        env: {
-          ...logger.env,
-          CODIFF_COMMAND: logger.commandPath,
-          PI_HOME: join(home, '.pi'),
-        },
+  await execFileAsync(
+    process.execPath,
+    [resolve('pi/skills/codiff/scripts/open-codiff.mjs'), '--file', walkthroughFile, 'HEAD'],
+    {
+      cwd: repositoryPath,
+      env: {
+        ...logger.env,
+        CODIFF_COMMAND: logger.commandPath,
+        PI_HOME: join(home, '.pi'),
       },
-    );
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '-w',
-      '--agent',
-      'pi',
-      '--walkthrough-file',
-      walkthroughFile,
-      '--pi-session',
-      sessionId,
-      'HEAD',
-      realRepositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-w',
+    '--agent',
+    'pi',
+    '--walkthrough-file',
+    walkthroughFile,
+    '--pi-session',
+    sessionId,
+    'HEAD',
+    realRepositoryPath,
+  ]);
 });
 
 test('OpenCode skill launcher links the project session from a repository subdirectory', async () => {
-  const logger = await createFakeCommandLogger('codiff-opencode-launcher-', 'codiff');
+  await using logger = await createFakeCommandLogger('codiff-opencode-launcher-', 'codiff');
   const repositoryPath = join(logger.directory, 'repo');
   const workingDirectory = join(repositoryPath, 'nested');
   const walkthroughFile = join(logger.directory, 'walkthrough.json');
@@ -1317,135 +1203,114 @@ test('OpenCode skill launcher links the project session from a repository subdir
   const openCodePath = join(homePath, '.opencode', 'bin', 'opencode');
   const sessionId = 'ses_121b4816bffebMr9YE52O4870p';
 
-  try {
-    await mkdir(workingDirectory, { recursive: true });
-    await mkdir(join(homePath, '.opencode', 'bin'), { recursive: true });
-    const realRepositoryPath = await realpath(repositoryPath);
-    const realWorkingDirectory = await realpath(workingDirectory);
-    await writeFile(walkthroughFile, '{}');
-    await writeFile(
-      openCodePath,
-      `#!/bin/sh
+  await mkdir(workingDirectory, { recursive: true });
+  await mkdir(join(homePath, '.opencode', 'bin'), { recursive: true });
+  const realRepositoryPath = await realpath(repositoryPath);
+  const realWorkingDirectory = await realpath(workingDirectory);
+  await writeFile(walkthroughFile, '{}');
+  await writeFile(
+    openCodePath,
+    `#!/bin/sh
 printf '[{"id":"${sessionId}","directory":"%s"}]\\n' "$OPENCODE_SESSION_DIRECTORY"
 `,
-    );
-    await chmod(openCodePath, 0o755);
+  );
+  await chmod(openCodePath, 0o755);
 
-    await execFileAsync(
-      process.execPath,
-      [
-        resolve('opencode/skills/codiff/scripts/open-codiff.mjs'),
-        '--file',
-        walkthroughFile,
-        'HEAD',
-      ],
-      {
-        cwd: workingDirectory,
-        env: {
-          ...logger.env,
-          CODIFF_COMMAND: logger.commandPath,
-          HOME: homePath,
-          OPENCODE_SESSION_DIRECTORY: realRepositoryPath,
-          PATH: logger.directory,
-        },
+  await execFileAsync(
+    process.execPath,
+    [resolve('opencode/skills/codiff/scripts/open-codiff.mjs'), '--file', walkthroughFile, 'HEAD'],
+    {
+      cwd: workingDirectory,
+      env: {
+        ...logger.env,
+        CODIFF_COMMAND: logger.commandPath,
+        HOME: homePath,
+        OPENCODE_SESSION_DIRECTORY: realRepositoryPath,
+        PATH: logger.directory,
       },
-    );
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '-w',
-      '--agent',
-      'opencode',
-      '--walkthrough-file',
-      walkthroughFile,
-      '--opencode-session',
-      sessionId,
-      'HEAD',
-      realWorkingDirectory,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-w',
+    '--agent',
+    'opencode',
+    '--walkthrough-file',
+    walkthroughFile,
+    '--opencode-session',
+    sessionId,
+    'HEAD',
+    realWorkingDirectory,
+  ]);
 });
 
 test('packaged terminal helper forwards the agent and Claude session to Electron', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
   const repositoryPath = join(logger.directory, 'repo');
   const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
 
-  try {
-    await mkdir(repositoryPath);
+  await mkdir(repositoryPath);
 
-    await execFileAsync(
-      resolve('bin/codiff-app'),
-      ['-w', '--agent', 'claude', '--claude-session', sessionId, repositoryPath],
-      {
-        env: logger.env,
-      },
-    );
+  await execFileAsync(
+    resolve('bin/codiff-app'),
+    ['-w', '--agent', 'claude', '--claude-session', sessionId, repositoryPath],
+    {
+      env: logger.env,
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--claude-session',
-      sessionId,
-      '--agent',
-      'claude',
-      '--walkthrough',
-      repositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--claude-session',
+    sessionId,
+    '--agent',
+    'claude',
+    '--walkthrough',
+    repositoryPath,
+  ]);
 });
 
 test('packaged terminal helper forwards the OpenCode session to Electron', async () => {
-  const logger = await createFakeOpenLogger();
+  await using logger = await createFakeOpenLogger();
   const repositoryPath = join(logger.directory, 'repo');
   const sessionId = 'ses_121b4816bffebMr9YE52O4870p';
 
-  try {
-    await mkdir(repositoryPath);
+  await mkdir(repositoryPath);
 
-    await execFileAsync(
-      resolve('bin/codiff-app'),
-      ['-w', '--agent', 'opencode', '--opencode-session', sessionId, repositoryPath],
-      {
-        env: logger.env,
-      },
-    );
+  await execFileAsync(
+    resolve('bin/codiff-app'),
+    ['-w', '--agent', 'opencode', '--opencode-session', sessionId, repositoryPath],
+    {
+      env: logger.env,
+    },
+  );
 
-    expect(await logger.readArgs()).toEqual([
-      '-n',
-      resolve('bin/../../../..'),
-      '--args',
-      '--opencode-session',
-      sessionId,
-      '--agent',
-      'opencode',
-      '--walkthrough',
-      repositoryPath,
-    ]);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    '--opencode-session',
+    sessionId,
+    '--agent',
+    'opencode',
+    '--walkthrough',
+    repositoryPath,
+  ]);
 });
 
 test('packaged terminal helper runs --share through the bundled Node entry point', async () => {
-  const logger = await createFakeCommandLogger('codiff-packaged-share-', 'runtime');
+  await using logger = await createFakeCommandLogger('codiff-packaged-share-', 'runtime');
 
-  try {
-    await execFileAsync(resolve('bin/codiff-app'), ['--share', 'HEAD'], {
-      env: {
-        ...logger.env,
-        CODIFF_NODE_COMMAND: logger.commandPath,
-      },
-    });
+  await execFileAsync(resolve('bin/codiff-app'), ['--share', 'HEAD'], {
+    env: {
+      ...logger.env,
+      CODIFF_NODE_COMMAND: logger.commandPath,
+    },
+  });
 
-    expect(await logger.readArgs()).toEqual([resolve('bin/codiff.js'), '--share', 'HEAD']);
-  } finally {
-    await logger.cleanup();
-  }
+  expect(await logger.readArgs()).toEqual([resolve('bin/codiff.js'), '--share', 'HEAD']);
 });
 
 test('parseArguments recognizes --help and -h flags', () => {

--- a/core/__tests__/codiff-share-cli.test.ts
+++ b/core/__tests__/codiff-share-cli.test.ts
@@ -1,12 +1,15 @@
 import { execFile } from 'node:child_process';
-import { chmod, mkdir, mkdtemp, readFile, realpath, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
-import { removeGitTestDirectory } from './helpers/git.ts';
+import {
+  bindDisposableHttpServer,
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from './helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { readRepositoryState } = require('../../electron/git-state.cjs') as {
@@ -55,9 +58,9 @@ const git = (repositoryPath: string, args: ReadonlyArray<string>) =>
   });
 
 test('headless share uploads the canonical snapshot and prints its URL', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-headless-share-'));
-  const repositoryPath = join(directory, 'repo');
-  const walkthroughFile = join(directory, 'walkthrough.json');
+  await using directory = await createTemporaryDirectory('codiff-headless-share-');
+  const repositoryPath = join(directory.path, 'repo');
+  const walkthroughFile = join(directory.path, 'walkthrough.json');
   let uploadedBody: UploadedBody | null = null;
   let uploadHeaders: Record<string, string | Array<string> | undefined> = {};
 
@@ -98,94 +101,87 @@ test('headless share uploads the canonical snapshot and prints its URL', async (
     response.end();
   });
 
-  try {
-    await mkdir(repositoryPath);
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['config', 'user.email', 'author@cloudflare.com']);
-    await git(repositoryPath, ['config', 'user.name', 'Cloudflare Author']);
-    await writeFile(join(repositoryPath, 'example.txt'), 'before\n');
-    await git(repositoryPath, ['add', 'example.txt']);
-    await git(repositoryPath, ['commit', '-m', 'Initial commit']);
-    await writeFile(join(repositoryPath, 'example.txt'), 'after\n');
+  await mkdir(repositoryPath);
+  await git(repositoryPath, ['init']);
+  await git(repositoryPath, ['config', 'user.email', 'author@cloudflare.com']);
+  await git(repositoryPath, ['config', 'user.name', 'Cloudflare Author']);
+  await writeFile(join(repositoryPath, 'example.txt'), 'before\n');
+  await git(repositoryPath, ['add', 'example.txt']);
+  await git(repositoryPath, ['commit', '-m', 'Initial commit']);
+  await writeFile(join(repositoryPath, 'example.txt'), 'after\n');
 
-    const state = await readRepositoryState(repositoryPath);
-    const file = state.files[0];
-    const hunk = getSectionWalkthroughHunks(file, file.sections[0])[0];
-    await writeFile(
-      walkthroughFile,
-      JSON.stringify({
-        chapters: [
-          {
-            blurb: 'Review the behavior change.',
-            icon: 'wrench',
-            id: 'change',
-            stops: [
-              {
-                hunkIds: [hunk.id],
-                id: 's1',
-                importance: 'normal',
-                prose: 'The file now contains the updated value.',
-              },
-            ],
-            title: 'Change',
-          },
-        ],
-        focus: 'Update the example value.',
-        kind: 'narrative',
-        title: 'Example update',
-        version: 4,
-      }),
-    );
-
-    await new Promise<void>((resolveListen) => {
-      server.listen(0, '127.0.0.1', resolveListen);
-    });
-    const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
-    const { stdout } = await execFileAsync(
-      process.execPath,
-      [resolve('bin/share-codiff.mjs'), '--file', walkthroughFile, repositoryPath],
-      {
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          CODIFF_SHARE_SERVER_URL: origin,
-          HOME: join(directory, 'home'),
+  const state = await readRepositoryState(repositoryPath);
+  const file = state.files[0];
+  const hunk = getSectionWalkthroughHunks(file, file.sections[0])[0];
+  await writeFile(
+    walkthroughFile,
+    JSON.stringify({
+      chapters: [
+        {
+          blurb: 'Review the behavior change.',
+          icon: 'wrench',
+          id: 'change',
+          stops: [
+            {
+              hunkIds: [hunk.id],
+              id: 's1',
+              importance: 'normal',
+              prose: 'The file now contains the updated value.',
+            },
+          ],
+          title: 'Change',
         },
-      },
-    );
+      ],
+      focus: 'Update the example value.',
+      kind: 'narrative',
+      title: 'Example update',
+      version: 4,
+    }),
+  );
 
-    const body = uploadedBody as unknown as UploadedBody;
-    expect(stdout.trim()).toBe(`${origin}/w/shared-walkthrough`);
-    expect(uploadHeaders.authorization).toBe('Bearer secret');
-    expect(uploadHeaders['x-codiff-upload-code']).toBe('CODE');
-    expect(body.uploader).toMatchObject({
-      email: 'author@cloudflare.com',
-      name: 'Cloudflare Author',
-    });
-    expect(body.snapshot).toMatchObject({
-      kind: 'codiff-walkthrough-share',
-      repository: {
-        root: await realpath(repositoryPath),
-        source: { type: 'working-tree' },
+  await using _server = await bindDisposableHttpServer(server);
+  const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [resolve('bin/share-codiff.mjs'), '--file', walkthroughFile, repositoryPath],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CODIFF_SHARE_SERVER_URL: origin,
+        HOME: join(directory.path, 'home'),
       },
-      version: 1,
-      walkthrough: {
-        agent: 'codex',
-        title: 'Example update',
-        version: 4,
-      },
-    });
-  } finally {
-    await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
-    await removeGitTestDirectory(directory);
-  }
+    },
+  );
+
+  const body = uploadedBody as unknown as UploadedBody;
+  expect(stdout.trim()).toBe(`${origin}/w/shared-walkthrough`);
+  expect(uploadHeaders.authorization).toBe('Bearer secret');
+  expect(uploadHeaders['x-codiff-upload-code']).toBe('CODE');
+  expect(body.uploader).toMatchObject({
+    email: 'author@cloudflare.com',
+    name: 'Cloudflare Author',
+  });
+  expect(body.snapshot).toMatchObject({
+    kind: 'codiff-walkthrough-share',
+    repository: {
+      root: await realpath(repositoryPath),
+      source: { type: 'working-tree' },
+    },
+    version: 1,
+    walkthrough: {
+      agent: 'codex',
+      title: 'Example update',
+      version: 4,
+    },
+  });
 });
 
 test('headless plan share works outside Git without invoking it', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-headless-plan-share-'));
-  const fakeBin = join(directory, 'bin');
-  const gitMarker = join(directory, 'git-invoked');
-  const planFile = join(directory, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-headless-plan-share-');
+  const fakeBin = join(directory.path, 'bin');
+  const gitMarker = join(directory.path, 'git-invoked');
+  const planFile = join(directory.path, 'plan.md');
   type PlanSnapshot = {
     document: { content: string; name: string; title: string };
     kind: string;
@@ -234,119 +230,112 @@ test('headless plan share works outside Git without invoking it', async () => {
     response.end();
   });
 
-  try {
-    await mkdir(fakeBin);
-    await writeFile(join(fakeBin, 'git'), `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`);
-    await chmod(join(fakeBin, 'git'), 0o755);
-    await writeFile(planFile, '# Ship plan sharing\n\nKeep walkthroughs stable.\n');
-    await new Promise<void>((resolveListen) => {
-      server.listen(0, '127.0.0.1', resolveListen);
-    });
-    const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+  await mkdir(fakeBin);
+  await writeFile(join(fakeBin, 'git'), `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`);
+  await chmod(join(fakeBin, 'git'), 0o755);
+  await writeFile(planFile, '# Ship plan sharing\n\nKeep walkthroughs stable.\n');
+  await using _server = await bindDisposableHttpServer(server);
+  const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
 
-    const { stdout } = await execFileAsync(
-      process.execPath,
-      [
-        resolve('bin/share-codiff.mjs'),
-        '--plan',
-        planFile,
-        '--agent',
-        'codex',
-        '--codex-session',
-        'thread-id',
-      ],
-      {
-        cwd: directory,
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          CODIFF_SHARE_SERVER_URL: origin,
-          HOME: join(directory, 'home'),
-          PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
-        },
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      resolve('bin/share-codiff.mjs'),
+      '--plan',
+      planFile,
+      '--agent',
+      'codex',
+      '--codex-session',
+      'thread-id',
+    ],
+    {
+      cwd: directory.path,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CODIFF_SHARE_SERVER_URL: origin,
+        HOME: join(directory.path, 'home'),
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
       },
-    );
+    },
+  );
 
-    const body = uploadedBody as PlanUploadedBody | null;
-    const snapshot = body && 'snapshot' in body ? body.snapshot : body;
-    expect(stdout.trim()).toBe(`${origin}/p/shared-plan`);
-    expect(body && 'uploader' in body ? body.uploader : undefined).toBeUndefined();
-    expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
-    expect(snapshot).toMatchObject({
-      document: {
-        content: '# Ship plan sharing\n\nKeep walkthroughs stable.\n',
-        name: 'plan.md',
-        title: 'Ship plan sharing',
-      },
-      kind: 'codiff-plan-share',
-      review: {
-        threads: [],
-        version: 1,
-      },
-      source: {
-        agent: 'codex',
-        sessionId: 'thread-id',
-      },
+  const body = uploadedBody as PlanUploadedBody | null;
+  const snapshot = body && 'snapshot' in body ? body.snapshot : body;
+  expect(stdout.trim()).toBe(`${origin}/p/shared-plan`);
+  expect(body && 'uploader' in body ? body.uploader : undefined).toBeUndefined();
+  expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
+  expect(snapshot).toMatchObject({
+    document: {
+      content: '# Ship plan sharing\n\nKeep walkthroughs stable.\n',
+      name: 'plan.md',
+      title: 'Ship plan sharing',
+    },
+    kind: 'codiff-plan-share',
+    review: {
+      threads: [],
       version: 1,
-    });
-  } finally {
-    await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
-    await removeGitTestDirectory(directory);
-  }
+    },
+    source: {
+      agent: 'codex',
+      sessionId: 'thread-id',
+    },
+    version: 1,
+  });
 });
 
 test('headless walkthrough share resolves GitHub PR branch targets', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-headless-pr-branch-'));
-  const fakeBin = join(directory, 'bin');
-  const ghArgsPath = join(directory, 'gh-args.txt');
-  const repositoryPath = join(directory, 'repo');
-  const walkthroughFile = join(directory, 'walkthrough.json');
+  await using directory = await createTemporaryDirectory('codiff-headless-pr-branch-');
+  const fakeBin = join(directory.path, 'bin');
+  const ghArgsPath = join(directory.path, 'gh-args.txt');
+  const repositoryPath = join(directory.path, 'repo');
+  const walkthroughFile = join(directory.path, 'walkthrough.json');
 
-  try {
-    await mkdir(fakeBin);
-    await mkdir(repositoryPath);
-    await writeFile(walkthroughFile, '{}');
-    await writeFile(
-      join(fakeBin, 'gh'),
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$GH_ARGS_FILE"\ndone\nprintf "%s\\n" \'{"state":"MERGED","url":"https://github.com/nkzw-tech/codiff/pull/127"}\'\n',
-    );
-    await chmod(join(fakeBin, 'gh'), 0o755);
+  await mkdir(fakeBin);
+  await mkdir(repositoryPath);
+  await writeFile(walkthroughFile, '{}');
+  await writeFile(
+    join(fakeBin, 'gh'),
+    '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$GH_ARGS_FILE"\ndone\nprintf "%s\\n" \'{"state":"MERGED","url":"https://github.com/nkzw-tech/codiff/pull/127"}\'\n',
+  );
+  await chmod(join(fakeBin, 'gh'), 0o755);
 
-    await expect(
-      execFileAsync(
-        process.execPath,
-        [
-          resolve('bin/share-codiff.mjs'),
-          '--file',
-          walkthroughFile,
-          'pr',
-          'owner:merged-branch',
-          repositoryPath,
-        ],
-        {
-          encoding: 'utf8',
-          env: {
-            ...process.env,
-            GH_ARGS_FILE: ghArgsPath,
-            PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
-          },
+  await using _environment = createTemporaryEnvironment({
+    GH_ARGS_FILE: ghArgsPath,
+    PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+  });
+  await expect(
+    execFileAsync(
+      process.execPath,
+      [
+        resolve('bin/share-codiff.mjs'),
+        '--file',
+        walkthroughFile,
+        'pr',
+        'owner:merged-branch',
+        repositoryPath,
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GH_ARGS_FILE: ghArgsPath,
+          PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
         },
-      ),
-    ).rejects.toMatchObject({
-      stderr: expect.stringContaining(
-        'Could not find an open GitHub pull request for branch "owner:merged-branch".',
-      ),
-    });
-    expect(await readFile(ghArgsPath, 'utf8')).toContain('owner:merged-branch\n');
-  } finally {
-    await removeGitTestDirectory(directory);
-  }
+      },
+    ),
+  ).rejects.toMatchObject({
+    stderr: expect.stringContaining(
+      'Could not find an open GitHub pull request for branch "owner:merged-branch".',
+    ),
+  });
+  expect(await readFile(ghArgsPath, 'utf8')).toContain('owner:merged-branch\n');
 });
 
 test('codiff --share falls back to HEAD for a clean working tree and prints only its URL', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-generate-share-'));
-  const repositoryPath = join(directory, 'repo');
-  const fakeCodexPath = join(directory, 'codex');
+  await using directory = await createTemporaryDirectory('codiff-generate-share-');
+  const repositoryPath = join(directory.path, 'repo');
+  const fakeCodexPath = join(directory.path, 'codex');
   let uploadedBody: UploadedBody | null = null;
 
   const server = createServer((request, response) => {
@@ -385,48 +374,47 @@ test('codiff --share falls back to HEAD for a clean working tree and prints only
     response.end();
   });
 
-  try {
-    await mkdir(repositoryPath);
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['config', 'user.email', 'author@cloudflare.com']);
-    await git(repositoryPath, ['config', 'user.name', 'Cloudflare Author']);
-    await writeFile(join(repositoryPath, 'example.txt'), 'before\n');
-    await git(repositoryPath, ['add', 'example.txt']);
-    await git(repositoryPath, ['commit', '-m', 'Initial commit']);
-    await writeFile(join(repositoryPath, 'example.txt'), 'after\n');
-    await git(repositoryPath, ['add', 'example.txt']);
-    await git(repositoryPath, ['commit', '-m', 'Update example']);
-    const { stdout: headOutput } = await git(repositoryPath, ['rev-parse', 'HEAD']);
-    const head = headOutput.trim();
+  await mkdir(repositoryPath);
+  await git(repositoryPath, ['init']);
+  await git(repositoryPath, ['config', 'user.email', 'author@cloudflare.com']);
+  await git(repositoryPath, ['config', 'user.name', 'Cloudflare Author']);
+  await writeFile(join(repositoryPath, 'example.txt'), 'before\n');
+  await git(repositoryPath, ['add', 'example.txt']);
+  await git(repositoryPath, ['commit', '-m', 'Initial commit']);
+  await writeFile(join(repositoryPath, 'example.txt'), 'after\n');
+  await git(repositoryPath, ['add', 'example.txt']);
+  await git(repositoryPath, ['commit', '-m', 'Update example']);
+  const { stdout: headOutput } = await git(repositoryPath, ['rev-parse', 'HEAD']);
+  const head = headOutput.trim();
 
-    const state = await readRepositoryState(repositoryPath, { ref: 'HEAD', type: 'commit' });
-    const file = state.files[0];
-    const hunk = getSectionWalkthroughHunks(file, file.sections[0])[0];
-    const generatedWalkthrough = JSON.stringify({
-      chapters: [
-        {
-          blurb: 'Review the committed behavior change.',
-          icon: 'wrench',
-          id: 'change',
-          stops: [
-            {
-              hunkIds: [hunk.id],
-              id: 's1',
-              importance: 'normal',
-              prose: 'The committed file now contains the updated value.',
-            },
-          ],
-          title: 'Change',
-        },
-      ],
-      focus: 'Update the example value.',
-      kind: 'narrative',
-      title: 'Example update',
-      version: 4,
-    });
-    await writeFile(
-      fakeCodexPath,
-      `#!/bin/sh
+  const state = await readRepositoryState(repositoryPath, { ref: 'HEAD', type: 'commit' });
+  const file = state.files[0];
+  const hunk = getSectionWalkthroughHunks(file, file.sections[0])[0];
+  const generatedWalkthrough = JSON.stringify({
+    chapters: [
+      {
+        blurb: 'Review the committed behavior change.',
+        icon: 'wrench',
+        id: 'change',
+        stops: [
+          {
+            hunkIds: [hunk.id],
+            id: 's1',
+            importance: 'normal',
+            prose: 'The committed file now contains the updated value.',
+          },
+        ],
+        title: 'Change',
+      },
+    ],
+    focus: 'Update the example value.',
+    kind: 'narrative',
+    title: 'Example update',
+    version: 4,
+  });
+  await writeFile(
+    fakeCodexPath,
+    `#!/bin/sh
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "--output-last-message" ]; then
     shift
@@ -439,42 +427,36 @@ EOF
 done
 exit 1
 `,
-    );
-    await chmod(fakeCodexPath, 0o755);
+  );
+  await chmod(fakeCodexPath, 0o755);
 
-    await new Promise<void>((resolveListen) => {
-      server.listen(0, '127.0.0.1', resolveListen);
-    });
-    const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
-    const { stderr, stdout } = await execFileAsync(
-      process.execPath,
-      [resolve('bin/codiff.js'), '--share', repositoryPath],
-      {
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          CODIFF_CODEX_PATH: fakeCodexPath,
-          CODIFF_SHARE_SERVER_URL: origin,
-          HOME: join(directory, 'home'),
-        },
+  await using _server = await bindDisposableHttpServer(server);
+  const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+  const { stderr, stdout } = await execFileAsync(
+    process.execPath,
+    [resolve('bin/codiff.js'), '--share', repositoryPath],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CODIFF_CODEX_PATH: fakeCodexPath,
+        CODIFF_SHARE_SERVER_URL: origin,
+        HOME: join(directory.path, 'home'),
       },
-    );
+    },
+  );
 
-    const body = uploadedBody as unknown as UploadedBody;
-    expect(stderr).toBe('');
-    expect(stdout).toBe(`${origin}/w/generated-walkthrough\n`);
-    expect(body.snapshot.repository).toMatchObject({
-      root: await realpath(repositoryPath),
-      source: { ref: head, type: 'commit' },
-      title: 'Update example',
-    });
-    expect(body.snapshot.walkthrough).toMatchObject({
-      agent: 'codex',
-      title: 'Example update',
-      version: 4,
-    });
-  } finally {
-    await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
-    await removeGitTestDirectory(directory);
-  }
+  const body = uploadedBody as unknown as UploadedBody;
+  expect(stderr).toBe('');
+  expect(stdout).toBe(`${origin}/w/generated-walkthrough\n`);
+  expect(body.snapshot.repository).toMatchObject({
+    root: await realpath(repositoryPath),
+    source: { ref: head, type: 'commit' },
+    title: 'Update example',
+  });
+  expect(body.snapshot.walkthrough).toMatchObject({
+    agent: 'codex',
+    title: 'Example update',
+    version: 4,
+  });
 }, 15_000);

--- a/core/__tests__/config-defaults.test.ts
+++ b/core/__tests__/config-defaults.test.ts
@@ -6,7 +6,7 @@ import { expect, test } from 'vite-plus/test';
 import packageJson from '../../package.json' with { type: 'json' };
 import schema from '../config/codiff-config.schema.json' with { type: 'json' };
 import { createDefaultConfig } from '../config/defaults.ts';
-import { createTemporaryDirectory, createTemporaryEnvironment } from './helpers/resources.ts';
+import { createTemporaryDirectorySync, createTemporaryEnvironment } from './helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { createDefaultConfig: createElectronDefaultConfig, readConfig } =
@@ -15,9 +15,9 @@ const { createDefaultConfig: createElectronDefaultConfig, readConfig } =
     readConfig: () => ReturnType<typeof createDefaultConfig>;
   };
 
-const readElectronConfig = async (raw: unknown) => {
-  await using home = await createTemporaryDirectory('codiff-config-home.');
-  await using _environment = createTemporaryEnvironment({ HOME: home.path });
+const readElectronConfig = (raw: unknown) => {
+  using home = createTemporaryDirectorySync('codiff-config-home.');
+  using _environment = createTemporaryEnvironment({ HOME: home.path });
   const configDirectory = join(home.path, '.codiff');
   mkdirSync(configDirectory);
   writeFileSync(join(configDirectory, 'codiff.jsonc'), `${JSON.stringify(raw)}\n`);
@@ -43,58 +43,47 @@ test('electron and renderer defaults match', () => {
   expect(createElectronDefaultConfig()).toEqual(createDefaultConfig());
 });
 
-test('electron config normalizes code font settings', async () => {
-  expect((await readElectronConfig({})).settings.codeFontFamily).toBe('');
-  expect((await readElectronConfig({})).settings.codeFontSize).toBe(13);
+test('electron config normalizes code font settings', () => {
+  expect(readElectronConfig({}).settings.codeFontFamily).toBe('');
+  expect(readElectronConfig({}).settings.codeFontSize).toBe(13);
 
   expect(
-    (
-      await readElectronConfig({
-        settings: {
-          codeFontFamily: '  JetBrains Mono  ',
-          codeFontSize: 14.6,
-        },
-      })
-    ).settings,
+    readElectronConfig({
+      settings: {
+        codeFontFamily: '  JetBrains Mono  ',
+        codeFontSize: 14.6,
+      },
+    }).settings,
   ).toMatchObject({
     codeFontFamily: 'JetBrains Mono',
     codeFontSize: 15,
   });
 
   expect(
-    (await readElectronConfig({ settings: { codeFontFamily: 42, codeFontSize: 'large' } }))
-      .settings,
+    readElectronConfig({ settings: { codeFontFamily: 42, codeFontSize: 'large' } }).settings,
   ).toMatchObject({
     codeFontFamily: '',
     codeFontSize: 13,
   });
-  expect((await readElectronConfig({ settings: { codeFontSize: 8 } })).settings.codeFontSize).toBe(
-    10,
-  );
-  expect((await readElectronConfig({ settings: { codeFontSize: 99 } })).settings.codeFontSize).toBe(
-    32,
-  );
+  expect(readElectronConfig({ settings: { codeFontSize: 8 } }).settings.codeFontSize).toBe(10);
+  expect(readElectronConfig({ settings: { codeFontSize: 99 } }).settings.codeFontSize).toBe(32);
 });
 
-test('electron config keeps custom walkthrough prompt text only when it is a string', async () => {
+test('electron config keeps custom walkthrough prompt text only when it is a string', () => {
   expect(
-    (
-      await readElectronConfig({
-        settings: {
-          walkthroughPrompt: 'Respond in German with product-review terminology.',
-        },
-      })
-    ).settings.walkthroughPrompt,
+    readElectronConfig({
+      settings: {
+        walkthroughPrompt: 'Respond in German with product-review terminology.',
+      },
+    }).settings.walkthroughPrompt,
   ).toBe('Respond in German with product-review terminology.');
 
   expect(
-    (
-      await readElectronConfig({
-        settings: {
-          walkthroughPrompt: ['Respond in German'],
-        },
-      })
-    ).settings.walkthroughPrompt,
+    readElectronConfig({
+      settings: {
+        walkthroughPrompt: ['Respond in German'],
+      },
+    }).settings.walkthroughPrompt,
   ).toBe('');
 });
 

--- a/core/__tests__/config-defaults.test.ts
+++ b/core/__tests__/config-defaults.test.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,6 +6,7 @@ import { expect, test } from 'vite-plus/test';
 import packageJson from '../../package.json' with { type: 'json' };
 import schema from '../config/codiff-config.schema.json' with { type: 'json' };
 import { createDefaultConfig } from '../config/defaults.ts';
+import { createTemporaryDirectory, createTemporaryEnvironment } from './helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { createDefaultConfig: createElectronDefaultConfig, readConfig } =
@@ -14,24 +15,13 @@ const { createDefaultConfig: createElectronDefaultConfig, readConfig } =
     readConfig: () => ReturnType<typeof createDefaultConfig>;
   };
 
-const readElectronConfig = (raw: unknown) => {
-  const home = mkdtempSync(join(tmpdir(), 'codiff-config-home.'));
-  const configDirectory = join(home, '.codiff');
-  const previousHome = process.env.HOME;
+const readElectronConfig = async (raw: unknown) => {
+  await using home = await createTemporaryDirectory('codiff-config-home.');
+  await using _environment = createTemporaryEnvironment({ HOME: home.path });
+  const configDirectory = join(home.path, '.codiff');
   mkdirSync(configDirectory);
   writeFileSync(join(configDirectory, 'codiff.jsonc'), `${JSON.stringify(raw)}\n`);
-  process.env.HOME = home;
-
-  try {
-    return readConfig();
-  } finally {
-    if (previousHome == null) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = previousHome;
-    }
-    rmSync(home, { force: true, recursive: true });
-  }
+  return readConfig();
 };
 
 const getSchemaDefaults = (section: 'keymap' | 'settings') =>
@@ -53,47 +43,58 @@ test('electron and renderer defaults match', () => {
   expect(createElectronDefaultConfig()).toEqual(createDefaultConfig());
 });
 
-test('electron config normalizes code font settings', () => {
-  expect(readElectronConfig({}).settings.codeFontFamily).toBe('');
-  expect(readElectronConfig({}).settings.codeFontSize).toBe(13);
+test('electron config normalizes code font settings', async () => {
+  expect((await readElectronConfig({})).settings.codeFontFamily).toBe('');
+  expect((await readElectronConfig({})).settings.codeFontSize).toBe(13);
 
   expect(
-    readElectronConfig({
-      settings: {
-        codeFontFamily: '  JetBrains Mono  ',
-        codeFontSize: 14.6,
-      },
-    }).settings,
+    (
+      await readElectronConfig({
+        settings: {
+          codeFontFamily: '  JetBrains Mono  ',
+          codeFontSize: 14.6,
+        },
+      })
+    ).settings,
   ).toMatchObject({
     codeFontFamily: 'JetBrains Mono',
     codeFontSize: 15,
   });
 
   expect(
-    readElectronConfig({ settings: { codeFontFamily: 42, codeFontSize: 'large' } }).settings,
+    (await readElectronConfig({ settings: { codeFontFamily: 42, codeFontSize: 'large' } }))
+      .settings,
   ).toMatchObject({
     codeFontFamily: '',
     codeFontSize: 13,
   });
-  expect(readElectronConfig({ settings: { codeFontSize: 8 } }).settings.codeFontSize).toBe(10);
-  expect(readElectronConfig({ settings: { codeFontSize: 99 } }).settings.codeFontSize).toBe(32);
+  expect((await readElectronConfig({ settings: { codeFontSize: 8 } })).settings.codeFontSize).toBe(
+    10,
+  );
+  expect((await readElectronConfig({ settings: { codeFontSize: 99 } })).settings.codeFontSize).toBe(
+    32,
+  );
 });
 
-test('electron config keeps custom walkthrough prompt text only when it is a string', () => {
+test('electron config keeps custom walkthrough prompt text only when it is a string', async () => {
   expect(
-    readElectronConfig({
-      settings: {
-        walkthroughPrompt: 'Respond in German with product-review terminology.',
-      },
-    }).settings.walkthroughPrompt,
+    (
+      await readElectronConfig({
+        settings: {
+          walkthroughPrompt: 'Respond in German with product-review terminology.',
+        },
+      })
+    ).settings.walkthroughPrompt,
   ).toBe('Respond in German with product-review terminology.');
 
   expect(
-    readElectronConfig({
-      settings: {
-        walkthroughPrompt: ['Respond in German'],
-      },
-    }).settings.walkthroughPrompt,
+    (
+      await readElectronConfig({
+        settings: {
+          walkthroughPrompt: ['Respond in German'],
+        },
+      })
+    ).settings.walkthroughPrompt,
   ).toBe('');
 });
 

--- a/core/__tests__/document-appearance.test.tsx
+++ b/core/__tests__/document-appearance.test.tsx
@@ -53,22 +53,22 @@ test('code font calculations normalize supported sizes and line heights', () => 
 test('document appearance manages theme and code font properties with cleanup', async () => {
   const root = document.documentElement;
   root.style.setProperty('--font-diff-mono', 'stale');
-  const view = await renderReact(
-    <DocumentAppearanceHarness
-      cleanupCodeFontProperties
-      clearEmptyCodeFontFamily
-      codeFontFamily=""
-      codeFontSize={14}
-      theme="dark"
-    />,
-  );
+  {
+    await using _view = await renderReact(
+      <DocumentAppearanceHarness
+        cleanupCodeFontProperties
+        clearEmptyCodeFontFamily
+        codeFontFamily=""
+        codeFontSize={14}
+        theme="dark"
+      />,
+    );
 
-  expect(root.getAttribute('data-theme')).toBe('dark');
-  expect(root.style.getPropertyValue('--font-diff-mono')).toBe('');
-  expect(root.style.getPropertyValue('--font-diff-size')).toBe('14px');
-  expect(root.style.getPropertyValue('--font-diff-line-height')).toBe('22px');
-
-  await view.cleanup();
+    expect(root.getAttribute('data-theme')).toBe('dark');
+    expect(root.style.getPropertyValue('--font-diff-mono')).toBe('');
+    expect(root.style.getPropertyValue('--font-diff-size')).toBe('14px');
+    expect(root.style.getPropertyValue('--font-diff-line-height')).toBe('22px');
+  }
 
   expect(root.style.getPropertyValue('--font-diff-mono')).toBe('');
   expect(root.style.getPropertyValue('--font-diff-size')).toBe('');
@@ -78,16 +78,16 @@ test('document appearance manages theme and code font properties with cleanup', 
 test('document appearance can preserve shared walkthrough font properties', async () => {
   const root = document.documentElement;
   root.style.setProperty('--font-diff-mono', 'existing');
-  const view = await renderReact(
-    <DocumentAppearanceHarness codeFontFamily="" codeFontSize={13} theme="system" />,
-  );
+  {
+    await using _view = await renderReact(
+      <DocumentAppearanceHarness codeFontFamily="" codeFontSize={13} theme="system" />,
+    );
 
-  expect(root.hasAttribute('data-theme')).toBe(false);
-  expect(root.style.getPropertyValue('--font-diff-mono')).toBe('existing');
-  expect(root.style.getPropertyValue('--font-diff-size')).toBe('13px');
-  expect(root.style.getPropertyValue('--font-diff-line-height')).toBe('20px');
-
-  await view.cleanup();
+    expect(root.hasAttribute('data-theme')).toBe(false);
+    expect(root.style.getPropertyValue('--font-diff-mono')).toBe('existing');
+    expect(root.style.getPropertyValue('--font-diff-size')).toBe('13px');
+    expect(root.style.getPropertyValue('--font-diff-line-height')).toBe('20px');
+  }
 
   expect(root.style.getPropertyValue('--font-diff-mono')).toBe('existing');
   expect(root.style.getPropertyValue('--font-diff-size')).toBe('13px');

--- a/core/__tests__/git-files.test.ts
+++ b/core/__tests__/git-files.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { afterAll, beforeAll, expect, test } from 'vite-plus/test';
 import { removeGitTestDirectory } from './helpers/git.ts';
+import { createTemporaryEnvironment } from './helpers/resources.ts';
 
 type FileContentResult = {
   binary: boolean;
@@ -228,36 +229,27 @@ test('batched Git file reads preserve text, binary, rename, missing, and size be
 test.each(batchCases)(
   'batches pull request content reads for $fileCount files',
   async ({ fileCount, maximumProcesses }) => {
-    const previousTrace = process.env.GIT_TRACE2_EVENT;
     const tracePath = join(repo, `trace-${fileCount}.jsonl`);
-    process.env.GIT_TRACE2_EVENT = tracePath;
+    await using _environment = createTemporaryEnvironment({ GIT_TRACE2_EVENT: tracePath });
 
-    try {
-      const paths = Array.from(
-        { length: fileCount },
-        (_, index) => `src/file-${index.toString().padStart(3, '0')}.ts`,
-      );
-      const [oldFiles, newFiles] = await Promise.all([
-        readGitFiles(repo, base, paths, { refScopedEmptyCacheKey: true }),
-        readGitFiles(repo, head, paths, { refScopedEmptyCacheKey: true }),
-      ]);
+    const paths = Array.from(
+      { length: fileCount },
+      (_, index) => `src/file-${index.toString().padStart(3, '0')}.ts`,
+    );
+    const [oldFiles, newFiles] = await Promise.all([
+      readGitFiles(repo, base, paths, { refScopedEmptyCacheKey: true }),
+      readGitFiles(repo, head, paths, { refScopedEmptyCacheKey: true }),
+    ]);
 
-      expect(oldFiles).toHaveLength(fileCount);
-      expect(newFiles).toHaveLength(fileCount);
+    expect(oldFiles).toHaveLength(fileCount);
+    expect(newFiles).toHaveLength(fileCount);
 
-      const processCount = (await readFile(tracePath, 'utf8'))
-        .trim()
-        .split('\n')
-        .filter(Boolean)
-        .map((line) => JSON.parse(line) as { event?: string })
-        .filter(({ event }) => event === 'version').length;
-      expect(processCount).toBeLessThanOrEqual(maximumProcesses);
-    } finally {
-      if (previousTrace == null) {
-        delete process.env.GIT_TRACE2_EVENT;
-      } else {
-        process.env.GIT_TRACE2_EVENT = previousTrace;
-      }
-    }
+    const processCount = (await readFile(tracePath, 'utf8'))
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { event?: string })
+      .filter(({ event }) => event === 'version').length;
+    expect(processCount).toBeLessThanOrEqual(maximumProcesses);
   },
 );

--- a/core/__tests__/git-state.test.ts
+++ b/core/__tests__/git-state.test.ts
@@ -12,7 +12,7 @@ import type {
   RepositoryState,
   ReviewSource,
 } from '../types.ts';
-import { getGitTestEnvironment, withGitTestEnvironment } from './helpers/git.ts';
+import { getGitTestEnvironment } from './helpers/git.ts';
 import { createTemporaryDirectory, createTemporaryEnvironment } from './helpers/resources.ts';
 
 type StatusEntry = {
@@ -275,12 +275,10 @@ const pullRequestCommentRequest = {
 };
 
 const withRepo = async (run: (repo: string) => Promise<void>) => {
-  await withGitTestEnvironment(async () => {
-    await using directory = await createTemporaryDirectory('codiff-git-state-');
-    const repo = await realpath(directory.path);
-    await git(repo, ['init']);
-    await run(repo);
-  });
+  await using directory = await createTemporaryDirectory('codiff-git-state-');
+  const repo = await realpath(directory.path);
+  await git(repo, ['init']);
+  await run(repo);
 };
 
 test('readRepositoryState marks generated files from gitattributes and path heuristics', async () => {

--- a/core/__tests__/git-state.test.ts
+++ b/core/__tests__/git-state.test.ts
@@ -12,7 +12,7 @@ import type {
   RepositoryState,
   ReviewSource,
 } from '../types.ts';
-import { getGitTestEnvironment, withGitTestEnvironment } from './helpers/git.ts';
+import { getGitTestEnvironmentForSubprocess, withGitTestEnvironment } from './helpers/git.ts';
 import { createTemporaryDirectory, createTemporaryEnvironment } from './helpers/resources.ts';
 
 type StatusEntry = {
@@ -169,7 +169,7 @@ const {
 const git = async (repo: string, args: ReadonlyArray<string>) => {
   const { stdout } = await execFileAsync('git', ['-C', repo, ...args], {
     encoding: 'utf8',
-    env: getGitTestEnvironment(),
+    env: getGitTestEnvironmentForSubprocess(),
     maxBuffer: 1024 * 1024 * 16,
   });
   return stdout;

--- a/core/__tests__/git-state.test.ts
+++ b/core/__tests__/git-state.test.ts
@@ -12,7 +12,7 @@ import type {
   RepositoryState,
   ReviewSource,
 } from '../types.ts';
-import { getGitTestEnvironment } from './helpers/git.ts';
+import { getGitTestEnvironment, withGitTestEnvironment } from './helpers/git.ts';
 import { createTemporaryDirectory, createTemporaryEnvironment } from './helpers/resources.ts';
 
 type StatusEntry = {
@@ -275,10 +275,12 @@ const pullRequestCommentRequest = {
 };
 
 const withRepo = async (run: (repo: string) => Promise<void>) => {
-  await using directory = await createTemporaryDirectory('codiff-git-state-');
-  const repo = await realpath(directory.path);
-  await git(repo, ['init']);
-  await run(repo);
+  await withGitTestEnvironment(async () => {
+    await using directory = await createTemporaryDirectory('codiff-git-state-');
+    const repo = await realpath(directory.path);
+    await git(repo, ['init']);
+    await run(repo);
+  });
 };
 
 test('readRepositoryState marks generated files from gitattributes and path heuristics', async () => {

--- a/core/__tests__/git-state.test.ts
+++ b/core/__tests__/git-state.test.ts
@@ -1,8 +1,7 @@
 import { execFile } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
@@ -13,7 +12,8 @@ import type {
   RepositoryState,
   ReviewSource,
 } from '../types.ts';
-import { getGitTestEnvironment, removeGitTestDirectory } from './helpers/git.ts';
+import { getGitTestEnvironment, withGitTestEnvironment } from './helpers/git.ts';
+import { createTemporaryDirectory, createTemporaryEnvironment } from './helpers/resources.ts';
 
 type StatusEntry = {
   oldPath?: string;
@@ -175,12 +175,6 @@ const git = async (repo: string, args: ReadonlyArray<string>) => {
   return stdout;
 };
 
-const createRepo = async () => {
-  const repo = await mkdtemp(join(tmpdir(), 'codiff-git-state-'));
-  await git(repo, ['init']);
-  return realpath(repo);
-};
-
 const writeRepoFile = async (repo: string, path: string, contents: string | Uint8Array) => {
   const absolutePath = join(repo, path);
   await mkdir(dirname(absolutePath), { recursive: true });
@@ -196,13 +190,12 @@ const withFakeGitHub = async (
   mode: 'diagnosis-fails' | 'no-pending-review' | 'pending-review' | 'success',
   callback: (repo: string, readCalls: () => ReadonlyArray<ReadonlyArray<string>>) => Promise<void>,
 ) => {
-  const repo = await createRepo();
-  const fakeBin = await mkdtemp(join(tmpdir(), 'codiff-github-'));
-  const fakeGh = join(fakeBin, 'gh');
-  const callsPath = join(fakeBin, 'calls.jsonl');
-  const originalPath = process.env.PATH;
-  const originalMode = process.env.CODIFF_GITHUB_TEST_MODE;
-  const originalCallsPath = process.env.CODIFF_GITHUB_TEST_CALLS;
+  await using repoDirectory = await createTemporaryDirectory('codiff-git-state-');
+  const repo = await realpath(repoDirectory.path);
+  await git(repo, ['init']);
+  await using fakeBinDirectory = await createTemporaryDirectory('codiff-github-');
+  const fakeGh = join(fakeBinDirectory.path, 'gh');
+  const callsPath = join(fakeBinDirectory.path, 'calls.jsonl');
 
   await git(repo, ['remote', 'add', 'origin', 'https://github.com/octo/example.git']);
   await writeFile(
@@ -252,36 +245,19 @@ process.stdin.on('end', () => {
 `,
   );
   await chmod(fakeGh, 0o755);
-  process.env.PATH = `${fakeBin}:${originalPath ?? ''}`;
-  process.env.CODIFF_GITHUB_TEST_MODE = mode;
-  process.env.CODIFF_GITHUB_TEST_CALLS = callsPath;
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_GITHUB_TEST_CALLS: callsPath,
+    CODIFF_GITHUB_TEST_MODE: mode,
+    PATH: `${fakeBinDirectory.path}:${process.env.PATH ?? ''}`,
+  });
 
-  try {
-    await callback(repo, () =>
-      readFileSync(callsPath, 'utf8')
-        .trim()
-        .split('\n')
-        .filter(Boolean)
-        .map((line) => (JSON.parse(line) as { args: ReadonlyArray<string> }).args),
-    );
-  } finally {
-    if (originalPath == null) {
-      delete process.env.PATH;
-    } else {
-      process.env.PATH = originalPath;
-    }
-    if (originalMode == null) {
-      delete process.env.CODIFF_GITHUB_TEST_MODE;
-    } else {
-      process.env.CODIFF_GITHUB_TEST_MODE = originalMode;
-    }
-    if (originalCallsPath == null) {
-      delete process.env.CODIFF_GITHUB_TEST_CALLS;
-    } else {
-      process.env.CODIFF_GITHUB_TEST_CALLS = originalCallsPath;
-    }
-    await Promise.all([removeGitTestDirectory(repo), removeGitTestDirectory(fakeBin)]);
-  }
+  await callback(repo, () =>
+    readFileSync(callsPath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => (JSON.parse(line) as { args: ReadonlyArray<string> }).args),
+  );
 };
 
 const pullRequestCommentRequest = {
@@ -299,12 +275,12 @@ const pullRequestCommentRequest = {
 };
 
 const withRepo = async (run: (repo: string) => Promise<void>) => {
-  const repo = await createRepo();
-  try {
+  await withGitTestEnvironment(async () => {
+    await using directory = await createTemporaryDirectory('codiff-git-state-');
+    const repo = await realpath(directory.path);
+    await git(repo, ['init']);
     await run(repo);
-  } finally {
-    await removeGitTestDirectory(repo);
-  }
+  });
 };
 
 test('readRepositoryState marks generated files from gitattributes and path heuristics', async () => {
@@ -362,8 +338,8 @@ test('historical generated attributes fall back to a temporary index without --s
       '.gitattributes',
       '*.api.ts -linguist-generated\npnpm-lock.yaml linguist-generated\n',
     );
-    const wrapperDirectory = await mkdtemp(join(tmpdir(), 'codiff-old-git-'));
-    const wrapperPath = join(wrapperDirectory, 'git');
+    await using wrapperDirectory = await createTemporaryDirectory('codiff-old-git-');
+    const wrapperPath = join(wrapperDirectory.path, 'git');
     await writeFile(
       wrapperPath,
       `#!/bin/sh
@@ -380,35 +356,21 @@ exec git "$@"
     );
     await chmod(wrapperPath, 0o755);
 
-    const originalPath = process.env.PATH;
-    const originalGitPath = process.env.CODIFF_TEST_ORIGINAL_PATH;
-    process.env.CODIFF_TEST_ORIGINAL_PATH = originalPath ?? '';
-    process.env.PATH = `${wrapperDirectory}:${originalPath ?? ''}`;
-    try {
-      const generatedStates = await readGeneratedAttributeStates(
-        repo,
-        ['client.api.ts', 'pnpm-lock.yaml'],
-        commit,
-      );
-      expect(generatedStates).toEqual(
-        new Map([
-          ['client.api.ts', true],
-          ['pnpm-lock.yaml', false],
-        ]),
-      );
-    } finally {
-      if (originalPath == null) {
-        delete process.env.PATH;
-      } else {
-        process.env.PATH = originalPath;
-      }
-      if (originalGitPath == null) {
-        delete process.env.CODIFF_TEST_ORIGINAL_PATH;
-      } else {
-        process.env.CODIFF_TEST_ORIGINAL_PATH = originalGitPath;
-      }
-      await removeGitTestDirectory(wrapperDirectory);
-    }
+    await using _environment = createTemporaryEnvironment({
+      CODIFF_TEST_ORIGINAL_PATH: process.env.PATH ?? '',
+      PATH: `${wrapperDirectory.path}:${process.env.PATH ?? ''}`,
+    });
+    const generatedStates = await readGeneratedAttributeStates(
+      repo,
+      ['client.api.ts', 'pnpm-lock.yaml'],
+      commit,
+    );
+    expect(generatedStates).toEqual(
+      new Map([
+        ['client.api.ts', true],
+        ['pnpm-lock.yaml', false],
+      ]),
+    );
   });
 });
 
@@ -1088,17 +1050,8 @@ test.sequential('clean implicit walkthrough reads use a bounded number of Git pr
     await commitAll(repo, 'initial commit');
 
     const tracePath = join(repo, '.git', 'walkthrough-trace.jsonl');
-    const previousTrace = process.env.GIT_TRACE2_EVENT;
-    process.env.GIT_TRACE2_EVENT = tracePath;
-    try {
-      await readWalkthroughRepositoryState(repo);
-    } finally {
-      if (previousTrace == null) {
-        delete process.env.GIT_TRACE2_EVENT;
-      } else {
-        process.env.GIT_TRACE2_EVENT = previousTrace;
-      }
-    }
+    await using _environment = createTemporaryEnvironment({ GIT_TRACE2_EVENT: tracePath });
+    await readWalkthroughRepositoryState(repo);
     const processCount = readFileSync(tracePath, 'utf8')
       .trim()
       .split('\n')
@@ -1790,12 +1743,8 @@ test('readRepositoryState defers medium committed files and loads them on demand
 });
 
 test('readRepositoryState rejects non-repository launch paths', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-not-a-repo-'));
-  try {
-    await expect(readRepositoryState(directory)).rejects.toThrow(/not a git repository/i);
-  } finally {
-    await removeGitTestDirectory(directory);
-  }
+  await using directory = await createTemporaryDirectory('codiff-not-a-repo-');
+  await expect(readRepositoryState(directory.path)).rejects.toThrow(/not a git repository/i);
 });
 
 test('readRepositoryState builds a diff for a base...head range', () =>

--- a/core/__tests__/gitlab.test.ts
+++ b/core/__tests__/gitlab.test.ts
@@ -1,11 +1,10 @@
 import { execFile } from 'node:child_process';
-import { chmod, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { describe, expect, test } from 'vite-plus/test';
-import { removeGitTestDirectory } from './helpers/git.ts';
+import { createTemporaryDirectory, createTemporaryEnvironment } from './helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 type GitLabPosition = Record<string, unknown> & {
@@ -64,26 +63,23 @@ type GlabCall = {
 const withFakeGitLab = async (
   callback: (repo: string, readCalls: () => Promise<ReadonlyArray<GlabCall>>) => Promise<void>,
 ) => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-gitlab-'));
-  const repo = join(directory, 'repo');
-  const fakeGlabPath = join(directory, 'glab');
-  const callsPath = join(directory, 'calls.jsonl');
-  const previousGlabPath = process.env.CODIFF_GLAB_PATH;
-  const previousCallsPath = process.env.CODIFF_GLAB_TEST_CALLS;
+  await using directory = await createTemporaryDirectory('codiff-gitlab-');
+  const repo = join(directory.path, 'repo');
+  const fakeGlabPath = join(directory.path, 'glab');
+  const callsPath = join(directory.path, 'calls.jsonl');
 
-  try {
-    await execFileAsync('git', ['init', repo]);
-    await execFileAsync('git', [
-      '-C',
-      repo,
-      'remote',
-      'add',
-      'origin',
-      'ssh://git@gitlab.example.com/group/project.git',
-    ]);
-    await writeFile(
-      fakeGlabPath,
-      `#!/usr/bin/env node
+  await execFileAsync('git', ['init', repo]);
+  await execFileAsync('git', [
+    '-C',
+    repo,
+    'remote',
+    'add',
+    'origin',
+    'ssh://git@gitlab.example.com/group/project.git',
+  ]);
+  await writeFile(
+    fakeGlabPath,
+    `#!/usr/bin/env node
 const { appendFileSync } = require('node:fs');
 const args = process.argv.slice(2);
 const endpoint = args.at(-1) || '';
@@ -117,31 +113,20 @@ process.stdin.on('end', () => {
   process.stdout.write('{}');
 });
 `,
-    );
-    await chmod(fakeGlabPath, 0o755);
-    process.env.CODIFF_GLAB_PATH = fakeGlabPath;
-    process.env.CODIFF_GLAB_TEST_CALLS = callsPath;
+  );
+  await chmod(fakeGlabPath, 0o755);
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_GLAB_PATH: fakeGlabPath,
+    CODIFF_GLAB_TEST_CALLS: callsPath,
+  });
 
-    await callback(repo, async () =>
-      (await readFile(callsPath, 'utf8'))
-        .trim()
-        .split('\n')
-        .filter(Boolean)
-        .map((line) => JSON.parse(line) as GlabCall),
-    );
-  } finally {
-    if (previousGlabPath == null) {
-      delete process.env.CODIFF_GLAB_PATH;
-    } else {
-      process.env.CODIFF_GLAB_PATH = previousGlabPath;
-    }
-    if (previousCallsPath == null) {
-      delete process.env.CODIFF_GLAB_TEST_CALLS;
-    } else {
-      process.env.CODIFF_GLAB_TEST_CALLS = previousCallsPath;
-    }
-    await removeGitTestDirectory(directory);
-  }
+  await callback(repo, async () =>
+    (await readFile(callsPath, 'utf8'))
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as GlabCall),
+  );
 };
 
 describe('GitLab merge requests', () => {

--- a/core/__tests__/helpers/cli.ts
+++ b/core/__tests__/helpers/cli.ts
@@ -5,14 +5,7 @@ import { join } from 'node:path';
 const loggerScript =
   '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n';
 
-export type FakeOpenLogger = AsyncDisposable & {
-  directory: string;
-  env: NodeJS.ProcessEnv;
-  readArgs: () => Promise<Array<string>>;
-  reset: () => Promise<void>;
-};
-
-export const createFakeOpenLogger = async (): Promise<FakeOpenLogger> => {
+export const createFakeOpenLogger = async () => {
   const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
   const fakeBin = join(directory, 'bin');
   const logPath = join(directory, 'open-args.txt');
@@ -37,17 +30,7 @@ export const createFakeOpenLogger = async (): Promise<FakeOpenLogger> => {
   };
 };
 
-export type FakeCommandLogger = AsyncDisposable & {
-  commandPath: string;
-  directory: string;
-  env: NodeJS.ProcessEnv;
-  readArgs: () => Promise<Array<string>>;
-};
-
-export const createFakeCommandLogger = async (
-  prefix: string,
-  commandName: string,
-): Promise<FakeCommandLogger> => {
+export const createFakeCommandLogger = async (prefix: string, commandName: string) => {
   const directory = await mkdtemp(join(tmpdir(), prefix));
   const commandPath = join(directory, commandName);
   const logPath = join(directory, 'args.txt');

--- a/core/__tests__/helpers/cli.ts
+++ b/core/__tests__/helpers/cli.ts
@@ -5,7 +5,14 @@ import { join } from 'node:path';
 const loggerScript =
   '#!/bin/sh\nfor arg in "$@"; do\n  printf "%s\\n" "$arg" >> "$OPEN_ARGS_FILE"\ndone\n';
 
-export const createFakeOpenLogger = async () => {
+export type FakeOpenLogger = AsyncDisposable & {
+  directory: string;
+  env: NodeJS.ProcessEnv;
+  readArgs: () => Promise<Array<string>>;
+  reset: () => Promise<void>;
+};
+
+export const createFakeOpenLogger = async (): Promise<FakeOpenLogger> => {
   const directory = await mkdtemp(join(tmpdir(), 'codiff-app-helper-'));
   const fakeBin = join(directory, 'bin');
   const logPath = join(directory, 'open-args.txt');
@@ -16,7 +23,6 @@ export const createFakeOpenLogger = async () => {
   await chmod(openPath, 0o755);
 
   return {
-    cleanup: () => rm(directory, { force: true, recursive: true }),
     directory,
     env: {
       ...process.env,
@@ -25,10 +31,23 @@ export const createFakeOpenLogger = async () => {
     },
     readArgs: async () => (await readFile(logPath, 'utf8')).trim().split('\n'),
     reset: () => writeFile(logPath, ''),
+    async [Symbol.asyncDispose]() {
+      await rm(directory, { force: true, recursive: true });
+    },
   };
 };
 
-export const createFakeCommandLogger = async (prefix: string, commandName: string) => {
+export type FakeCommandLogger = AsyncDisposable & {
+  commandPath: string;
+  directory: string;
+  env: NodeJS.ProcessEnv;
+  readArgs: () => Promise<Array<string>>;
+};
+
+export const createFakeCommandLogger = async (
+  prefix: string,
+  commandName: string,
+): Promise<FakeCommandLogger> => {
   const directory = await mkdtemp(join(tmpdir(), prefix));
   const commandPath = join(directory, commandName);
   const logPath = join(directory, 'args.txt');
@@ -37,7 +56,6 @@ export const createFakeCommandLogger = async (prefix: string, commandName: strin
   await chmod(commandPath, 0o755);
 
   return {
-    cleanup: () => rm(directory, { force: true, recursive: true }),
     commandPath,
     directory,
     env: {
@@ -45,5 +63,8 @@ export const createFakeCommandLogger = async (prefix: string, commandName: strin
       OPEN_ARGS_FILE: logPath,
     },
     readArgs: async () => (await readFile(logPath, 'utf8')).trim().split('\n'),
+    async [Symbol.asyncDispose]() {
+      await rm(directory, { force: true, recursive: true });
+    },
   };
 };

--- a/core/__tests__/helpers/git.ts
+++ b/core/__tests__/helpers/git.ts
@@ -1,4 +1,8 @@
 import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createTemporaryEnvironment } from './resources.ts';
+
+const emptyGitHooksPath = join(import.meta.dirname, 'empty-git-hooks');
 
 export const getGitTestEnvironment = (
   overrides: Readonly<Record<string, string | undefined>> = {},
@@ -8,13 +12,15 @@ export const getGitTestEnvironment = (
   GIT_AUTHOR_NAME: 'Codiff Test',
   GIT_COMMITTER_EMAIL: 'codiff@example.com',
   GIT_COMMITTER_NAME: 'Codiff Test',
-  GIT_CONFIG_COUNT: '3',
+  GIT_CONFIG_COUNT: '4',
   GIT_CONFIG_KEY_0: 'core.excludesfile',
   GIT_CONFIG_KEY_1: 'commit.gpgSign',
   GIT_CONFIG_KEY_2: 'tag.gpgSign',
+  GIT_CONFIG_KEY_3: 'core.hooksPath',
   GIT_CONFIG_VALUE_0: '/dev/null',
   GIT_CONFIG_VALUE_1: 'false',
   GIT_CONFIG_VALUE_2: 'false',
+  GIT_CONFIG_VALUE_3: emptyGitHooksPath,
   ...overrides,
 });
 
@@ -31,31 +37,14 @@ export const withGitTestEnvironment = async <T>(
   overrides: Readonly<Record<string, string | undefined>> = {},
 ) => {
   const environment = getGitTestEnvironment(overrides);
-  const keys = Object.keys(environment).filter(
-    (key) =>
-      key.startsWith('GIT_AUTHOR_') ||
-      key.startsWith('GIT_COMMITTER_') ||
-      key.startsWith('GIT_CONFIG_'),
+  const scopedEnvironment = Object.fromEntries(
+    Object.entries(environment).filter(
+      ([key]) =>
+        key.startsWith('GIT_AUTHOR_') ||
+        key.startsWith('GIT_COMMITTER_') ||
+        key.startsWith('GIT_CONFIG_'),
+    ),
   );
-  const previous = new Map(keys.map((key) => [key, process.env[key]]));
-
-  for (const key of keys) {
-    const value = environment[key];
-    if (value == null) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-  try {
-    return await callback();
-  } finally {
-    for (const [key, value] of previous) {
-      if (value == null) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-  }
+  await using _environment = createTemporaryEnvironment(scopedEnvironment);
+  return await callback();
 };

--- a/core/__tests__/helpers/git.ts
+++ b/core/__tests__/helpers/git.ts
@@ -1,15 +1,10 @@
-import { mkdtempSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { createTemporaryEnvironment } from './resources.ts';
-
-const emptyGitHooksPath = mkdtempSync(join(tmpdir(), 'codiff-empty-git-hooks-'));
 
 const gitHookIsolation = {
   GIT_CONFIG_COUNT: '4',
   GIT_CONFIG_KEY_3: 'core.hooksPath',
-  GIT_CONFIG_VALUE_3: emptyGitHooksPath,
+  GIT_CONFIG_VALUE_3: '/dev/null',
 } as const;
 
 export const getGitTestEnvironment = (

--- a/core/__tests__/helpers/git.ts
+++ b/core/__tests__/helpers/git.ts
@@ -1,5 +1,10 @@
+import { mkdtempSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createTemporaryEnvironment } from './resources.ts';
+
+const emptyGitHooksPath = mkdtempSync(join(tmpdir(), 'codiff-empty-git-hooks-'));
 
 export const getGitTestEnvironment = (
   overrides: Readonly<Record<string, string | undefined>> = {},
@@ -9,13 +14,15 @@ export const getGitTestEnvironment = (
   GIT_AUTHOR_NAME: 'Codiff Test',
   GIT_COMMITTER_EMAIL: 'codiff@example.com',
   GIT_COMMITTER_NAME: 'Codiff Test',
-  GIT_CONFIG_COUNT: '3',
+  GIT_CONFIG_COUNT: '4',
   GIT_CONFIG_KEY_0: 'core.excludesfile',
   GIT_CONFIG_KEY_1: 'commit.gpgSign',
   GIT_CONFIG_KEY_2: 'tag.gpgSign',
+  GIT_CONFIG_KEY_3: 'core.hooksPath',
   GIT_CONFIG_VALUE_0: '/dev/null',
   GIT_CONFIG_VALUE_1: 'false',
   GIT_CONFIG_VALUE_2: 'false',
+  GIT_CONFIG_VALUE_3: emptyGitHooksPath,
   ...overrides,
 });
 

--- a/core/__tests__/helpers/git.ts
+++ b/core/__tests__/helpers/git.ts
@@ -1,8 +1,10 @@
+import { mkdtempSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createTemporaryEnvironment } from './resources.ts';
 
-const emptyGitHooksPath = join(import.meta.dirname, 'empty-git-hooks');
+const emptyGitHooksPath = mkdtempSync(join(tmpdir(), 'codiff-empty-git-hooks-'));
 
 export const getGitTestEnvironment = (
   overrides: Readonly<Record<string, string | undefined>> = {},

--- a/core/__tests__/helpers/git.ts
+++ b/core/__tests__/helpers/git.ts
@@ -6,6 +6,12 @@ import { createTemporaryEnvironment } from './resources.ts';
 
 const emptyGitHooksPath = mkdtempSync(join(tmpdir(), 'codiff-empty-git-hooks-'));
 
+const gitHookIsolation = {
+  GIT_CONFIG_COUNT: '4',
+  GIT_CONFIG_KEY_3: 'core.hooksPath',
+  GIT_CONFIG_VALUE_3: emptyGitHooksPath,
+} as const;
+
 export const getGitTestEnvironment = (
   overrides: Readonly<Record<string, string | undefined>> = {},
 ): NodeJS.ProcessEnv => ({
@@ -14,17 +20,19 @@ export const getGitTestEnvironment = (
   GIT_AUTHOR_NAME: 'Codiff Test',
   GIT_COMMITTER_EMAIL: 'codiff@example.com',
   GIT_COMMITTER_NAME: 'Codiff Test',
-  GIT_CONFIG_COUNT: '4',
+  GIT_CONFIG_COUNT: '3',
   GIT_CONFIG_KEY_0: 'core.excludesfile',
   GIT_CONFIG_KEY_1: 'commit.gpgSign',
   GIT_CONFIG_KEY_2: 'tag.gpgSign',
-  GIT_CONFIG_KEY_3: 'core.hooksPath',
   GIT_CONFIG_VALUE_0: '/dev/null',
   GIT_CONFIG_VALUE_1: 'false',
   GIT_CONFIG_VALUE_2: 'false',
-  GIT_CONFIG_VALUE_3: emptyGitHooksPath,
   ...overrides,
 });
+
+export const getGitTestEnvironmentForSubprocess = (
+  overrides: Readonly<Record<string, string | undefined>> = {},
+) => getGitTestEnvironment({ ...gitHookIsolation, ...overrides });
 
 export const removeGitTestDirectory = (path: string) =>
   rm(path, {
@@ -38,7 +46,7 @@ export const withGitTestEnvironment = async <T>(
   callback: () => Promise<T>,
   overrides: Readonly<Record<string, string | undefined>> = {},
 ) => {
-  const environment = getGitTestEnvironment(overrides);
+  const environment = getGitTestEnvironmentForSubprocess(overrides);
   const keys = Object.keys(environment).filter(
     (key) =>
       key.startsWith('GIT_AUTHOR_') ||

--- a/core/__tests__/helpers/git.ts
+++ b/core/__tests__/helpers/git.ts
@@ -1,10 +1,5 @@
-import { mkdtempSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { createTemporaryEnvironment } from './resources.ts';
-
-const emptyGitHooksPath = mkdtempSync(join(tmpdir(), 'codiff-empty-git-hooks-'));
 
 export const getGitTestEnvironment = (
   overrides: Readonly<Record<string, string | undefined>> = {},
@@ -14,15 +9,13 @@ export const getGitTestEnvironment = (
   GIT_AUTHOR_NAME: 'Codiff Test',
   GIT_COMMITTER_EMAIL: 'codiff@example.com',
   GIT_COMMITTER_NAME: 'Codiff Test',
-  GIT_CONFIG_COUNT: '4',
+  GIT_CONFIG_COUNT: '3',
   GIT_CONFIG_KEY_0: 'core.excludesfile',
   GIT_CONFIG_KEY_1: 'commit.gpgSign',
   GIT_CONFIG_KEY_2: 'tag.gpgSign',
-  GIT_CONFIG_KEY_3: 'core.hooksPath',
   GIT_CONFIG_VALUE_0: '/dev/null',
   GIT_CONFIG_VALUE_1: 'false',
   GIT_CONFIG_VALUE_2: 'false',
-  GIT_CONFIG_VALUE_3: emptyGitHooksPath,
   ...overrides,
 });
 
@@ -39,14 +32,16 @@ export const withGitTestEnvironment = async <T>(
   overrides: Readonly<Record<string, string | undefined>> = {},
 ) => {
   const environment = getGitTestEnvironment(overrides);
-  const scopedEnvironment = Object.fromEntries(
-    Object.entries(environment).filter(
-      ([key]) =>
-        key.startsWith('GIT_AUTHOR_') ||
-        key.startsWith('GIT_COMMITTER_') ||
-        key.startsWith('GIT_CONFIG_'),
-    ),
+  const keys = Object.keys(environment).filter(
+    (key) =>
+      key.startsWith('GIT_AUTHOR_') ||
+      key.startsWith('GIT_COMMITTER_') ||
+      key.startsWith('GIT_CONFIG_'),
   );
+  const scopedEnvironment: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    scopedEnvironment[key] = environment[key];
+  }
   await using _environment = createTemporaryEnvironment(scopedEnvironment);
   return await callback();
 };

--- a/core/__tests__/helpers/react.tsx
+++ b/core/__tests__/helpers/react.tsx
@@ -1,7 +1,13 @@
 import { act, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-export const renderReact = async (element: ReactNode) => {
+export type ReactRenderResult = AsyncDisposable & {
+  cleanup: () => Promise<void>;
+  container: HTMLDivElement;
+  rerender: (nextElement: ReactNode) => Promise<void>;
+};
+
+export const renderReact = async (element: ReactNode): Promise<ReactRenderResult> => {
   const container = document.createElement('div');
   document.body.append(container);
   const root = createRoot(container);
@@ -10,18 +16,23 @@ export const renderReact = async (element: ReactNode) => {
     root.render(element);
   });
 
+  const cleanup = async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  };
+
   return {
-    cleanup: async () => {
-      await act(async () => {
-        root.unmount();
-      });
-      container.remove();
-    },
+    cleanup,
     container,
     rerender: async (nextElement: ReactNode) => {
       await act(async () => {
         root.render(nextElement);
       });
+    },
+    async [Symbol.asyncDispose]() {
+      await cleanup();
     },
   };
 };

--- a/core/__tests__/helpers/react.tsx
+++ b/core/__tests__/helpers/react.tsx
@@ -1,13 +1,7 @@
 import { act, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-export type ReactRenderResult = AsyncDisposable & {
-  cleanup: () => Promise<void>;
-  container: HTMLDivElement;
-  rerender: (nextElement: ReactNode) => Promise<void>;
-};
-
-export const renderReact = async (element: ReactNode): Promise<ReactRenderResult> => {
+export const renderReact = async (element: ReactNode) => {
   const container = document.createElement('div');
   document.body.append(container);
   const root = createRoot(container);
@@ -16,15 +10,7 @@ export const renderReact = async (element: ReactNode): Promise<ReactRenderResult
     root.render(element);
   });
 
-  const cleanup = async () => {
-    await act(async () => {
-      root.unmount();
-    });
-    container.remove();
-  };
-
   return {
-    cleanup,
     container,
     rerender: async (nextElement: ReactNode) => {
       await act(async () => {
@@ -32,7 +18,10 @@ export const renderReact = async (element: ReactNode): Promise<ReactRenderResult
       });
     },
     async [Symbol.asyncDispose]() {
-      await cleanup();
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
     },
   };
 };

--- a/core/__tests__/helpers/resources.ts
+++ b/core/__tests__/helpers/resources.ts
@@ -1,8 +1,19 @@
+import { mkdtempSync, rmSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { createServer, type RequestListener, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { removeGitTestDirectory } from './git.ts';
+
+export const createTemporaryDirectorySync = (prefix: string) => {
+  const path = mkdtempSync(join(tmpdir(), prefix));
+  return {
+    path,
+    [Symbol.dispose]() {
+      rmSync(path, { force: true, recursive: true });
+    },
+  };
+};
 
 export const createTemporaryDirectory = async (prefix: string) => {
   const path = await mkdtemp(join(tmpdir(), prefix));
@@ -18,7 +29,7 @@ export const createTemporaryWorkingDirectory = (cwd: string) => {
   const previousCwd = process.cwd();
   process.chdir(cwd);
   return {
-    async [Symbol.asyncDispose]() {
+    [Symbol.dispose]() {
       process.chdir(previousCwd);
     },
   };
@@ -28,11 +39,12 @@ export const bindDisposableHttpServer = async (server: Server, host = '127.0.0.1
   await new Promise<void>((resolveListen) => {
     server.listen(0, host, resolveListen);
   });
-  return Object.assign(server, {
+  return {
+    ...server,
     async [Symbol.asyncDispose]() {
       await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
     },
-  });
+  };
 };
 
 export const createDisposableHttpServer = async (handler: RequestListener, host = '127.0.0.1') =>
@@ -51,7 +63,7 @@ export const createTemporaryEnvironment = (
     }
   }
   return {
-    async [Symbol.asyncDispose]() {
+    [Symbol.dispose]() {
       for (const [key, value] of previous) {
         if (value == null) {
           delete process.env[key];

--- a/core/__tests__/helpers/resources.ts
+++ b/core/__tests__/helpers/resources.ts
@@ -1,0 +1,80 @@
+import { mkdtemp } from 'node:fs/promises';
+/**
+ * Test helpers that return `AsyncDisposable` values for `await using`.
+ *
+ * Factory names stay verb-based (`createTemporaryDirectory`, not `*Using` /
+ * `*Disposable`); the return type signals that callers must bind with
+ * `await using`. Prefer `withGitTestEnvironment` when a callback scope is enough.
+ */
+import { createServer, type RequestListener, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { removeGitTestDirectory } from './git.ts';
+
+export type DisposableHttpServer = AsyncDisposable & Server;
+
+export type TemporaryDirectory = AsyncDisposable & { path: string };
+
+export const createTemporaryDirectory = async (prefix: string): Promise<TemporaryDirectory> => {
+  const path = await mkdtemp(join(tmpdir(), prefix));
+  return {
+    path,
+    async [Symbol.asyncDispose]() {
+      await removeGitTestDirectory(path);
+    },
+  };
+};
+
+export const createTemporaryWorkingDirectory = (cwd: string): AsyncDisposable => {
+  const previousCwd = process.cwd();
+  process.chdir(cwd);
+  return {
+    async [Symbol.asyncDispose]() {
+      process.chdir(previousCwd);
+    },
+  };
+};
+
+export const bindDisposableHttpServer = async (
+  server: Server,
+  host = '127.0.0.1',
+): Promise<DisposableHttpServer> => {
+  await new Promise<void>((resolveListen) => {
+    server.listen(0, host, resolveListen);
+  });
+  return Object.assign(server, {
+    async [Symbol.asyncDispose]() {
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    },
+  });
+};
+
+export const createDisposableHttpServer = async (
+  handler: RequestListener,
+  host = '127.0.0.1',
+): Promise<DisposableHttpServer> => bindDisposableHttpServer(createServer(handler), host);
+
+export const createTemporaryEnvironment = (
+  overrides: Readonly<Record<string, string | undefined>>,
+): AsyncDisposable => {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(overrides)) {
+    previous.set(key, process.env[key]);
+    if (value == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  return {
+    async [Symbol.asyncDispose]() {
+      for (const [key, value] of previous) {
+        if (value == null) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    },
+  };
+};

--- a/core/__tests__/helpers/resources.ts
+++ b/core/__tests__/helpers/resources.ts
@@ -3,19 +3,15 @@ import { mkdtemp } from 'node:fs/promises';
  * Test helpers that return `AsyncDisposable` values for `await using`.
  *
  * Factory names stay verb-based (`createTemporaryDirectory`, not `*Using` /
- * `*Disposable`); the return type signals that callers must bind with
- * `await using`. Prefer `withGitTestEnvironment` when a callback scope is enough.
+ * `*Disposable`); callers must bind with `await using`. Prefer
+ * `withGitTestEnvironment` when a callback scope is enough.
  */
 import { createServer, type RequestListener, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { removeGitTestDirectory } from './git.ts';
 
-export type DisposableHttpServer = AsyncDisposable & Server;
-
-export type TemporaryDirectory = AsyncDisposable & { path: string };
-
-export const createTemporaryDirectory = async (prefix: string): Promise<TemporaryDirectory> => {
+export const createTemporaryDirectory = async (prefix: string) => {
   const path = await mkdtemp(join(tmpdir(), prefix));
   return {
     path,
@@ -25,7 +21,7 @@ export const createTemporaryDirectory = async (prefix: string): Promise<Temporar
   };
 };
 
-export const createTemporaryWorkingDirectory = (cwd: string): AsyncDisposable => {
+export const createTemporaryWorkingDirectory = (cwd: string) => {
   const previousCwd = process.cwd();
   process.chdir(cwd);
   return {
@@ -35,10 +31,7 @@ export const createTemporaryWorkingDirectory = (cwd: string): AsyncDisposable =>
   };
 };
 
-export const bindDisposableHttpServer = async (
-  server: Server,
-  host = '127.0.0.1',
-): Promise<DisposableHttpServer> => {
+export const bindDisposableHttpServer = async (server: Server, host = '127.0.0.1') => {
   await new Promise<void>((resolveListen) => {
     server.listen(0, host, resolveListen);
   });
@@ -49,14 +42,12 @@ export const bindDisposableHttpServer = async (
   });
 };
 
-export const createDisposableHttpServer = async (
-  handler: RequestListener,
-  host = '127.0.0.1',
-): Promise<DisposableHttpServer> => bindDisposableHttpServer(createServer(handler), host);
+export const createDisposableHttpServer = async (handler: RequestListener, host = '127.0.0.1') =>
+  bindDisposableHttpServer(createServer(handler), host);
 
 export const createTemporaryEnvironment = (
   overrides: Readonly<Record<string, string | undefined>>,
-): AsyncDisposable => {
+) => {
   const previous = new Map<string, string | undefined>();
   for (const [key, value] of Object.entries(overrides)) {
     previous.set(key, process.env[key]);

--- a/core/__tests__/helpers/resources.ts
+++ b/core/__tests__/helpers/resources.ts
@@ -1,11 +1,4 @@
 import { mkdtemp } from 'node:fs/promises';
-/**
- * Test helpers that return `AsyncDisposable` values for `await using`.
- *
- * Factory names stay verb-based (`createTemporaryDirectory`, not `*Using` /
- * `*Disposable`); callers must bind with `await using`. Prefer
- * `withGitTestEnvironment` when a callback scope is enough.
- */
 import { createServer, type RequestListener, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/core/__tests__/plan-result.test.ts
+++ b/core/__tests__/plan-result.test.ts
@@ -1,72 +1,60 @@
 import { EventEmitter } from 'node:events';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
 import { waitForPlanResult } from '../../bin/plan-result.js';
+import { createTemporaryDirectory } from './helpers/resources.ts';
 
 test('plan result waiting only applies the timeout before the app opens', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-result-'));
-  const resultPath = join(directory, 'result.json');
+  await using directory = await createTemporaryDirectory('codiff-plan-result-');
+  const resultPath = join(directory.path, 'result.json');
   const child = new EventEmitter();
 
-  try {
-    await writeFile(resultPath, '{"pid":1234,"status":"open"}\n');
-    const result = waitForPlanResult(resultPath, child, {
-      isRunning: () => true,
-      openTimeoutMs: 10,
-      pollIntervalMs: 2,
-    });
-    setTimeout(() => {
-      void writeFile(resultPath, '{"pid":1234,"status":"done"}\n');
-    }, 30);
+  await writeFile(resultPath, '{"pid":1234,"status":"open"}\n');
+  const result = waitForPlanResult(resultPath, child, {
+    isRunning: () => true,
+    openTimeoutMs: 10,
+    pollIntervalMs: 2,
+  });
+  setTimeout(() => {
+    void writeFile(resultPath, '{"pid":1234,"status":"done"}\n');
+  }, 30);
 
-    await expect(result).resolves.toEqual({ pid: 1234, status: 'done' });
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(result).resolves.toEqual({ pid: 1234, status: 'done' });
 });
 
 test('plan result waiting fails when the app never opens', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-result-'));
-  const resultPath = join(directory, 'result.json');
+  await using directory = await createTemporaryDirectory('codiff-plan-result-');
+  const resultPath = join(directory.path, 'result.json');
   const child = new EventEmitter();
 
-  try {
-    await expect(
-      waitForPlanResult(resultPath, child, {
-        isRunning: () => true,
-        openTimeoutMs: 10,
-        pollIntervalMs: 2,
-      }),
-    ).rejects.toThrow('Codiff did not open the plan within 0.01 seconds.');
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(
+    waitForPlanResult(resultPath, child, {
+      isRunning: () => true,
+      openTimeoutMs: 10,
+      pollIntervalMs: 2,
+    }),
+  ).rejects.toThrow('Codiff did not open the plan within 0.01 seconds.');
 });
 
 test('plan result waiting cancels when the opened app exits', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-result-'));
-  const resultPath = join(directory, 'result.json');
+  await using directory = await createTemporaryDirectory('codiff-plan-result-');
+  const resultPath = join(directory.path, 'result.json');
   const child = new EventEmitter();
 
-  try {
-    await writeFile(resultPath, '{"pid":1234,"status":"open"}\n');
-    await expect(
-      waitForPlanResult(resultPath, child, {
-        isRunning: () => false,
-        openTimeoutMs: 10,
-        pollIntervalMs: 2,
-      }),
-    ).resolves.toEqual({ status: 'canceled' });
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await writeFile(resultPath, '{"pid":1234,"status":"open"}\n');
+  await expect(
+    waitForPlanResult(resultPath, child, {
+      isRunning: () => false,
+      openTimeoutMs: 10,
+      pollIntervalMs: 2,
+    }),
+  ).resolves.toEqual({ status: 'canceled' });
 });
 
 test('plan result waiting returns the edited document identity and review packet', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-result-'));
-  const resultPath = join(directory, 'result.json');
+  await using directory = await createTemporaryDirectory('codiff-plan-result-');
+  const resultPath = join(directory.path, 'result.json');
   const child = new EventEmitter();
   const result = {
     path: '/tmp/plan.md',
@@ -83,23 +71,19 @@ test('plan result waiting returns the edited document identity and review packet
     status: 'done',
   };
 
-  try {
-    await writeFile(resultPath, `${JSON.stringify(result)}\n`);
-    await expect(
-      waitForPlanResult(resultPath, child, {
-        isRunning: () => true,
-        openTimeoutMs: 10,
-        pollIntervalMs: 2,
-      }),
-    ).resolves.toEqual(result);
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await writeFile(resultPath, `${JSON.stringify(result)}\n`);
+  await expect(
+    waitForPlanResult(resultPath, child, {
+      isRunning: () => true,
+      openTimeoutMs: 10,
+      pollIntervalMs: 2,
+    }),
+  ).resolves.toEqual(result);
 });
 
 test('plan result waiting returns a closed handoff with its review packet', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-result-'));
-  const resultPath = join(directory, 'result.json');
+  await using directory = await createTemporaryDirectory('codiff-plan-result-');
+  const resultPath = join(directory.path, 'result.json');
   const child = new EventEmitter();
   const result = {
     documentChanged: true,
@@ -117,16 +101,12 @@ test('plan result waiting returns a closed handoff with its review packet', asyn
     status: 'closed',
   };
 
-  try {
-    await writeFile(resultPath, `${JSON.stringify(result)}\n`);
-    await expect(
-      waitForPlanResult(resultPath, child, {
-        isRunning: () => true,
-        openTimeoutMs: 10,
-        pollIntervalMs: 2,
-      }),
-    ).resolves.toEqual(result);
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await writeFile(resultPath, `${JSON.stringify(result)}\n`);
+  await expect(
+    waitForPlanResult(resultPath, child, {
+      isRunning: () => true,
+      openTimeoutMs: 10,
+      pollIntervalMs: 2,
+    }),
+  ).resolves.toEqual(result);
 });

--- a/core/__tests__/review-comment-hooks.test.tsx
+++ b/core/__tests__/review-comment-hooks.test.tsx
@@ -67,77 +67,71 @@ const renderReviewCommentDrafts = async ({
     }
     return stateRef.current;
   };
-  return { getState, onCommentFileChange, view };
+  return Object.assign(view, { getState, onCommentFileChange });
 };
 
 test('review comment drafts create, update, focus, and delete local comments', async () => {
   const randomUUID = vi
     .spyOn(crypto, 'randomUUID')
     .mockReturnValue('00000000-0000-4000-8000-000000000001');
-  const { getState, onCommentFileChange, view } = await renderReviewCommentDrafts();
+  await using view = await renderReviewCommentDrafts();
+  const { getState, onCommentFileChange } = view;
 
-  try {
-    const comment = createComment('ignored');
-    const { body: _body, id: _id, ...location } = comment;
-    await act(async () => {
-      getState().createComment(location);
-    });
-
-    expect(getState().comments).toEqual([
-      {
-        ...location,
-        body: '',
-        id: '00000000-0000-4000-8000-000000000001',
-      },
-    ]);
-    expect(getState().focusCommentId).toBe('00000000-0000-4000-8000-000000000001');
-    expect(getState().focusCommentRequest).toBe(1);
-    expect(onCommentFileChange).toHaveBeenLastCalledWith('src/app.ts');
-
-    await act(async () => {
-      getState().updateComment('00000000-0000-4000-8000-000000000001', 'Review this');
-      getState().updateActiveReviewCommentDraft({
-        body: 'Review this',
-        id: '00000000-0000-4000-8000-000000000001',
-      });
-    });
-    expect(getState().comments[0]?.body).toBe('Review this');
-    expect(getState().activeReviewCommentDraftState).toEqual({
-      body: 'pending',
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      randomUUID.mockRestore();
+    },
+  };
+  const comment = createComment('ignored');
+  const { body: _body, id: _id, ...location } = comment;
+  await act(async () => {
+    getState().createComment(location);
+  });
+  expect(getState().comments).toEqual([
+    {
+      ...location,
+      body: '',
+      id: '00000000-0000-4000-8000-000000000001',
+    },
+  ]);
+  expect(getState().focusCommentId).toBe('00000000-0000-4000-8000-000000000001');
+  expect(getState().focusCommentRequest).toBe(1);
+  expect(onCommentFileChange).toHaveBeenLastCalledWith('src/app.ts');
+  await act(async () => {
+    getState().updateComment('00000000-0000-4000-8000-000000000001', 'Review this');
+    getState().updateActiveReviewCommentDraft({
+      body: 'Review this',
       id: '00000000-0000-4000-8000-000000000001',
     });
-
-    await act(async () => {
-      getState().deleteComment('00000000-0000-4000-8000-000000000001');
-    });
-    expect(getState().comments).toEqual([]);
-    expect(getState().focusCommentId).toBeNull();
-    expect(getState().activeReviewCommentDraftRef.current).toBeNull();
-  } finally {
-    randomUUID.mockRestore();
-    await view.cleanup();
-  }
+  });
+  expect(getState().comments[0]?.body).toBe('Review this');
+  expect(getState().activeReviewCommentDraftState).toEqual({
+    body: 'pending',
+    id: '00000000-0000-4000-8000-000000000001',
+  });
+  await act(async () => {
+    getState().deleteComment('00000000-0000-4000-8000-000000000001');
+  });
+  expect(getState().comments).toEqual([]);
+  expect(getState().focusCommentId).toBeNull();
+  expect(getState().activeReviewCommentDraftRef.current).toBeNull();
 });
 
 test('review comment drafts focus an existing empty comment at the same location', async () => {
   const existing = createComment('existing');
-  const { getState, onCommentFileChange, view } = await renderReviewCommentDrafts({
+  await using view = await renderReviewCommentDrafts({
     initialComments: [existing],
   });
+  const { getState, onCommentFileChange } = view;
 
-  try {
-    const { body: _body, id: _id, ...location } = existing;
-    await act(async () => {
-      getState().createComment(location);
-    });
-
-    expect(getState().comments).toEqual([existing]);
-    expect(getState().focusCommentId).toBe('existing');
-    expect(getState().focusCommentRequest).toBe(1);
-    expect(onCommentFileChange).not.toHaveBeenCalled();
-  } finally {
-    await view.cleanup();
-  }
+  const { body: _body, id: _id, ...location } = existing;
+  await act(async () => {
+    getState().createComment(location);
+  });
+  expect(getState().comments).toEqual([existing]);
+  expect(getState().focusCommentId).toBe('existing');
+  expect(getState().focusCommentRequest).toBe(1);
+  expect(onCommentFileChange).not.toHaveBeenCalled();
 });
 
 test('review comment drafts preserve active text when reusing another empty draft', async () => {
@@ -149,56 +143,52 @@ test('review comment drafts preserve active text when reusing another empty draf
   const randomUUID = vi
     .spyOn(crypto, 'randomUUID')
     .mockReturnValue('00000000-0000-4000-8000-000000000002');
-  const { getState, onCommentFileChange, view } = await renderReviewCommentDrafts({
+  await using view = await renderReviewCommentDrafts({
     initialComments: [active, reusable],
   });
+  const { getState, onCommentFileChange } = view;
 
-  try {
-    await act(async () => {
-      getState().updateActiveReviewCommentDraft({
-        body: 'Unflushed editor text',
-        id: active.id,
-      });
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      randomUUID.mockRestore();
+    },
+  };
+  await act(async () => {
+    getState().updateActiveReviewCommentDraft({
+      body: 'Unflushed editor text',
+      id: active.id,
     });
-    const next = createComment('ignored', {
-      filePath: 'src/new.ts',
-      sectionId: 'src/new.ts:unstaged',
-    });
-    const { body: _body, id: _id, ...location } = next;
-    await act(async () => {
-      getState().createComment(location);
-    });
-
-    expect(getState().comments[0]).toEqual(active);
-    expect(getState().comments[1]).toEqual({
-      ...location,
-      body: '',
-      id: '00000000-0000-4000-8000-000000000002',
-    });
-    expect(onCommentFileChange).toHaveBeenNthCalledWith(1, 'src/old.ts');
-    expect(onCommentFileChange).toHaveBeenNthCalledWith(2, 'src/new.ts');
-  } finally {
-    randomUUID.mockRestore();
-    await view.cleanup();
-  }
+  });
+  const next = createComment('ignored', {
+    filePath: 'src/new.ts',
+    sectionId: 'src/new.ts:unstaged',
+  });
+  const { body: _body, id: _id, ...location } = next;
+  await act(async () => {
+    getState().createComment(location);
+  });
+  expect(getState().comments[0]).toEqual(active);
+  expect(getState().comments[1]).toEqual({
+    ...location,
+    body: '',
+    id: '00000000-0000-4000-8000-000000000002',
+  });
+  expect(onCommentFileChange).toHaveBeenNthCalledWith(1, 'src/old.ts');
+  expect(onCommentFileChange).toHaveBeenNthCalledWith(2, 'src/new.ts');
 });
 
 test('review comment drafts can disable comment creation', async () => {
-  const { getState, onCommentFileChange, view } = await renderReviewCommentDrafts({
+  await using view = await renderReviewCommentDrafts({
     canCreateComment: false,
   });
+  const { getState, onCommentFileChange } = view;
 
-  try {
-    const comment = createComment('ignored');
-    const { body: _body, id: _id, ...location } = comment;
-    await act(async () => {
-      getState().createComment(location);
-    });
-
-    expect(getState().comments).toEqual([]);
-    expect(getState().focusCommentRequest).toBe(0);
-    expect(onCommentFileChange).not.toHaveBeenCalled();
-  } finally {
-    await view.cleanup();
-  }
+  const comment = createComment('ignored');
+  const { body: _body, id: _id, ...location } = comment;
+  await act(async () => {
+    getState().createComment(location);
+  });
+  expect(getState().comments).toEqual([]);
+  expect(getState().focusCommentRequest).toBe(0);
+  expect(onCommentFileChange).not.toHaveBeenCalled();
 });

--- a/core/__tests__/review-comment-hooks.test.tsx
+++ b/core/__tests__/review-comment-hooks.test.tsx
@@ -53,21 +53,24 @@ const renderReviewCommentDrafts = async ({
 } = {}) => {
   const onCommentFileChange = vi.fn();
   const stateRef: { current: ReviewCommentDrafts | null } = { current: null };
-  const view = await renderReact(
-    <ReviewCommentDraftsHarness
-      canCreateComment={canCreateComment}
-      initialComments={initialComments}
-      onCommentFileChange={onCommentFileChange}
-      onState={(state) => (stateRef.current = state)}
-    />,
-  );
   const getState = () => {
     if (!stateRef.current) {
       throw new Error('Review comment drafts did not render.');
     }
     return stateRef.current;
   };
-  return Object.assign(view, { getState, onCommentFileChange });
+  return {
+    ...(await renderReact(
+      <ReviewCommentDraftsHarness
+        canCreateComment={canCreateComment}
+        initialComments={initialComments}
+        onCommentFileChange={onCommentFileChange}
+        onState={(state) => (stateRef.current = state)}
+      />,
+    )),
+    getState,
+    onCommentFileChange,
+  };
 };
 
 test('review comment drafts create, update, focus, and delete local comments', async () => {

--- a/core/__tests__/review-hooks.test.tsx
+++ b/core/__tests__/review-hooks.test.tsx
@@ -42,47 +42,40 @@ test('review file state keeps collapse, generated expansion, viewed state, and v
     fingerprint: 'walkthrough-fingerprint',
     key: 'walkthrough:generated',
   };
-  const view = await renderReact(
+  await using _view = await renderReact(
     <ReviewFileStateHarness
       onState={(state) => (stateRef.current = state)}
       onViewedChange={onViewedChange}
     />,
   );
 
-  try {
-    expect(getState().selectedPath).toBe('src/initial.ts');
-
-    await act(async () => {
-      getState().setCollapsed(new Set([reviewIdentity.key]));
-      getState().toggleCollapsed(file, true, reviewIdentity.key);
-    });
-    expect(getState().collapsed.has(reviewIdentity.key)).toBe(false);
-    expect(getState().expandedGenerated.has(reviewIdentity.key)).toBe(true);
-    expect(getState().itemVersionByKey[reviewIdentity.key]).toBe(1);
-
-    await act(async () => {
-      getState().toggleViewed(file, false, reviewIdentity);
-    });
-    expect(getState().viewed).toEqual({
-      [reviewIdentity.key]: reviewIdentity.fingerprint,
-    });
-    expect(getState().collapsed.has(reviewIdentity.key)).toBe(true);
-    expect(getState().expandedGenerated.has(reviewIdentity.key)).toBe(false);
-    expect(getState().itemVersionByKey[reviewIdentity.key]).toBe(2);
-    expect(onViewedChange).toHaveBeenLastCalledWith({
-      [reviewIdentity.key]: reviewIdentity.fingerprint,
-    });
-
-    await act(async () => {
-      getState().toggleViewed(file, true, reviewIdentity);
-    });
-    expect(getState().viewed).toEqual({});
-    expect(getState().collapsed.has(reviewIdentity.key)).toBe(false);
-    expect(getState().itemVersionByKey[reviewIdentity.key]).toBe(3);
-    expect(onViewedChange).toHaveBeenLastCalledWith({});
-  } finally {
-    await view.cleanup();
-  }
+  expect(getState().selectedPath).toBe('src/initial.ts');
+  await act(async () => {
+    getState().setCollapsed(new Set([reviewIdentity.key]));
+    getState().toggleCollapsed(file, true, reviewIdentity.key);
+  });
+  expect(getState().collapsed.has(reviewIdentity.key)).toBe(false);
+  expect(getState().expandedGenerated.has(reviewIdentity.key)).toBe(true);
+  expect(getState().itemVersionByKey[reviewIdentity.key]).toBe(1);
+  await act(async () => {
+    getState().toggleViewed(file, false, reviewIdentity);
+  });
+  expect(getState().viewed).toEqual({
+    [reviewIdentity.key]: reviewIdentity.fingerprint,
+  });
+  expect(getState().collapsed.has(reviewIdentity.key)).toBe(true);
+  expect(getState().expandedGenerated.has(reviewIdentity.key)).toBe(false);
+  expect(getState().itemVersionByKey[reviewIdentity.key]).toBe(2);
+  expect(onViewedChange).toHaveBeenLastCalledWith({
+    [reviewIdentity.key]: reviewIdentity.fingerprint,
+  });
+  await act(async () => {
+    getState().toggleViewed(file, true, reviewIdentity);
+  });
+  expect(getState().viewed).toEqual({});
+  expect(getState().collapsed.has(reviewIdentity.key)).toBe(false);
+  expect(getState().itemVersionByKey[reviewIdentity.key]).toBe(3);
+  expect(onViewedChange).toHaveBeenLastCalledWith({});
 });
 
 function ResizableSidebarHarness({
@@ -133,32 +126,27 @@ const prepareResizeHandle = (container: HTMLElement) => {
 
 test('resizable sidebars clamp drag widths and commit them on release', async () => {
   const onWidthCommit = vi.fn();
-  const view = await renderReact(<ResizableSidebarHarness onWidthCommit={onWidthCommit} />);
+  await using view = await renderReact(<ResizableSidebarHarness onWidthCommit={onWidthCommit} />);
 
-  try {
-    const handle = prepareResizeHandle(view.container);
-    await act(async () => {
-      handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
-      handle.dispatchEvent(new MouseEvent('pointermove', { clientX: 370 }));
-    });
-    expect(handle.dataset.width).toBe('350');
-    expect(onWidthCommit).not.toHaveBeenCalled();
-
-    await act(async () => {
-      handle.dispatchEvent(new MouseEvent('pointerup'));
-    });
-    expect(onWidthCommit).toHaveBeenCalledWith(350);
-    expect(handle.classList.contains('dragging')).toBe(false);
-    expect(document.body.style.cursor).toBe('');
-  } finally {
-    await view.cleanup();
-  }
+  const handle = prepareResizeHandle(view.container);
+  await act(async () => {
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
+    handle.dispatchEvent(new MouseEvent('pointermove', { clientX: 370 }));
+  });
+  expect(handle.dataset.width).toBe('350');
+  expect(onWidthCommit).not.toHaveBeenCalled();
+  await act(async () => {
+    handle.dispatchEvent(new MouseEvent('pointerup'));
+  });
+  expect(onWidthCommit).toHaveBeenCalledWith(350);
+  expect(handle.classList.contains('dragging')).toBe(false);
+  expect(document.body.style.cursor).toBe('');
 });
 
 test('resizable sidebars can collapse during a drag without committing a width', async () => {
   const onCollapse = vi.fn();
   const onWidthCommit = vi.fn();
-  const view = await renderReact(
+  await using view = await renderReact(
     <ResizableSidebarHarness
       collapseThreshold={SIDEBAR_COLLAPSE_THRESHOLD}
       onCollapse={onCollapse}
@@ -166,17 +154,13 @@ test('resizable sidebars can collapse during a drag without committing a width',
     />,
   );
 
-  try {
-    const handle = prepareResizeHandle(view.container);
-    await act(async () => {
-      handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
-      handle.dispatchEvent(new MouseEvent('pointermove', { clientX: 50 }));
-    });
-    expect(onCollapse).toHaveBeenCalledOnce();
-    expect(onWidthCommit).not.toHaveBeenCalled();
-    expect(handle.dataset.width).toBe('292');
-    expect(handle.classList.contains('dragging')).toBe(false);
-  } finally {
-    await view.cleanup();
-  }
+  const handle = prepareResizeHandle(view.container);
+  await act(async () => {
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
+    handle.dispatchEvent(new MouseEvent('pointermove', { clientX: 50 }));
+  });
+  expect(onCollapse).toHaveBeenCalledOnce();
+  expect(onWidthCommit).not.toHaveBeenCalled();
+  expect(handle.dataset.width).toBe('292');
+  expect(handle.classList.contains('dragging')).toBe(false);
 });

--- a/core/__tests__/useAppWalkthrough.test.tsx
+++ b/core/__tests__/useAppWalkthrough.test.tsx
@@ -92,13 +92,12 @@ const renderWalkthroughController = async ({
     />,
   );
 
-  return {
+  return Object.assign(view, {
     getController,
     preferencesRef,
     stateGenerationRef,
     stateRef,
-    view,
-  };
+  });
 };
 
 test('walkthrough controller lazily generates, refreshes, and transitions modes', async () => {
@@ -106,57 +105,50 @@ test('walkthrough controller lazily generates, refreshes, and transitions modes'
     status: 'ready' as const,
     walkthrough,
   }));
-  const { getController, stateGenerationRef, stateRef, view } = await renderWalkthroughController({
+  await using view = await renderWalkthroughController({
     codiff: {
       getNarrativeWalkthrough,
       onWalkthroughProgress: vi.fn(() => () => {}),
     },
   });
+  const { getController, stateGenerationRef, stateRef } = view;
 
-  try {
-    expect(getController().sidebarMode).toBe('tree');
-
-    await act(async () => {
-      getController().changeSidebarMode('walkthrough');
-    });
-    await waitFor(() => {
-      expect(getController().narrativeWalkthrough).toEqual(walkthrough);
-      expect(getController().walkthroughLoading).toBe(false);
-    });
-    expect(getNarrativeWalkthrough).toHaveBeenCalledWith(walkthrough.source, undefined);
-    expect(getController().sidebarMode).toBe('walkthrough');
-    expect(getController().walkthroughProgress.responseLabelIndex).toBe(0);
-
-    const refreshedState = {
-      ...stateRef.current,
-      files: [...stateRef.current.files, createChangedFile('src/added.ts')],
-    };
-    await act(async () => {
-      stateGenerationRef.current += 1;
-      stateRef.current = refreshedState;
-      getController().refreshWalkthroughForState(refreshedState);
-    });
-    await waitFor(() => {
-      expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(2);
-    });
-    expect(getNarrativeWalkthrough).toHaveBeenLastCalledWith(walkthrough.source, {
-      force: true,
-      previousWalkthrough: walkthrough,
-    });
-
-    await act(async () => {
-      getController().openCommitView();
-    });
-    expect(getController().showPlainCommitView).toBe(true);
-    expect(getController().sidebarMode).toBe('tree');
-
-    await act(async () => {
-      getController().closeCommitView();
-    });
-    expect(getController().showPlainCommitView).toBe(false);
-  } finally {
-    await view.cleanup();
-  }
+  expect(getController().sidebarMode).toBe('tree');
+  await act(async () => {
+    getController().changeSidebarMode('walkthrough');
+  });
+  await waitFor(() => {
+    expect(getController().narrativeWalkthrough).toEqual(walkthrough);
+    expect(getController().walkthroughLoading).toBe(false);
+  });
+  expect(getNarrativeWalkthrough).toHaveBeenCalledWith(walkthrough.source, undefined);
+  expect(getController().sidebarMode).toBe('walkthrough');
+  expect(getController().walkthroughProgress.responseLabelIndex).toBe(0);
+  const refreshedState = {
+    ...stateRef.current,
+    files: [...stateRef.current.files, createChangedFile('src/added.ts')],
+  };
+  await act(async () => {
+    stateGenerationRef.current += 1;
+    stateRef.current = refreshedState;
+    getController().refreshWalkthroughForState(refreshedState);
+  });
+  await waitFor(() => {
+    expect(getNarrativeWalkthrough).toHaveBeenCalledTimes(2);
+  });
+  expect(getNarrativeWalkthrough).toHaveBeenLastCalledWith(walkthrough.source, {
+    force: true,
+    previousWalkthrough: walkthrough,
+  });
+  await act(async () => {
+    getController().openCommitView();
+  });
+  expect(getController().showPlainCommitView).toBe(true);
+  expect(getController().sidebarMode).toBe('tree');
+  await act(async () => {
+    getController().closeCommitView();
+  });
+  expect(getController().showPlainCommitView).toBe(false);
 });
 
 test('walkthrough controller routes progress, commit APIs, and sharing through current state', async () => {
@@ -175,7 +167,7 @@ test('walkthrough controller routes progress, commit APIs, and sharing through c
     url: 'https://codiff.dev/w/test',
   }));
   const state = createRepositoryState();
-  const { getController, preferencesRef, view } = await renderWalkthroughController({
+  await using view = await renderWalkthroughController({
     codiff: {
       createWalkthroughCommit,
       onWalkthroughProgress: vi.fn((callback) => {
@@ -189,72 +181,67 @@ test('walkthrough controller routes progress, commit APIs, and sharing through c
     },
     state,
   });
+  const { getController, preferencesRef } = view;
 
-  try {
-    await act(async () => {
-      onProgress?.({ phase: 'agent-generation' });
-    });
-    expect(getController().walkthroughProgress.phase).toBe('agent-generation');
-    expect(getController().walkthroughProgress.stageRevision).toBe(1);
-
-    await act(async () => {
-      await getController().commitWalkthrough({
-        body: 'Body',
-        paths: ['src/app.ts'],
-        source: { ref: 'old', type: 'commit' },
-        subject: 'Subject',
-      });
-      await getController().updateWalkthroughCommitMessage({
-        body: 'Body',
-        paths: ['src/app.ts'],
-        source: { ref: 'old', type: 'commit' },
-        subject: 'Subject',
-      });
-    });
-    expect(createWalkthroughCommit).toHaveBeenCalledWith({
+  await act(async () => {
+    onProgress?.({ phase: 'agent-generation' });
+  });
+  expect(getController().walkthroughProgress.phase).toBe('agent-generation');
+  expect(getController().walkthroughProgress.stageRevision).toBe(1);
+  await act(async () => {
+    await getController().commitWalkthrough({
       body: 'Body',
       paths: ['src/app.ts'],
-      source: state.source,
+      source: { ref: 'old', type: 'commit' },
       subject: 'Subject',
     });
-    expect(updateWalkthroughCommitMessage).toHaveBeenCalledWith({
+    await getController().updateWalkthroughCommitMessage({
       body: 'Body',
       paths: ['src/app.ts'],
-      source: state.source,
+      source: { ref: 'old', type: 'commit' },
       subject: 'Subject',
     });
-
-    await act(async () => {
-      getController().setNarrativeWalkthrough(walkthrough);
-      getController().setShareWalkthroughEnabled(true);
-    });
-    await act(async () => {
-      getController().enabledShareWalkthrough?.();
-    });
-    await waitFor(() => {
-      expect(shareWalkthrough).toHaveBeenCalledOnce();
-      expect(getController().walkthroughSharing).toBe(false);
-    });
-    expect(shareWalkthrough).toHaveBeenCalledWith(
-      expect.objectContaining({
-        files: state.files,
-        preferences: {
-          codeFontFamily: preferencesRef.current.codeFontFamily,
-          codeFontSize: preferencesRef.current.codeFontSize,
-          diffStyle: preferencesRef.current.diffStyle,
-          showWhitespace: preferencesRef.current.showWhitespace,
-          theme: preferencesRef.current.theme,
-          wordWrap: preferencesRef.current.wordWrap,
-        },
-        repository: {
-          root: state.root,
-          source: state.source,
-          title: undefined,
-        },
-        walkthrough,
-      }),
-    );
-  } finally {
-    await view.cleanup();
-  }
+  });
+  expect(createWalkthroughCommit).toHaveBeenCalledWith({
+    body: 'Body',
+    paths: ['src/app.ts'],
+    source: state.source,
+    subject: 'Subject',
+  });
+  expect(updateWalkthroughCommitMessage).toHaveBeenCalledWith({
+    body: 'Body',
+    paths: ['src/app.ts'],
+    source: state.source,
+    subject: 'Subject',
+  });
+  await act(async () => {
+    getController().setNarrativeWalkthrough(walkthrough);
+    getController().setShareWalkthroughEnabled(true);
+  });
+  await act(async () => {
+    getController().enabledShareWalkthrough?.();
+  });
+  await waitFor(() => {
+    expect(shareWalkthrough).toHaveBeenCalledOnce();
+    expect(getController().walkthroughSharing).toBe(false);
+  });
+  expect(shareWalkthrough).toHaveBeenCalledWith(
+    expect.objectContaining({
+      files: state.files,
+      preferences: {
+        codeFontFamily: preferencesRef.current.codeFontFamily,
+        codeFontSize: preferencesRef.current.codeFontSize,
+        diffStyle: preferencesRef.current.diffStyle,
+        showWhitespace: preferencesRef.current.showWhitespace,
+        theme: preferencesRef.current.theme,
+        wordWrap: preferencesRef.current.wordWrap,
+      },
+      repository: {
+        root: state.root,
+        source: state.source,
+        title: undefined,
+      },
+      walkthrough,
+    }),
+  );
 });

--- a/core/__tests__/useAppWalkthrough.test.tsx
+++ b/core/__tests__/useAppWalkthrough.test.tsx
@@ -82,22 +82,21 @@ const renderWalkthroughController = async ({
     }
     return controller;
   };
-  const view = await renderReact(
-    <AppWalkthroughHarness
-      onController={(nextController) => (controller = nextController)}
-      preferencesRef={preferencesRef}
-      state={state}
-      stateGenerationRef={stateGenerationRef}
-      stateRef={stateRef}
-    />,
-  );
-
-  return Object.assign(view, {
+  return {
+    ...(await renderReact(
+      <AppWalkthroughHarness
+        onController={(nextController) => (controller = nextController)}
+        preferencesRef={preferencesRef}
+        state={state}
+        stateGenerationRef={stateGenerationRef}
+        stateRef={stateRef}
+      />,
+    )),
     getController,
     preferencesRef,
     stateGenerationRef,
     stateRef,
-  });
+  };
 };
 
 test('walkthrough controller lazily generates, refreshes, and transitions modes', async () => {

--- a/core/__tests__/useDiffSearch.test.tsx
+++ b/core/__tests__/useDiffSearch.test.tsx
@@ -55,7 +55,9 @@ const renderDiffSearch = async (files: ReadonlyArray<ChangedFile>, fileSearchQue
     getState,
     rerender: (nextFiles: ReadonlyArray<ChangedFile>, nextFileSearchQuery?: string) =>
       view.rerender(renderHarness(nextFiles, nextFileSearchQuery)),
-    view,
+    async [Symbol.asyncDispose]() {
+      await view[Symbol.asyncDispose]();
+    },
   };
 };
 
@@ -63,31 +65,23 @@ test('diff search filters files by file query, visible diffs, and diff matches',
   const matchingFile = createChangedFile('src/needle-one.ts');
   const otherFile = createChangedFile('docs/guide.md');
   const emptyFile = createChangedFile('src/empty.ts', { patch: '' });
-  const { getState, rerender, view } = await renderDiffSearch(
-    [matchingFile, otherFile, emptyFile],
-    'sno',
-  );
+  await using view = await renderDiffSearch([matchingFile, otherFile, emptyFile], 'sno');
+  const { getState, rerender } = view;
 
-  try {
-    expect(getState().fileFilteredFiles.map((file) => file.path)).toEqual(['src/needle-one.ts']);
-    expect(getState().visibleFiles).toEqual(getState().fileFilteredFiles);
-
-    await rerender([matchingFile, otherFile, emptyFile], '');
-    expect(getState().fileFilteredFiles.map((file) => file.path)).toEqual([
-      'src/needle-one.ts',
-      'docs/guide.md',
-    ]);
-
-    await act(async () => {
-      getState().updateQuery('needle');
-    });
-    expect(getState().hasQuery).toBe(true);
-    expect(getState().matchPathSet).toEqual(new Set(['src/needle-one.ts']));
-    expect(getState().visibleFiles.map((file) => file.path)).toEqual(['src/needle-one.ts']);
-    expect(getState().activeMatch?.filePath).toBe('src/needle-one.ts');
-  } finally {
-    await view.cleanup();
-  }
+  expect(getState().fileFilteredFiles.map((file) => file.path)).toEqual(['src/needle-one.ts']);
+  expect(getState().visibleFiles).toEqual(getState().fileFilteredFiles);
+  await rerender([matchingFile, otherFile, emptyFile], '');
+  expect(getState().fileFilteredFiles.map((file) => file.path)).toEqual([
+    'src/needle-one.ts',
+    'docs/guide.md',
+  ]);
+  await act(async () => {
+    getState().updateQuery('needle');
+  });
+  expect(getState().hasQuery).toBe(true);
+  expect(getState().matchPathSet).toEqual(new Set(['src/needle-one.ts']));
+  expect(getState().visibleFiles.map((file) => file.path)).toEqual(['src/needle-one.ts']);
+  expect(getState().activeMatch?.filePath).toBe('src/needle-one.ts');
 });
 
 test('diff search navigation wraps and clamps the active match when results shrink', async () => {
@@ -96,65 +90,54 @@ test('diff search navigation wraps and clamps the active match when results shri
     createChangedFile('src/needle-b.ts'),
     createChangedFile('src/needle-c.ts'),
   ];
-  const { getState, rerender, view } = await renderDiffSearch(files);
+  await using view = await renderDiffSearch(files);
+  const { getState, rerender } = view;
 
-  try {
-    await act(async () => {
-      getState().updateQuery('needle');
-    });
-    await act(async () => {
-      getState().moveMatch(-1);
-    });
-    expect(getState().matches).toHaveLength(3);
-    expect(getState().activeMatchIndex).toBe(2);
-    expect(getState().activeMatch?.filePath).toBe('src/needle-c.ts');
-
-    await act(async () => {
-      getState().moveMatch(1);
-    });
-    expect(getState().activeMatchIndex).toBe(0);
-    expect(getState().activeMatch?.filePath).toBe('src/needle-a.ts');
-
-    await act(async () => {
-      getState().moveMatch(-1);
-    });
-    await rerender(files.slice(0, 1));
-    expect(getState().activeMatchIndex).toBe(0);
-    expect(getState().activeMatch?.filePath).toBe('src/needle-a.ts');
-  } finally {
-    await view.cleanup();
-  }
+  await act(async () => {
+    getState().updateQuery('needle');
+  });
+  await act(async () => {
+    getState().moveMatch(-1);
+  });
+  expect(getState().matches).toHaveLength(3);
+  expect(getState().activeMatchIndex).toBe(2);
+  expect(getState().activeMatch?.filePath).toBe('src/needle-c.ts');
+  await act(async () => {
+    getState().moveMatch(1);
+  });
+  expect(getState().activeMatchIndex).toBe(0);
+  expect(getState().activeMatch?.filePath).toBe('src/needle-a.ts');
+  await act(async () => {
+    getState().moveMatch(-1);
+  });
+  await rerender(files.slice(0, 1));
+  expect(getState().activeMatchIndex).toBe(0);
+  expect(getState().activeMatch?.filePath).toBe('src/needle-a.ts');
 });
 
 test('diff search open, close, and reset preserve the existing panel lifecycle', async () => {
-  const { getState, view } = await renderDiffSearch([createChangedFile('src/needle.ts')]);
+  await using view = await renderDiffSearch([createChangedFile('src/needle.ts')]);
+  const { getState } = view;
 
-  try {
-    expect(getState().visible).toBe(false);
-    expect(getState().focusRequest).toBe(0);
-
-    await act(async () => {
-      getState().openSearch();
-      getState().openSearch();
-    });
-    expect(getState().visible).toBe(true);
-    expect(getState().focusRequest).toBe(2);
-
-    await act(async () => {
-      getState().updateQuery('needle');
-      getState().resetSearch();
-    });
-    expect(getState().query).toBe('');
-    expect(getState().visible).toBe(true);
-
-    await act(async () => {
-      getState().updateQuery('needle');
-      getState().closeSearch();
-    });
-    expect(getState().query).toBe('');
-    expect(getState().activeMatchIndex).toBe(0);
-    expect(getState().visible).toBe(false);
-  } finally {
-    await view.cleanup();
-  }
+  expect(getState().visible).toBe(false);
+  expect(getState().focusRequest).toBe(0);
+  await act(async () => {
+    getState().openSearch();
+    getState().openSearch();
+  });
+  expect(getState().visible).toBe(true);
+  expect(getState().focusRequest).toBe(2);
+  await act(async () => {
+    getState().updateQuery('needle');
+    getState().resetSearch();
+  });
+  expect(getState().query).toBe('');
+  expect(getState().visible).toBe(true);
+  await act(async () => {
+    getState().updateQuery('needle');
+    getState().closeSearch();
+  });
+  expect(getState().query).toBe('');
+  expect(getState().activeMatchIndex).toBe(0);
+  expect(getState().visible).toBe(false);
 });

--- a/core/__tests__/useNarrativeNavigation.test.tsx
+++ b/core/__tests__/useNarrativeNavigation.test.tsx
@@ -52,7 +52,9 @@ function NavigationHarness({
 }
 
 test('clicked walkthrough stops hold selection until target reached or user scroll input releases it', async () => {
-  const navigationRef: { current: NarrativeNavigation | null } = { current: null };
+  const navigationRef: { current: NarrativeNavigation | null } = {
+    current: null,
+  };
   const getNavigation = () => {
     if (!navigationRef.current) {
       throw new Error('Navigation did not render.');
@@ -60,50 +62,42 @@ test('clicked walkthrough stops hold selection until target reached or user scro
     return navigationRef.current;
   };
 
-  const view = await renderReact(
+  await using _view = await renderReact(
     <NavigationHarness onNavigation={(next) => (navigationRef.current = next)} />,
   );
 
-  try {
-    expect(getNavigation().index).toBe(0);
-
-    await act(async () => {
-      getNavigation().goStop(2);
-    });
-    expect(getNavigation().index).toBe(2);
-
-    await act(async () => {
-      getNavigation().syncIndexFromScroll(1);
-    });
-    expect(getNavigation().index).toBe(2);
-
-    await act(async () => {
-      getNavigation().syncIndexFromScroll(2);
-    });
-    expect(getNavigation().index).toBe(2);
-
-    await act(async () => {
-      getNavigation().syncIndexFromScroll(1);
-    });
-    expect(getNavigation().index).toBe(1);
-
-    await act(async () => {
-      getNavigation().goStop(2);
-    });
-    expect(getNavigation().index).toBe(2);
-
-    await act(async () => {
-      getNavigation().releaseStopScrollLock();
-      getNavigation().syncIndexFromScroll(1);
-    });
-    expect(getNavigation().index).toBe(1);
-  } finally {
-    await view.cleanup();
-  }
+  expect(getNavigation().index).toBe(0);
+  await act(async () => {
+    getNavigation().goStop(2);
+  });
+  expect(getNavigation().index).toBe(2);
+  await act(async () => {
+    getNavigation().syncIndexFromScroll(1);
+  });
+  expect(getNavigation().index).toBe(2);
+  await act(async () => {
+    getNavigation().syncIndexFromScroll(2);
+  });
+  expect(getNavigation().index).toBe(2);
+  await act(async () => {
+    getNavigation().syncIndexFromScroll(1);
+  });
+  expect(getNavigation().index).toBe(1);
+  await act(async () => {
+    getNavigation().goStop(2);
+  });
+  expect(getNavigation().index).toBe(2);
+  await act(async () => {
+    getNavigation().releaseStopScrollLock();
+    getNavigation().syncIndexFromScroll(1);
+  });
+  expect(getNavigation().index).toBe(1);
 });
 
 test('support navigation holds support mode until the support block is reached', async () => {
-  const navigationRef: { current: NarrativeNavigation | null } = { current: null };
+  const navigationRef: { current: NarrativeNavigation | null } = {
+    current: null,
+  };
   const getNavigation = () => {
     if (!navigationRef.current) {
       throw new Error('Navigation did not render.');
@@ -111,40 +105,32 @@ test('support navigation holds support mode until the support block is reached',
     return navigationRef.current;
   };
 
-  const view = await renderReact(
+  await using _view = await renderReact(
     <NavigationHarness onNavigation={(next) => (navigationRef.current = next)} />,
   );
 
-  try {
-    await act(async () => {
-      getNavigation().goStop(2);
-    });
-    expect(getNavigation().index).toBe(2);
-
-    await act(async () => {
-      getNavigation().openSupport();
-    });
-    expect(getNavigation().mode).toBe('support');
-    expect(getNavigation().supportVisited).toBe(true);
-
-    await act(async () => {
-      getNavigation().syncIndexFromScroll(1);
-    });
-    expect(getNavigation().mode).toBe('support');
-    expect(getNavigation().index).toBe(2);
-
-    await act(async () => {
-      getNavigation().syncSupportFromScroll();
-    });
-    expect(getNavigation().mode).toBe('support');
-
-    await act(async () => {
-      getNavigation().releaseStopScrollLock();
-      getNavigation().syncIndexFromScroll(1);
-    });
-    expect(getNavigation().mode).toBe('stop');
-    expect(getNavigation().index).toBe(1);
-  } finally {
-    await view.cleanup();
-  }
+  await act(async () => {
+    getNavigation().goStop(2);
+  });
+  expect(getNavigation().index).toBe(2);
+  await act(async () => {
+    getNavigation().openSupport();
+  });
+  expect(getNavigation().mode).toBe('support');
+  expect(getNavigation().supportVisited).toBe(true);
+  await act(async () => {
+    getNavigation().syncIndexFromScroll(1);
+  });
+  expect(getNavigation().mode).toBe('support');
+  expect(getNavigation().index).toBe(2);
+  await act(async () => {
+    getNavigation().syncSupportFromScroll();
+  });
+  expect(getNavigation().mode).toBe('support');
+  await act(async () => {
+    getNavigation().releaseStopScrollLock();
+    getNavigation().syncIndexFromScroll(1);
+  });
+  expect(getNavigation().mode).toBe('stop');
+  expect(getNavigation().index).toBe(1);
 });

--- a/electron/__tests__/agent-skills.test.ts
+++ b/electron/__tests__/agent-skills.test.ts
@@ -1,8 +1,8 @@
-import { lstat, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test, vi } from 'vite-plus/test';
+import { createTemporaryDirectory } from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { buildInstallSkillMenuItem, listAgentSkills } = require('../agent-skills.cjs') as {
@@ -126,9 +126,9 @@ test('keeps skill instructions identical outside agent integration details', asy
 });
 
 test('installs the OpenCode skill into its global skills directory', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-opencode-skill-'));
-  const home = join(directory, 'home');
-  const root = join(directory, 'app');
+  await using directory = await createTemporaryDirectory('codiff-opencode-skill-');
+  const home = join(directory.path, 'home');
+  const root = join(directory.path, 'app');
   const source = join(root, 'opencode/skills/codiff');
   const target = join(home, '.config/opencode/skills/codiff');
   const commandSource = join(root, 'opencode/commands/codiff.md');
@@ -136,81 +136,73 @@ test('installs the OpenCode skill into its global skills directory', async () =>
   const skill = listAgentSkills().find(({ id }) => id === 'opencode');
   let model = 'anthropic/claude-sonnet-4-6';
 
-  try {
-    await mkdir(source, { recursive: true });
-    await mkdir(join(root, 'opencode/commands'), { recursive: true });
-    await writeFile(
-      commandSource,
-      '---\n{{MODEL}}\n---\n<!-- codiff-managed-opencode-command:v1 -->\nRun Codiff.\n',
-    );
-    expect(skill).toBeDefined();
-    const installer = createSkillInstaller({
-      app: {
-        getPath: () => home,
-        isPackaged: false,
-      },
-      dialog: {
-        showMessageBox: async () => {},
-      },
-      renderManagedFile: (_file, template) => template.replace('{{MODEL}}', `model: ${model}`),
-      root,
-      skill: skill!,
-    });
+  await mkdir(source, { recursive: true });
+  await mkdir(join(root, 'opencode/commands'), { recursive: true });
+  await writeFile(
+    commandSource,
+    '---\n{{MODEL}}\n---\n<!-- codiff-managed-opencode-command:v1 -->\nRun Codiff.\n',
+  );
+  expect(skill).toBeDefined();
+  const installer = createSkillInstaller({
+    app: {
+      getPath: () => home,
+      isPackaged: false,
+    },
+    dialog: {
+      showMessageBox: async () => {},
+    },
+    renderManagedFile: (_file, template) => template.replace('{{MODEL}}', `model: ${model}`),
+    root,
+    skill: skill!,
+  });
 
-    await expect(installer.install()).resolves.toBe(true);
-    expect(installer.getStatus()).toEqual({ installed: true, path: target });
-    await expect(realpath(target)).resolves.toBe(await realpath(source));
-    await expect(readFile(commandTarget, 'utf8')).resolves.toContain(
-      'model: anthropic/claude-sonnet-4-6',
-    );
+  await expect(installer.install()).resolves.toBe(true);
+  expect(installer.getStatus()).toEqual({ installed: true, path: target });
+  await expect(realpath(target)).resolves.toBe(await realpath(source));
+  await expect(readFile(commandTarget, 'utf8')).resolves.toContain(
+    'model: anthropic/claude-sonnet-4-6',
+  );
 
-    await rm(commandTarget);
-    model = 'openai/gpt-5.5';
-    installer.refreshManagedFiles();
-    await expect(readFile(commandTarget, 'utf8')).resolves.toContain('model: openai/gpt-5.5');
-    expect(installer.getStatus()).toEqual({ installed: true, path: target });
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await rm(commandTarget);
+  model = 'openai/gpt-5.5';
+  installer.refreshManagedFiles();
+  await expect(readFile(commandTarget, 'utf8')).resolves.toContain('model: openai/gpt-5.5');
+  expect(installer.getStatus()).toEqual({ installed: true, path: target });
 });
 
 test('does not replace a user-authored OpenCode command', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-opencode-command-conflict-'));
-  const home = join(directory, 'home');
-  const root = join(directory, 'app');
+  await using directory = await createTemporaryDirectory('codiff-opencode-command-conflict-');
+  const home = join(directory.path, 'home');
+  const root = join(directory.path, 'app');
   const source = join(root, 'opencode/skills/codiff');
   const commandSource = join(root, 'opencode/commands/codiff.md');
   const commandTarget = join(home, '.config/opencode/commands/codiff.md');
   const skill = listAgentSkills().find(({ id }) => id === 'opencode');
 
-  try {
-    await mkdir(source, { recursive: true });
-    await mkdir(join(root, 'opencode/commands'), { recursive: true });
-    await mkdir(join(home, '.config/opencode/commands'), { recursive: true });
-    await writeFile(commandSource, '<!-- codiff-managed-opencode-command:v1 -->\nRun Codiff.\n');
-    await writeFile(
-      commandTarget,
-      '<!-- This user-authored file mentions Managed by Codiff. -->\nMy custom Codiff command.\n',
-    );
-    expect(skill).toBeDefined();
-    const installer = createSkillInstaller({
-      app: {
-        getPath: () => home,
-        isPackaged: false,
-      },
-      dialog: {
-        showMessageBox: async () => {},
-      },
-      root,
-      skill: skill!,
-    });
+  await mkdir(source, { recursive: true });
+  await mkdir(join(root, 'opencode/commands'), { recursive: true });
+  await mkdir(join(home, '.config/opencode/commands'), { recursive: true });
+  await writeFile(commandSource, '<!-- codiff-managed-opencode-command:v1 -->\nRun Codiff.\n');
+  await writeFile(
+    commandTarget,
+    '<!-- This user-authored file mentions Managed by Codiff. -->\nMy custom Codiff command.\n',
+  );
+  expect(skill).toBeDefined();
+  const installer = createSkillInstaller({
+    app: {
+      getPath: () => home,
+      isPackaged: false,
+    },
+    dialog: {
+      showMessageBox: async () => {},
+    },
+    root,
+    skill: skill!,
+  });
 
-    await expect(installer.install()).resolves.toBe(false);
-    await expect(readFile(commandTarget, 'utf8')).resolves.toContain('My custom Codiff command.');
-    await expect(lstat(join(home, '.config/opencode/skills/codiff'))).rejects.toMatchObject({
-      code: 'ENOENT',
-    });
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(installer.install()).resolves.toBe(false);
+  await expect(readFile(commandTarget, 'utf8')).resolves.toContain('My custom Codiff command.');
+  await expect(lstat(join(home, '.config/opencode/skills/codiff'))).rejects.toMatchObject({
+    code: 'ENOENT',
+  });
 });

--- a/electron/__tests__/claude-session-context.test.ts
+++ b/electron/__tests__/claude-session-context.test.ts
@@ -1,8 +1,11 @@
-import { appendFile, mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, truncate, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { readClaudeSessionContext } = require('../claude-session-context.cjs') as {
@@ -17,132 +20,102 @@ const { readClaudeSessionContext } = require('../claude-session-context.cjs') as
 const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
 
 test('extracts bounded readable messages from Claude Code session jsonl', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-claude-session-'));
-  const sessionDirectory = join(directory, 'projects', 'repo');
+  await using directory = await createTemporaryDirectory('codiff-claude-session-');
+  const sessionDirectory = join(directory.path, 'projects', 'repo');
   const sessionPath = join(sessionDirectory, `${sessionId}.jsonl`);
-  const previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  await using _environment = createTemporaryEnvironment({ CLAUDE_CONFIG_DIR: directory.path });
 
-  try {
-    await mkdir(sessionDirectory, { recursive: true });
-    await writeFile(
-      sessionPath,
-      [
-        JSON.stringify({
-          message: {
-            content: [{ text: 'Implement walkthrough session handoff.', type: 'text' }],
-            role: 'user',
-          },
-          type: 'user',
-        }),
-        JSON.stringify({
-          message: {
-            content: [
-              { thinking: 'planning', type: 'thinking' },
-              { text: 'Updated the CLI and skill handoff.', type: 'text' },
-            ],
-            role: 'assistant',
-          },
-          type: 'assistant',
-        }),
-        JSON.stringify({
-          message: { content: [{ text: '/codiff', type: 'text' }], role: 'user' },
-          type: 'user',
-        }),
-      ].join('\n'),
-    );
-    process.env.CLAUDE_CONFIG_DIR = directory;
+  await mkdir(sessionDirectory, { recursive: true });
+  await writeFile(
+    sessionPath,
+    [
+      JSON.stringify({
+        message: {
+          content: [{ text: 'Implement walkthrough session handoff.', type: 'text' }],
+          role: 'user',
+        },
+        type: 'user',
+      }),
+      JSON.stringify({
+        message: {
+          content: [
+            { thinking: 'planning', type: 'thinking' },
+            { text: 'Updated the CLI and skill handoff.', type: 'text' },
+          ],
+          role: 'assistant',
+        },
+        type: 'assistant',
+      }),
+      JSON.stringify({
+        message: { content: [{ text: '/codiff', type: 'text' }], role: 'user' },
+        type: 'user',
+      }),
+    ].join('\n'),
+  );
 
-    await expect(readClaudeSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [
-        { role: 'user', text: 'Implement walkthrough session handoff.' },
-        { role: 'assistant', text: 'Updated the CLI and skill handoff.' },
-      ],
-    });
-  } finally {
-    if (previousClaudeConfigDir == null) {
-      delete process.env.CLAUDE_CONFIG_DIR;
-    } else {
-      process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readClaudeSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [
+      { role: 'user', text: 'Implement walkthrough session handoff.' },
+      { role: 'assistant', text: 'Updated the CLI and skill handoff.' },
+    ],
+  });
 });
 
 test('finds the active Claude Code session under CLAUDE_CONFIG_DIR', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-claude-home-'));
-  const previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  await using directory = await createTemporaryDirectory('codiff-claude-home-');
+  await using _environment = createTemporaryEnvironment({ CLAUDE_CONFIG_DIR: directory.path });
 
-  try {
-    const projectDirectory = join(directory, 'projects', '-home-reviewer-repo');
-    const sessionPath = join(projectDirectory, `${sessionId}.jsonl`);
-    await mkdir(projectDirectory, { recursive: true });
-    await writeFile(
-      sessionPath,
-      `${JSON.stringify({
-        cwd: '/home/reviewer/repo',
-        message: {
-          content: [{ text: 'Keep Codiff in charge of the ephemeral walkthrough.', type: 'text' }],
-          role: 'user',
-        },
-        type: 'user',
-      })}\n`,
-    );
-    process.env.CLAUDE_CONFIG_DIR = directory;
-
-    await expect(readClaudeSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [
-        {
-          role: 'user',
-          text: 'Keep Codiff in charge of the ephemeral walkthrough.',
-        },
-      ],
-      source: {
-        threadId: sessionId,
-        type: 'claude-session-excerpt',
+  const projectDirectory = join(directory.path, 'projects', '-home-reviewer-repo');
+  const sessionPath = join(projectDirectory, `${sessionId}.jsonl`);
+  await mkdir(projectDirectory, { recursive: true });
+  await writeFile(
+    sessionPath,
+    `${JSON.stringify({
+      cwd: '/home/reviewer/repo',
+      message: {
+        content: [{ text: 'Keep Codiff in charge of the ephemeral walkthrough.', type: 'text' }],
+        role: 'user',
       },
-      version: 1,
-    });
-  } finally {
-    if (previousClaudeConfigDir == null) {
-      delete process.env.CLAUDE_CONFIG_DIR;
-    } else {
-      process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+      type: 'user',
+    })}\n`,
+  );
+
+  await expect(readClaudeSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [
+      {
+        role: 'user',
+        text: 'Keep Codiff in charge of the ephemeral walkthrough.',
+      },
+    ],
+    source: {
+      threadId: sessionId,
+      type: 'claude-session-excerpt',
+    },
+    version: 1,
+  });
 });
 
 test('reads recent Claude messages from a large session without loading the whole file', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-claude-large-session-'));
-  const sessionDirectory = join(directory, 'projects', 'repo');
+  await using directory = await createTemporaryDirectory('codiff-claude-large-session-');
+  const sessionDirectory = join(directory.path, 'projects', 'repo');
   const sessionPath = join(sessionDirectory, `${sessionId}.jsonl`);
-  const previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  await using _environment = createTemporaryEnvironment({ CLAUDE_CONFIG_DIR: directory.path });
 
-  try {
-    await mkdir(sessionDirectory, { recursive: true });
-    await writeFile(sessionPath, '');
-    await truncate(sessionPath, 17 * 1024 * 1024);
-    await appendFile(
-      sessionPath,
-      `\n${JSON.stringify({
-        message: {
-          content: [{ text: 'Newest bounded Claude message.', type: 'text' }],
-          role: 'user',
-        },
-        type: 'user',
-      })}\n`,
-    );
-    process.env.CLAUDE_CONFIG_DIR = directory;
+  await mkdir(sessionDirectory, { recursive: true });
+  await writeFile(sessionPath, '');
+  await truncate(sessionPath, 17 * 1024 * 1024);
+  await appendFile(
+    sessionPath,
+    `\n${JSON.stringify({
+      message: {
+        content: [{ text: 'Newest bounded Claude message.', type: 'text' }],
+        role: 'user',
+      },
+      type: 'user',
+    })}\n`,
+  );
 
-    await expect(readClaudeSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [{ role: 'user', text: 'Newest bounded Claude message.' }],
-    });
-  } finally {
-    if (previousClaudeConfigDir == null) {
-      delete process.env.CLAUDE_CONFIG_DIR;
-    } else {
-      process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readClaudeSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [{ role: 'user', text: 'Newest bounded Claude message.' }],
+  });
 });

--- a/electron/__tests__/claude.test.ts
+++ b/electron/__tests__/claude.test.ts
@@ -1,8 +1,11 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test, vi } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 import { createCommandTransport } from './helpers/command-transport.ts';
 
 type CommandTransport = ReturnType<typeof createCommandTransport>['transport'];
@@ -39,36 +42,28 @@ test('normalizes Claude Code model preferences to known models', () => {
   expect(normalizeClaudeModel('gpt-4o')).toBe(DEFAULT_CLAUDE_MODEL);
 });
 
-test('rejects invalid explicit Claude CLI overrides', () => {
-  const previousClaudePath = process.env.CODIFF_CLAUDE_PATH;
-  process.env.CODIFF_CLAUDE_PATH = '/tmp/codiff-missing-claude';
+test('rejects invalid explicit Claude CLI overrides', async () => {
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_CLAUDE_PATH: '/tmp/codiff-missing-claude',
+  });
 
+  expect(() => getClaudeCommand()).toThrow('CODIFF_CLAUDE_PATH');
   try {
-    expect(() => getClaudeCommand()).toThrow('CODIFF_CLAUDE_PATH');
-    try {
-      getClaudeCommand();
-    } catch (error) {
-      expect(error).toMatchObject({ code: CLAUDE_NOT_FOUND_CODE });
-    }
-  } finally {
-    if (previousClaudePath == null) {
-      delete process.env.CODIFF_CLAUDE_PATH;
-    } else {
-      process.env.CODIFF_CLAUDE_PATH = previousClaudePath;
-    }
+    getClaudeCommand();
+  } catch (error) {
+    expect(error).toMatchObject({ code: CLAUDE_NOT_FOUND_CODE });
   }
 });
 
 test('runs Claude Code headless as a read-only structured-output call', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-claude-'));
-  const fakeClaudePath = join(directory, 'claude');
-  const argsPath = join(directory, 'args.txt');
-  const previousClaudePath = process.env.CODIFF_CLAUDE_PATH;
+  await using directory = await createTemporaryDirectory('codiff-claude-');
+  const fakeClaudePath = join(directory.path, 'claude');
+  const argsPath = join(directory.path, 'args.txt');
+  await using _environment = createTemporaryEnvironment({ CODIFF_CLAUDE_PATH: fakeClaudePath });
 
-  try {
-    await writeFile(
-      fakeClaudePath,
-      `#!/usr/bin/env node
+  await writeFile(
+    fakeClaudePath,
+    `#!/usr/bin/env node
 const { appendFileSync } = require('node:fs');
 const argsPath = ${JSON.stringify(argsPath)};
 for (const arg of process.argv.slice(2)) {
@@ -81,31 +76,22 @@ process.stdin.on('end', () => {
   )});
 });
 `,
-    );
-    await chmod(fakeClaudePath, 0o755);
-    process.env.CODIFF_CLAUDE_PATH = fakeClaudePath;
+  );
+  await chmod(fakeClaudePath, 0o755);
 
-    await expect(
-      runClaude(directory, 'prompt', { type: 'object' }, 'walkthrough.json', 'Timed out.'),
-    ).resolves.toBe('{"version":1}');
+  await expect(
+    runClaude(directory.path, 'prompt', { type: 'object' }, 'walkthrough.json', 'Timed out.'),
+  ).resolves.toBe('{"version":1}');
 
-    const args = (await readFile(argsPath, 'utf8')).trim().split('\n');
-    expect(args).toContain('-p');
-    expect(args).toContain('json');
-    expect(args).not.toContain('stream-json');
-    expect(args).not.toContain('--include-partial-messages');
-    expect(args).toContain('--json-schema');
-    expect(args).toContain('--add-dir');
-    expect(args).toContain(directory);
-    expect(args).toContain('--no-session-persistence');
-  } finally {
-    if (previousClaudePath == null) {
-      delete process.env.CODIFF_CLAUDE_PATH;
-    } else {
-      process.env.CODIFF_CLAUDE_PATH = previousClaudePath;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  const args = (await readFile(argsPath, 'utf8')).trim().split('\n');
+  expect(args).toContain('-p');
+  expect(args).toContain('json');
+  expect(args).not.toContain('stream-json');
+  expect(args).not.toContain('--include-partial-messages');
+  expect(args).toContain('--json-schema');
+  expect(args).toContain('--add-dir');
+  expect(args).toContain(directory.path);
+  expect(args).toContain('--no-session-persistence');
 });
 
 test('maps Claude thinking and text deltas to semantic walkthrough progress', async () => {
@@ -220,17 +206,19 @@ test('maps Claude structured output deltas to response progress', async () => {
 test('supports per-call Claude Code timeouts', async () => {
   const { transport } = createCommandTransport(() => {});
   vi.useFakeTimers();
-  try {
-    const result = runClaude('/repo', 'prompt', {}, 'walkthrough.json', 'Timed out.', {
-      commandTransport: transport,
-      timeoutMs: 10,
-    });
-    const rejection = expect(result).rejects.toThrow('Timed out.');
-    await vi.advanceTimersByTimeAsync(10);
-    await rejection;
-  } finally {
-    vi.useRealTimers();
-  }
+  using _timers = {
+    [Symbol.dispose]() {
+      vi.useRealTimers();
+    },
+  };
+
+  const result = runClaude('/repo', 'prompt', {}, 'walkthrough.json', 'Timed out.', {
+    commandTransport: transport,
+    timeoutMs: 10,
+  });
+  const rejection = expect(result).rejects.toThrow('Timed out.');
+  await vi.advanceTimersByTimeAsync(10);
+  await rejection;
 });
 
 test('surfaces a helpful message when Claude Code is not logged in', async () => {

--- a/electron/__tests__/codex-session-context.test.ts
+++ b/electron/__tests__/codex-session-context.test.ts
@@ -1,8 +1,11 @@
-import { mkdir, mkdtemp, open, rm, writeFile } from 'node:fs/promises';
+import { mkdir, open, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { readCodexSessionContext } = require('../codex-session-context.cjs') as {
@@ -17,203 +20,159 @@ const { readCodexSessionContext } = require('../codex-session-context.cjs') as {
 const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
 
 test('extracts bounded readable messages from Codex session jsonl', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-session-'));
-  const sessionDirectory = join(directory, 'sessions', '2026', '05', '25');
+  await using directory = await createTemporaryDirectory('codiff-session-');
+  const sessionDirectory = join(directory.path, 'sessions', '2026', '05', '25');
   const sessionPath = join(sessionDirectory, `rollout-${sessionId}.jsonl`);
-  const previousCodexHome = process.env.CODEX_HOME;
+  await using _environment = createTemporaryEnvironment({ CODEX_HOME: directory.path });
 
-  try {
-    await mkdir(sessionDirectory, { recursive: true });
-    await writeFile(
-      sessionPath,
-      [
-        JSON.stringify({
-          payload: {
-            content: [{ text: 'Implement walkthrough session handoff.', type: 'input_text' }],
-            role: 'user',
-            type: 'message',
-          },
-          type: 'response_item',
-        }),
-        JSON.stringify({
-          payload: {
-            content: [{ text: 'Updated the CLI and skill handoff.', type: 'output_text' }],
-            role: 'assistant',
-            type: 'message',
-          },
-          type: 'response_item',
-        }),
-        JSON.stringify({
-          payload: {
-            content: [{ text: 'Internal developer instruction.', type: 'input_text' }],
-            role: 'developer',
-            type: 'message',
-          },
-          type: 'response_item',
-        }),
-        JSON.stringify({
-          payload: {
-            content: [{ text: '$codiff', type: 'input_text' }],
-            role: 'user',
-            type: 'message',
-          },
-          type: 'response_item',
-        }),
-      ].join('\n'),
-    );
-    process.env.CODEX_HOME = directory;
+  await mkdir(sessionDirectory, { recursive: true });
+  await writeFile(
+    sessionPath,
+    [
+      JSON.stringify({
+        payload: {
+          content: [{ text: 'Implement walkthrough session handoff.', type: 'input_text' }],
+          role: 'user',
+          type: 'message',
+        },
+        type: 'response_item',
+      }),
+      JSON.stringify({
+        payload: {
+          content: [{ text: 'Updated the CLI and skill handoff.', type: 'output_text' }],
+          role: 'assistant',
+          type: 'message',
+        },
+        type: 'response_item',
+      }),
+      JSON.stringify({
+        payload: {
+          content: [{ text: 'Internal developer instruction.', type: 'input_text' }],
+          role: 'developer',
+          type: 'message',
+        },
+        type: 'response_item',
+      }),
+      JSON.stringify({
+        payload: {
+          content: [{ text: '$codiff', type: 'input_text' }],
+          role: 'user',
+          type: 'message',
+        },
+        type: 'response_item',
+      }),
+    ].join('\n'),
+  );
 
-    await expect(readCodexSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [
-        { role: 'user', text: 'Implement walkthrough session handoff.' },
-        { role: 'assistant', text: 'Updated the CLI and skill handoff.' },
-      ],
-    });
-  } finally {
-    if (previousCodexHome == null) {
-      delete process.env.CODEX_HOME;
-    } else {
-      process.env.CODEX_HOME = previousCodexHome;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readCodexSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [
+      { role: 'user', text: 'Implement walkthrough session handoff.' },
+      { role: 'assistant', text: 'Updated the CLI and skill handoff.' },
+    ],
+  });
 });
 
 test('finds the active Codex session under CODEX_HOME', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-codex-home-'));
-  const previousCodexHome = process.env.CODEX_HOME;
+  await using directory = await createTemporaryDirectory('codiff-codex-home-');
+  await using _environment = createTemporaryEnvironment({ CODEX_HOME: directory.path });
 
-  try {
-    const sessionDirectory = join(directory, 'sessions', '2026', '05', '25');
-    const sessionPath = join(sessionDirectory, `rollout-${sessionId}.jsonl`);
-    await mkdir(sessionDirectory, { recursive: true });
-    await writeFile(
-      sessionPath,
-      `${JSON.stringify({
-        payload: {
-          content: [
-            {
-              text: 'Keep Codiff in charge of the ephemeral walkthrough.',
-              type: 'input_text',
-            },
-          ],
-          role: 'user',
-          type: 'message',
-        },
-        type: 'response_item',
-      })}\n`,
-    );
-    process.env.CODEX_HOME = directory;
-
-    await expect(readCodexSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [
-        {
-          role: 'user',
-          text: 'Keep Codiff in charge of the ephemeral walkthrough.',
-        },
-      ],
-      source: {
-        threadId: sessionId,
-        type: 'codex-session-excerpt',
+  const sessionDirectory = join(directory.path, 'sessions', '2026', '05', '25');
+  const sessionPath = join(sessionDirectory, `rollout-${sessionId}.jsonl`);
+  await mkdir(sessionDirectory, { recursive: true });
+  await writeFile(
+    sessionPath,
+    `${JSON.stringify({
+      payload: {
+        content: [
+          {
+            text: 'Keep Codiff in charge of the ephemeral walkthrough.',
+            type: 'input_text',
+          },
+        ],
+        role: 'user',
+        type: 'message',
       },
-      version: 1,
-    });
-  } finally {
-    if (previousCodexHome == null) {
-      delete process.env.CODEX_HOME;
-    } else {
-      process.env.CODEX_HOME = previousCodexHome;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+      type: 'response_item',
+    })}\n`,
+  );
+
+  await expect(readCodexSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [
+      {
+        role: 'user',
+        text: 'Keep Codiff in charge of the ephemeral walkthrough.',
+      },
+    ],
+    source: {
+      threadId: sessionId,
+      type: 'codex-session-excerpt',
+    },
+    version: 1,
+  });
 });
 
 test('searches newer Codex session directories first', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-codex-session-order-'));
-  const olderDirectory = join(directory, 'sessions', '2025', '12', '31');
-  const newerDirectory = join(directory, 'sessions', '2026', '01', '01');
+  await using directory = await createTemporaryDirectory('codiff-codex-session-order-');
+  const olderDirectory = join(directory.path, 'sessions', '2025', '12', '31');
+  const newerDirectory = join(directory.path, 'sessions', '2026', '01', '01');
   const olderPath = join(olderDirectory, `rollout-${sessionId}.jsonl`);
   const newerPath = join(newerDirectory, `rollout-${sessionId}.jsonl`);
-  const previousCodexHome = process.env.CODEX_HOME;
+  await using _environment = createTemporaryEnvironment({ CODEX_HOME: directory.path });
 
-  try {
-    await mkdir(olderDirectory, { recursive: true });
-    await mkdir(newerDirectory, { recursive: true });
-    await writeFile(
-      olderPath,
-      `${JSON.stringify({
-        payload: {
-          content: [{ text: 'Older message.', type: 'input_text' }],
-          role: 'user',
-          type: 'message',
-        },
-        type: 'response_item',
-      })}\n`,
-    );
-    await writeFile(
-      newerPath,
-      `${JSON.stringify({
-        payload: {
-          content: [{ text: 'Newer message.', type: 'input_text' }],
-          role: 'user',
-          type: 'message',
-        },
-        type: 'response_item',
-      })}\n`,
-    );
-    process.env.CODEX_HOME = directory;
+  await mkdir(olderDirectory, { recursive: true });
+  await mkdir(newerDirectory, { recursive: true });
+  await writeFile(
+    olderPath,
+    `${JSON.stringify({
+      payload: {
+        content: [{ text: 'Older message.', type: 'input_text' }],
+        role: 'user',
+        type: 'message',
+      },
+      type: 'response_item',
+    })}\n`,
+  );
+  await writeFile(
+    newerPath,
+    `${JSON.stringify({
+      payload: {
+        content: [{ text: 'Newer message.', type: 'input_text' }],
+        role: 'user',
+        type: 'message',
+      },
+      type: 'response_item',
+    })}\n`,
+  );
 
-    await expect(readCodexSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [{ role: 'user', text: 'Newer message.' }],
-    });
-  } finally {
-    if (previousCodexHome == null) {
-      delete process.env.CODEX_HOME;
-    } else {
-      process.env.CODEX_HOME = previousCodexHome;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readCodexSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [{ role: 'user', text: 'Newer message.' }],
+  });
 });
 
 test('reads recent Codex messages from a large session without loading the whole file', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-codex-large-session-'));
-  const sessionDirectory = join(directory, 'sessions', '2026', '05', '25');
+  await using directory = await createTemporaryDirectory('codiff-codex-large-session-');
+  const sessionDirectory = join(directory.path, 'sessions', '2026', '05', '25');
   const sessionPath = join(sessionDirectory, `rollout-${sessionId}.jsonl`);
-  const previousCodexHome = process.env.CODEX_HOME;
+  await using _environment = createTemporaryEnvironment({ CODEX_HOME: directory.path });
 
-  try {
-    await mkdir(sessionDirectory, { recursive: true });
-    const file = await open(sessionPath, 'w');
-    try {
-      await file.truncate(16 * 1024 * 1024 + 1);
-      await file.write('\n', 0, 'utf8');
-      await file.write(
-        `${JSON.stringify({
-          payload: {
-            content: [{ text: 'Newest bounded Codex message.', type: 'input_text' }],
-            role: 'user',
-            type: 'message',
-          },
-          type: 'response_item',
-        })}\n`,
-        1,
-        'utf8',
-      );
-    } finally {
-      await file.close();
-    }
-    process.env.CODEX_HOME = directory;
+  await mkdir(sessionDirectory, { recursive: true });
+  await using file = await open(sessionPath, 'w');
+  await file.truncate(16 * 1024 * 1024 + 1);
+  await file.write('\n', 0, 'utf8');
+  await file.write(
+    `${JSON.stringify({
+      payload: {
+        content: [{ text: 'Newest bounded Codex message.', type: 'input_text' }],
+        role: 'user',
+        type: 'message',
+      },
+      type: 'response_item',
+    })}\n`,
+    1,
+    'utf8',
+  );
 
-    await expect(readCodexSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [{ role: 'user', text: 'Newest bounded Codex message.' }],
-    });
-  } finally {
-    if (previousCodexHome == null) {
-      delete process.env.CODEX_HOME;
-    } else {
-      process.env.CODEX_HOME = previousCodexHome;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readCodexSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [{ role: 'user', text: 'Newest bounded Codex message.' }],
+  });
 });

--- a/electron/__tests__/codex-skill.test.ts
+++ b/electron/__tests__/codex-skill.test.ts
@@ -1,8 +1,8 @@
-import { mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises';
+import { mkdir, realpath, symlink } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test, vi } from 'vite-plus/test';
+import { createTemporaryDirectory } from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { createCodexSkillInstaller } = require('../main/codex-skill.cjs') as {
@@ -22,72 +22,64 @@ const { createCodexSkillInstaller } = require('../main/codex-skill.cjs') as {
 };
 
 test('installs every Codiff Codex skill as a symlink', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-skill-'));
-  const home = join(directory, 'home');
-  const root = join(directory, 'app');
+  await using directory = await createTemporaryDirectory('codiff-skill-');
+  const home = join(directory.path, 'home');
+  const root = join(directory.path, 'app');
   const codiffSource = join(root, 'codex/skills/codiff');
 
-  try {
-    await mkdir(codiffSource, { recursive: true });
+  await mkdir(codiffSource, { recursive: true });
 
-    const installer = createCodexSkillInstaller({
-      app: {
-        getPath: () => home,
-        isPackaged: false,
-      },
-      dialog: {
-        showMessageBox: vi.fn(async () => {}),
-      },
-      root,
-    });
+  const installer = createCodexSkillInstaller({
+    app: {
+      getPath: () => home,
+      isPackaged: false,
+    },
+    dialog: {
+      showMessageBox: vi.fn(async () => {}),
+    },
+    root,
+  });
 
-    expect(installer.getCodexSkillStatus()).toEqual({
-      installed: false,
-      path: join(home, '.codex/skills/codiff'),
-    });
+  expect(installer.getCodexSkillStatus()).toEqual({
+    installed: false,
+    path: join(home, '.codex/skills/codiff'),
+  });
 
-    await expect(installer.installCodexSkill()).resolves.toBe(true);
-    expect(installer.getCodexSkillStatus()).toEqual({
-      installed: true,
-      path: join(home, '.codex/skills/codiff'),
-    });
-    await expect(realpath(join(home, '.codex/skills/codiff'))).resolves.toBe(
-      await realpath(codiffSource),
-    );
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(installer.installCodexSkill()).resolves.toBe(true);
+  expect(installer.getCodexSkillStatus()).toEqual({
+    installed: true,
+    path: join(home, '.codex/skills/codiff'),
+  });
+  await expect(realpath(join(home, '.codex/skills/codiff'))).resolves.toBe(
+    await realpath(codiffSource),
+  );
 });
 
 test('updates stale Codiff Codex skill symlinks', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-skill-'));
-  const home = join(directory, 'home');
-  const root = join(directory, 'app');
+  await using directory = await createTemporaryDirectory('codiff-skill-');
+  const home = join(directory.path, 'home');
+  const root = join(directory.path, 'app');
   const codiffSource = join(root, 'codex/skills/codiff');
-  const staleSource = join(directory, 'stale/codiff');
+  const staleSource = join(directory.path, 'stale/codiff');
   const target = join(home, '.codex/skills/codiff');
 
-  try {
-    await mkdir(codiffSource, { recursive: true });
-    await mkdir(staleSource, { recursive: true });
-    await mkdir(join(home, '.codex/skills'), { recursive: true });
-    await symlink(staleSource, target, 'dir');
+  await mkdir(codiffSource, { recursive: true });
+  await mkdir(staleSource, { recursive: true });
+  await mkdir(join(home, '.codex/skills'), { recursive: true });
+  await symlink(staleSource, target, 'dir');
 
-    const installer = createCodexSkillInstaller({
-      app: {
-        getPath: () => home,
-        isPackaged: false,
-      },
-      dialog: {
-        showMessageBox: vi.fn(async () => {}),
-      },
-      root,
-    });
+  const installer = createCodexSkillInstaller({
+    app: {
+      getPath: () => home,
+      isPackaged: false,
+    },
+    dialog: {
+      showMessageBox: vi.fn(async () => {}),
+    },
+    root,
+  });
 
-    expect(installer.getCodexSkillStatus().installed).toBe(false);
-    await expect(installer.installCodexSkill()).resolves.toBe(true);
-    await expect(realpath(target)).resolves.toBe(await realpath(codiffSource));
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  expect(installer.getCodexSkillStatus().installed).toBe(false);
+  await expect(installer.installCodexSkill()).resolves.toBe(true);
+  await expect(realpath(target)).resolves.toBe(await realpath(codiffSource));
 });

--- a/electron/__tests__/codex.test.ts
+++ b/electron/__tests__/codex.test.ts
@@ -1,8 +1,11 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 import { createCommandTransport, type FakeCommandProcess } from './helpers/command-transport.ts';
 
 type CommandTransport = ReturnType<typeof createCommandTransport>['transport'];
@@ -78,23 +81,16 @@ test('normalizes OpenAI model preferences to known models', () => {
   expect(normalizeOpenAIModel('gpt-4o')).toBe(DEFAULT_OPENAI_MODEL);
 });
 
-test('rejects invalid explicit Codex CLI overrides', () => {
-  const previousCodexPath = process.env.CODIFF_CODEX_PATH;
-  process.env.CODIFF_CODEX_PATH = '/tmp/codiff-missing-codex';
+test('rejects invalid explicit Codex CLI overrides', async () => {
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_CODEX_PATH: '/tmp/codiff-missing-codex',
+  });
 
+  expect(() => getCodexCommand()).toThrow('CODIFF_CODEX_PATH');
   try {
-    expect(() => getCodexCommand()).toThrow('CODIFF_CODEX_PATH');
-    try {
-      getCodexCommand();
-    } catch (error) {
-      expect(error).toMatchObject({ code: CODEX_NOT_FOUND_CODE });
-    }
-  } finally {
-    if (previousCodexPath == null) {
-      delete process.env.CODIFF_CODEX_PATH;
-    } else {
-      process.env.CODIFF_CODEX_PATH = previousCodexPath;
-    }
+    getCodexCommand();
+  } catch (error) {
+    expect(error).toMatchObject({ code: CODEX_NOT_FOUND_CODE });
   }
 });
 
@@ -171,15 +167,14 @@ test('retries unavailable GPT-5.6 models with model-specific reasoning', async (
 });
 
 test('streams Codex app-server reasoning and message deltas as semantic progress', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-codex-progress-'));
-  const fakeCodexPath = join(directory, 'codex');
-  const requestsPath = join(directory, 'requests.txt');
-  const previousCodexPath = process.env.CODIFF_CODEX_PATH;
+  await using directory = await createTemporaryDirectory('codiff-codex-progress-');
+  const fakeCodexPath = join(directory.path, 'codex');
+  const requestsPath = join(directory.path, 'requests.txt');
+  await using _environment = createTemporaryEnvironment({ CODIFF_CODEX_PATH: fakeCodexPath });
 
-  try {
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+  await writeFile(
+    fakeCodexPath,
+    `#!/usr/bin/env node
 const { appendFileSync } = require('node:fs');
 const readline = require('node:readline');
 const requestsPath = ${JSON.stringify(requestsPath)};
@@ -239,75 +234,66 @@ readline.createInterface({ input: process.stdin }).on('line', (line) => {
   }
 });
 `,
-    );
-    await chmod(fakeCodexPath, 0o755);
-    process.env.CODIFF_CODEX_PATH = fakeCodexPath;
-    const phases: Array<string> = [];
-    const metrics: Array<any> = [];
+  );
+  await chmod(fakeCodexPath, 0o755);
+  const phases: Array<string> = [];
+  const metrics: Array<any> = [];
 
-    await expect(
-      runCodex(directory, 'prompt', {}, 'walkthrough.json', 'Timed out.', {
-        onProgress: (phase) => phases.push(phase),
-        onMetrics: (value) => metrics.push(value),
-      }),
-    ).resolves.toBe('{"version":1}');
+  await expect(
+    runCodex(directory.path, 'prompt', {}, 'walkthrough.json', 'Timed out.', {
+      onProgress: (phase) => phases.push(phase),
+      onMetrics: (value) => metrics.push(value),
+    }),
+  ).resolves.toBe('{"version":1}');
 
-    expect(phases).toEqual([
-      'agent-generation',
-      'agent-generation',
-      'agent-generation',
-      'agent-generation',
-      'response-received',
-      'response-received',
-      'response-received',
-    ]);
-    expect(metrics).toEqual([
-      {
-        transport: 'app-server',
-        usage: {
-          cachedInputTokens: 80,
-          inputTokens: 100,
-          outputTokens: 25,
-          reasoningOutputTokens: 10,
-          totalTokens: 125,
-        },
+  expect(phases).toEqual([
+    'agent-generation',
+    'agent-generation',
+    'agent-generation',
+    'agent-generation',
+    'response-received',
+    'response-received',
+    'response-received',
+  ]);
+  expect(metrics).toEqual([
+    {
+      transport: 'app-server',
+      usage: {
+        cachedInputTokens: 80,
+        inputTokens: 100,
+        outputTokens: 25,
+        reasoningOutputTokens: 10,
+        totalTokens: 125,
       },
-    ]);
+    },
+  ]);
 
-    const records = (await readFile(requestsPath, 'utf8'))
-      .trim()
-      .split('\n')
-      .map((line) => JSON.parse(line));
-    expect(records.filter((record) => record.arg).map((record) => record.arg)).toContain(
-      'app-server',
-    );
-    const threadStart = records.find((record) => record.message?.method === 'thread/start').message;
-    expect(threadStart.params).toMatchObject({
-      approvalPolicy: 'never',
-      cwd: directory,
-      ephemeral: true,
-      sandbox: 'read-only',
-    });
-    const turnStart = records.find((record) => record.message?.method === 'turn/start').message;
-    expect(turnStart.params).toMatchObject({
-      approvalPolicy: 'never',
-      cwd: directory,
-      effort: 'low',
-      outputSchema: {},
-      sandboxPolicy: {
-        networkAccess: false,
-        type: 'readOnly',
-      },
-      threadId: 'thread-1',
-    });
-  } finally {
-    if (previousCodexPath == null) {
-      delete process.env.CODIFF_CODEX_PATH;
-    } else {
-      process.env.CODIFF_CODEX_PATH = previousCodexPath;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  const records = (await readFile(requestsPath, 'utf8'))
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line));
+  expect(records.filter((record) => record.arg).map((record) => record.arg)).toContain(
+    'app-server',
+  );
+  const threadStart = records.find((record) => record.message?.method === 'thread/start').message;
+  expect(threadStart.params).toMatchObject({
+    approvalPolicy: 'never',
+    cwd: directory.path,
+    ephemeral: true,
+    sandbox: 'read-only',
+  });
+  const turnStart = records.find((record) => record.message?.method === 'turn/start').message;
+  expect(turnStart.params).toMatchObject({
+    approvalPolicy: 'never',
+    cwd: directory.path,
+    effort: 'low',
+    outputSchema: {},
+    sandboxPolicy: {
+      networkAccess: false,
+      type: 'readOnly',
+    },
+    threadId: 'thread-1',
+  });
 });
 
 test('reports Codex exec token usage for eval instrumentation', async () => {

--- a/electron/__tests__/command-line.test.ts
+++ b/electron/__tests__/command-line.test.ts
@@ -1,11 +1,15 @@
 import { execFile } from 'node:child_process';
-import { chmod, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
-import { getGitTestEnvironment, removeGitTestDirectory } from '../../core/__tests__/helpers/git.ts';
+import { getGitTestEnvironment } from '../../core/__tests__/helpers/git.ts';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+  createTemporaryWorkingDirectory,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { getCommandLineLaunchOptions, getCommandLineRepositoryPath, getInitialRepositoryPath } =
@@ -87,31 +91,27 @@ test('parses the OpenCode agent override', () => {
 });
 
 test.sequential('plan command lines do not inspect Git refs', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-command-line-'));
-  const fakeBin = join(directory, 'bin');
-  const gitMarker = join(directory, 'git-invoked');
-  const planFile = join(directory, 'plan.md');
-  const previousPath = process.env.PATH;
+  await using directory = await createTemporaryDirectory('codiff-plan-command-line-');
+  const fakeBin = join(directory.path, 'bin');
+  const gitMarker = join(directory.path, 'git-invoked');
+  const planFile = join(directory.path, 'plan.md');
+  await using _environment = createTemporaryEnvironment({
+    PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+  });
 
-  try {
-    await mkdir(fakeBin);
-    await writeFile(planFile, '# Plan\n');
-    await writeFile(join(fakeBin, 'git'), `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`);
-    await chmod(join(fakeBin, 'git'), 0o755);
-    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+  await mkdir(fakeBin);
+  await writeFile(planFile, '# Plan\n');
+  await writeFile(join(fakeBin, 'git'), `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`);
+  await chmod(join(fakeBin, 'git'), 0o755);
 
-    expect(readCommandLine(['codiff', '--plan-file', planFile, 'workspace'])).toMatchObject({
-      launchOptions: {
-        planFile,
-        repositoryPathProvided: true,
-      },
-      repositoryPath: 'workspace',
-    });
-    expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
-  } finally {
-    process.env.PATH = previousPath;
-    await removeGitTestDirectory(directory);
-  }
+  expect(readCommandLine(['codiff', '--plan-file', planFile, 'workspace'])).toMatchObject({
+    launchOptions: {
+      planFile,
+      repositoryPathProvided: true,
+    },
+    repositoryPath: 'workspace',
+  });
+  expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
 });
 
 test('parses commit and walkthrough command-line options', () => {
@@ -179,183 +179,158 @@ test('parses positional HEAD revisions as commit sources', () => {
 });
 
 test('parses plain refs as branch sources', async () => {
-  const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-branch-ref-'));
-  const previousCwd = process.cwd();
+  await using directory = await createTemporaryDirectory('codiff-branch-ref-');
+  await git(directory.path, ['init']);
+  await git(directory.path, ['commit', '--allow-empty', '-m', 'initial commit']);
+  await git(directory.path, ['checkout', '-b', 'feature']);
+  await using _cwd = createTemporaryWorkingDirectory(directory.path);
 
-  try {
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'initial commit']);
-    await git(repositoryPath, ['checkout', '-b', 'feature']);
-    process.chdir(repositoryPath);
-
-    expect(readCommandLine(['codiff', 'feature'])).toEqual({
-      launchOptions: {
-        repositoryPathProvided: false,
-        source: {
-          ref: 'feature',
-          type: 'branch-working-tree',
-        },
-        walkthrough: false,
+  expect(readCommandLine(['codiff', 'feature'])).toEqual({
+    launchOptions: {
+      repositoryPathProvided: false,
+      source: {
+        ref: 'feature',
+        type: 'branch-working-tree',
       },
-      pullRequestNumber: null,
-      repositoryPath: null,
-    });
+      walkthrough: false,
+    },
+    pullRequestNumber: null,
+    repositoryPath: null,
+  });
 
-    expect(readCommandLine(['codiff', 'feature', repositoryPath])).toEqual({
-      launchOptions: {
-        repositoryPathProvided: true,
-        source: {
-          ref: 'feature',
-          type: 'branch-working-tree',
-        },
-        walkthrough: false,
+  expect(readCommandLine(['codiff', 'feature', directory.path])).toEqual({
+    launchOptions: {
+      repositoryPathProvided: true,
+      source: {
+        ref: 'feature',
+        type: 'branch-working-tree',
       },
-      pullRequestNumber: null,
-      repositoryPath,
-    });
-  } finally {
-    process.chdir(previousCwd);
-    await removeGitTestDirectory(repositoryPath);
-  }
+      walkthrough: false,
+    },
+    pullRequestNumber: null,
+    repositoryPath: directory.path,
+  });
 });
 
 test('parses missing plain refs in Git repositories as branch sources', async () => {
-  const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-missing-branch-ref-'));
-  const previousCwd = process.cwd();
+  await using directory = await createTemporaryDirectory('codiff-missing-branch-ref-');
+  await git(directory.path, ['init']);
+  await git(directory.path, ['commit', '--allow-empty', '-m', 'initial commit']);
+  await using _cwd = createTemporaryWorkingDirectory(directory.path);
 
-  try {
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'initial commit']);
-    process.chdir(repositoryPath);
-
-    expect(readCommandLine(['codiff', 'definitely-missing-branch'])).toEqual({
-      launchOptions: {
-        repositoryPathProvided: false,
-        source: {
-          ref: 'definitely-missing-branch',
-          type: 'branch-working-tree',
-        },
-        walkthrough: false,
+  expect(readCommandLine(['codiff', 'definitely-missing-branch'])).toEqual({
+    launchOptions: {
+      repositoryPathProvided: false,
+      source: {
+        ref: 'definitely-missing-branch',
+        type: 'branch-working-tree',
       },
-      pullRequestNumber: null,
-      repositoryPath: null,
-    });
+      walkthrough: false,
+    },
+    pullRequestNumber: null,
+    repositoryPath: null,
+  });
 
-    expect(readCommandLine(['codiff', 'definitely-missing-branch', repositoryPath])).toEqual({
-      launchOptions: {
-        repositoryPathProvided: true,
-        source: {
-          ref: 'definitely-missing-branch',
-          type: 'branch-working-tree',
-        },
-        walkthrough: false,
+  expect(readCommandLine(['codiff', 'definitely-missing-branch', directory.path])).toEqual({
+    launchOptions: {
+      repositoryPathProvided: true,
+      source: {
+        ref: 'definitely-missing-branch',
+        type: 'branch-working-tree',
       },
-      pullRequestNumber: null,
-      repositoryPath,
-    });
-  } finally {
-    process.chdir(previousCwd);
-    await removeGitTestDirectory(repositoryPath);
-  }
+      walkthrough: false,
+    },
+    pullRequestNumber: null,
+    repositoryPath: directory.path,
+  });
 });
 
 test('parses hex-like refs as commits before branches', async () => {
-  const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-hex-ref-'));
-  const previousCwd = process.cwd();
+  await using directory = await createTemporaryDirectory('codiff-hex-ref-');
+  await git(directory.path, ['init']);
+  await git(directory.path, ['commit', '--allow-empty', '-m', 'initial commit']);
+  const { stdout } = await execFileAsync('git', ['-C', directory.path, 'rev-parse', 'HEAD'], {
+    encoding: 'utf8',
+  });
+  const shortHash = stdout.trim().slice(0, 8);
+  await git(directory.path, ['branch', shortHash]);
+  await using _cwd = createTemporaryWorkingDirectory(directory.path);
 
-  try {
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'initial commit']);
-    const { stdout } = await execFileAsync('git', ['-C', repositoryPath, 'rev-parse', 'HEAD'], {
-      encoding: 'utf8',
-    });
-    const shortHash = stdout.trim().slice(0, 8);
-    await git(repositoryPath, ['branch', shortHash]);
-    process.chdir(repositoryPath);
+  expect(readCommandLine(['codiff', shortHash]).launchOptions.source).toEqual({
+    ref: shortHash,
+    type: 'commit',
+  });
 
-    expect(readCommandLine(['codiff', shortHash]).launchOptions.source).toEqual({
-      ref: shortHash,
-      type: 'commit',
-    });
-
-    expect(readCommandLine(['codiff', '--branch', shortHash]).launchOptions.source).toEqual({
-      ref: shortHash,
-      type: 'branch-working-tree',
-    });
-  } finally {
-    process.chdir(previousCwd);
-    await removeGitTestDirectory(repositoryPath);
-  }
+  expect(readCommandLine(['codiff', '--branch', shortHash]).launchOptions.source).toEqual({
+    ref: shortHash,
+    type: 'branch-working-tree',
+  });
 });
 
 test('parses Codex walkthrough seed command-line options', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-context-'));
-  const contextPath = join(directory, 'seed.json');
+  await using directory = await createTemporaryDirectory('codiff-context-');
+  const contextPath = join(directory.path, 'seed.json');
 
-  try {
-    await writeFile(
-      contextPath,
-      JSON.stringify({
-        objective: 'Make walkthroughs reuse the creating Codex session.',
-        messages: [
-          {
-            role: 'user',
-            text: 'Open Codiff with the context from this implementation session.',
-          },
-          {
-            role: 'developer',
-            text: 'Internal instruction that should not be included.',
-          },
-          {
-            role: 'assistant',
-            text: 'I wired the skill handoff through launch options.',
-          },
-        ],
-        source: {
-          generatedAt: '2026-05-25T00:00:00.000Z',
-          threadId: 'context-file-thread',
+  await writeFile(
+    contextPath,
+    JSON.stringify({
+      objective: 'Make walkthroughs reuse the creating Codex session.',
+      messages: [
+        {
+          role: 'user',
+          text: 'Open Codiff with the context from this implementation session.',
         },
-        version: 1,
-      }),
-    );
-
-    expect(
-      readCommandLine([
-        'codiff',
-        '--walkthrough',
-        '--codex-session',
-        'cli-thread',
-        '--walkthrough-context',
-        contextPath,
-        '/repo',
-      ]).launchOptions,
-    ).toEqual({
-      codexSessionId: 'cli-thread',
-      repositoryPathProvided: true,
-      walkthrough: true,
-      walkthroughContext: {
-        messages: [
-          {
-            role: 'user',
-            text: 'Open Codiff with the context from this implementation session.',
-          },
-          {
-            role: 'assistant',
-            text: 'I wired the skill handoff through launch options.',
-          },
-        ],
-        objective: 'Make walkthroughs reuse the creating Codex session.',
-        source: {
-          generatedAt: '2026-05-25T00:00:00.000Z',
-          threadId: 'context-file-thread',
-          type: 'codex-session',
+        {
+          role: 'developer',
+          text: 'Internal instruction that should not be included.',
         },
-        version: 1,
+        {
+          role: 'assistant',
+          text: 'I wired the skill handoff through launch options.',
+        },
+      ],
+      source: {
+        generatedAt: '2026-05-25T00:00:00.000Z',
+        threadId: 'context-file-thread',
       },
-    });
-  } finally {
-    await removeGitTestDirectory(directory);
-  }
+      version: 1,
+    }),
+  );
+
+  expect(
+    readCommandLine([
+      'codiff',
+      '--walkthrough',
+      '--codex-session',
+      'cli-thread',
+      '--walkthrough-context',
+      contextPath,
+      '/repo',
+    ]).launchOptions,
+  ).toEqual({
+    codexSessionId: 'cli-thread',
+    repositoryPathProvided: true,
+    walkthrough: true,
+    walkthroughContext: {
+      messages: [
+        {
+          role: 'user',
+          text: 'Open Codiff with the context from this implementation session.',
+        },
+        {
+          role: 'assistant',
+          text: 'I wired the skill handoff through launch options.',
+        },
+      ],
+      objective: 'Make walkthroughs reuse the creating Codex session.',
+      source: {
+        generatedAt: '2026-05-25T00:00:00.000Z',
+        threadId: 'context-file-thread',
+        type: 'codex-session',
+      },
+      version: 1,
+    },
+  });
 });
 
 test('parses Codex session ids without creating walkthrough context', () => {
@@ -386,40 +361,36 @@ test('parses full GitHub pull request URLs as launch sources', () => {
 });
 
 test('resolves GitHub and GitLab review markers through repository remotes', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-review-markers-'));
-  const githubRepo = join(directory, 'github');
-  const gitlabRepo = join(directory, 'gitlab');
+  await using directory = await createTemporaryDirectory('codiff-review-markers-');
+  const githubRepo = join(directory.path, 'github');
+  const gitlabRepo = join(directory.path, 'gitlab');
 
-  try {
-    await Promise.all([mkdir(githubRepo), mkdir(gitlabRepo)]);
-    await git(githubRepo, ['init']);
-    await git(githubRepo, ['remote', 'add', 'origin', 'git@github.com:nkzw-tech/codiff.git']);
-    await git(gitlabRepo, ['init']);
-    await git(gitlabRepo, [
-      'remote',
-      'add',
-      'origin',
-      'ssh://git@gitlab.example.com/group/subgroup/project.git',
-    ]);
+  await Promise.all([mkdir(githubRepo), mkdir(gitlabRepo)]);
+  await git(githubRepo, ['init']);
+  await git(githubRepo, ['remote', 'add', 'origin', 'git@github.com:nkzw-tech/codiff.git']);
+  await git(gitlabRepo, ['init']);
+  await git(gitlabRepo, [
+    'remote',
+    'add',
+    'origin',
+    'ssh://git@gitlab.example.com/group/subgroup/project.git',
+  ]);
 
-    expect(getCommandLineLaunchOptions(['codiff', 'pr', '12', githubRepo]).source).toEqual({
-      provider: 'github',
-      type: 'pull-request',
-      url: 'https://github.com/nkzw-tech/codiff/pull/12',
-    });
-    expect(getCommandLineLaunchOptions(['codiff', 'pr', '#12', githubRepo]).source).toEqual({
-      provider: 'github',
-      type: 'pull-request',
-      url: 'https://github.com/nkzw-tech/codiff/pull/12',
-    });
-    expect(getCommandLineLaunchOptions(['codiff', 'mr', '23', gitlabRepo]).source).toEqual({
-      provider: 'gitlab',
-      type: 'pull-request',
-      url: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
-    });
-  } finally {
-    await removeGitTestDirectory(directory);
-  }
+  expect(getCommandLineLaunchOptions(['codiff', 'pr', '12', githubRepo]).source).toEqual({
+    provider: 'github',
+    type: 'pull-request',
+    url: 'https://github.com/nkzw-tech/codiff/pull/12',
+  });
+  expect(getCommandLineLaunchOptions(['codiff', 'pr', '#12', githubRepo]).source).toEqual({
+    provider: 'github',
+    type: 'pull-request',
+    url: 'https://github.com/nkzw-tech/codiff/pull/12',
+  });
+  expect(getCommandLineLaunchOptions(['codiff', 'mr', '23', gitlabRepo]).source).toEqual({
+    provider: 'gitlab',
+    type: 'pull-request',
+    url: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
+  });
 });
 
 test('parses GitLab merge request markers and nested URLs', () => {
@@ -437,15 +408,11 @@ test('parses GitLab merge request markers and nested URLs', () => {
 });
 
 test('restores the last repository for plain app launches', async () => {
-  const lastRepositoryPath = await mkdtemp(join(tmpdir(), 'codiff-last-repo-'));
+  await using directory = await createTemporaryDirectory('codiff-last-repo-');
 
-  try {
-    expect(
-      getInitialRepositoryPath('/fallback', defaultLaunchOptions, lastRepositoryPath, {}),
-    ).toBe(lastRepositoryPath);
-  } finally {
-    await removeGitTestDirectory(lastRepositoryPath);
-  }
+  expect(getInitialRepositoryPath('/fallback', defaultLaunchOptions, directory.path, {})).toBe(
+    directory.path,
+  );
 });
 
 test('does not restore missing last repositories', () => {
@@ -455,94 +422,89 @@ test('does not restore missing last repositories', () => {
 });
 
 test('does not restore over explicit launch intent', async () => {
-  const lastRepositoryPath = await mkdtemp(join(tmpdir(), 'codiff-last-repo-'));
+  await using directory = await createTemporaryDirectory('codiff-last-repo-');
 
-  try {
-    expect(
-      getInitialRepositoryPath(
-        '/fallback',
-        {
-          repositoryPathProvided: true,
-          walkthrough: false,
+  expect(
+    getInitialRepositoryPath(
+      '/fallback',
+      {
+        repositoryPathProvided: true,
+        walkthrough: false,
+      },
+      directory.path,
+      {},
+    ),
+  ).toBe('/fallback');
+  expect(
+    getInitialRepositoryPath(
+      '/fallback',
+      {
+        repositoryPathProvided: false,
+        source: {
+          ref: 'HEAD',
+          type: 'commit',
         },
-        lastRepositoryPath,
-        {},
-      ),
-    ).toBe('/fallback');
-    expect(
-      getInitialRepositoryPath(
-        '/fallback',
-        {
-          repositoryPathProvided: false,
-          source: {
-            ref: 'HEAD',
-            type: 'commit',
-          },
-          walkthrough: false,
-        },
-        lastRepositoryPath,
-        {},
-      ),
-    ).toBe('/fallback');
-    expect(
-      getInitialRepositoryPath(
-        '/fallback',
-        {
-          repositoryPathProvided: false,
-          walkthrough: true,
-        },
-        lastRepositoryPath,
-        {},
-      ),
-    ).toBe('/fallback');
-    expect(
-      getInitialRepositoryPath(
-        '/fallback',
-        {
-          planFile: '/tmp/plan.md',
-          repositoryPathProvided: false,
-          walkthrough: false,
-        },
-        lastRepositoryPath,
-        {},
-      ),
-    ).toBe('/fallback');
-    expect(
-      getInitialRepositoryPath('/fallback', defaultLaunchOptions, lastRepositoryPath, {
-        CODIFF_REPOSITORY_PATH: '/explicit',
-      }),
-    ).toBe('/fallback');
-  } finally {
-    await removeGitTestDirectory(lastRepositoryPath);
-  }
+        walkthrough: false,
+      },
+      directory.path,
+      {},
+    ),
+  ).toBe('/fallback');
+  expect(
+    getInitialRepositoryPath(
+      '/fallback',
+      {
+        repositoryPathProvided: false,
+        walkthrough: true,
+      },
+      directory.path,
+      {},
+    ),
+  ).toBe('/fallback');
+  expect(
+    getInitialRepositoryPath(
+      '/fallback',
+      {
+        planFile: '/tmp/plan.md',
+        repositoryPathProvided: false,
+        walkthrough: false,
+      },
+      directory.path,
+      {},
+    ),
+  ).toBe('/fallback');
+  expect(
+    getInitialRepositoryPath('/fallback', defaultLaunchOptions, directory.path, {
+      CODIFF_REPOSITORY_PATH: '/explicit',
+    }),
+  ).toBe('/fallback');
 });
 
 test('reads base...head and base..head positionals as a range source', async () => {
-  const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-range-'));
+  await using directory = await createTemporaryDirectory('codiff-range-');
 
-  try {
-    await git(repositoryPath, ['init']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'first']);
-    await git(repositoryPath, ['branch', 'base']);
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'second']);
-    await git(repositoryPath, ['branch', 'head']);
+  await git(directory.path, ['init']);
+  await git(directory.path, ['commit', '--allow-empty', '-m', 'first']);
+  await git(directory.path, ['branch', 'base']);
+  await git(directory.path, ['commit', '--allow-empty', '-m', 'second']);
+  await git(directory.path, ['branch', 'head']);
 
-    expect(readCommandLine(['codiff', 'base...head', repositoryPath]).launchOptions.source).toEqual(
-      { base: 'base', head: 'head', symmetric: true, type: 'range' },
-    );
+  expect(readCommandLine(['codiff', 'base...head', directory.path]).launchOptions.source).toEqual({
+    base: 'base',
+    head: 'head',
+    symmetric: true,
+    type: 'range',
+  });
 
-    expect(readCommandLine(['codiff', 'base..head', repositoryPath]).launchOptions.source).toEqual({
-      base: 'base',
-      head: 'head',
-      symmetric: false,
-      type: 'range',
-    });
+  expect(readCommandLine(['codiff', 'base..head', directory.path]).launchOptions.source).toEqual({
+    base: 'base',
+    head: 'head',
+    symmetric: false,
+    type: 'range',
+  });
 
-    // A range whose ends don't resolve is not treated as a source.
-    expect(
-      readCommandLine(['codiff', 'nope...nada', repositoryPath]).launchOptions.source,
-    ).toBeUndefined();
-  } finally {
-    await removeGitTestDirectory(repositoryPath);
-  }
+  // A range whose ends don't resolve is not treated as a source.
+  expect(
+    readCommandLine(['codiff', 'nope...nada', directory.path]).launchOptions.source,
+  ).toBeUndefined();
 });

--- a/electron/__tests__/git-identity.test.ts
+++ b/electron/__tests__/git-identity.test.ts
@@ -1,11 +1,13 @@
 import { execFile } from 'node:child_process';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
-import { removeGitTestDirectory } from '../../core/__tests__/helpers/git.ts';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { readGitIdentity } = require('../git-state/working-tree.cjs') as {
@@ -18,57 +20,43 @@ const git = async (repo: string, args: ReadonlyArray<string>) => {
 };
 
 test('uses configured git identity without inferring it from the current commit author', async () => {
-  const repo = await mkdtemp(join(tmpdir(), 'codiff-git-identity-'));
-  try {
-    await git(repo, ['init']);
-    await writeFile(join(repo, 'README.md'), '# Test\n');
-    await git(repo, ['add', 'README.md']);
-    await git(repo, [
-      '-c',
-      'user.name=Commit Author',
-      '-c',
-      'user.email=commit@example.com',
-      'commit',
-      '-m',
-      'Initial commit',
-    ]);
+  await using directory = await createTemporaryDirectory('codiff-git-identity-');
+  await git(directory.path, ['init']);
+  await writeFile(join(directory.path, 'README.md'), '# Test\n');
+  await git(directory.path, ['add', 'README.md']);
+  await git(directory.path, [
+    '-c',
+    'user.name=Commit Author',
+    '-c',
+    'user.email=commit@example.com',
+    'commit',
+    '-m',
+    'Initial commit',
+  ]);
 
-    await git(repo, ['config', 'user.name', 'Configured User']);
-    await git(repo, ['config', 'user.email', 'configured@example.com']);
-    await expect(readGitIdentity(repo)).resolves.toMatchObject({
-      email: 'configured@example.com',
-      name: 'Configured User',
-    });
+  await git(directory.path, ['config', 'user.name', 'Configured User']);
+  await git(directory.path, ['config', 'user.email', 'configured@example.com']);
+  await expect(readGitIdentity(directory.path)).resolves.toMatchObject({
+    email: 'configured@example.com',
+    name: 'Configured User',
+  });
 
-    await git(repo, ['config', 'user.name', '']);
-    await git(repo, ['config', 'user.email', '']);
-    await expect(readGitIdentity(repo)).resolves.toMatchObject({
-      email: '',
-      name: '',
-    });
-  } finally {
-    await removeGitTestDirectory(repo);
-  }
+  await git(directory.path, ['config', 'user.name', '']);
+  await git(directory.path, ['config', 'user.email', '']);
+  await expect(readGitIdentity(directory.path)).resolves.toMatchObject({
+    email: '',
+    name: '',
+  });
 });
 
 test('reads the global git identity outside a repository', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-global-git-identity-'));
-  const globalConfig = join(directory, '.gitconfig');
-  const previousGlobalConfig = process.env.GIT_CONFIG_GLOBAL;
-  try {
-    await writeFile(globalConfig, '[user]\n\tname = Global User\n\temail = global@example.com\n');
-    process.env.GIT_CONFIG_GLOBAL = globalConfig;
+  await using directory = await createTemporaryDirectory('codiff-global-git-identity-');
+  const globalConfig = join(directory.path, '.gitconfig');
+  await writeFile(globalConfig, '[user]\n\tname = Global User\n\temail = global@example.com\n');
+  await using _environment = createTemporaryEnvironment({ GIT_CONFIG_GLOBAL: globalConfig });
 
-    await expect(readGitIdentity(directory)).resolves.toMatchObject({
-      email: 'global@example.com',
-      name: 'Global User',
-    });
-  } finally {
-    if (previousGlobalConfig == null) {
-      delete process.env.GIT_CONFIG_GLOBAL;
-    } else {
-      process.env.GIT_CONFIG_GLOBAL = previousGlobalConfig;
-    }
-    await removeGitTestDirectory(directory);
-  }
+  await expect(readGitIdentity(directory.path)).resolves.toMatchObject({
+    email: 'global@example.com',
+    name: 'Global User',
+  });
 });

--- a/electron/__tests__/markdown-document.test.ts
+++ b/electron/__tests__/markdown-document.test.ts
@@ -1,8 +1,8 @@
-import { chmod, lstat, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
+import { chmod, lstat, readFile, stat, symlink, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
+import { createTemporaryDirectory } from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { readMarkdownDocument, writeMarkdownDocument } = require('../markdown-document.cjs') as {
@@ -34,160 +34,141 @@ const { readMarkdownDocument, writeMarkdownDocument } = require('../markdown-doc
 };
 
 test('reads and atomically writes repository Markdown documents', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'codiff-markdown-'));
-  const path = join(root, 'plan.md');
-  const context = { repositoryRoot: root };
+  await using directory = await createTemporaryDirectory('codiff-markdown-');
+  const path = join(directory.path, 'plan.md');
+  const context = { repositoryRoot: directory.path };
 
-  try {
-    await writeFile(path, '# Original\n');
-    const document = await readMarkdownDocument({ kind: 'repository', path: 'plan.md' }, context);
-    const saved = await writeMarkdownDocument(
+  await writeFile(path, '# Original\n');
+  const document = await readMarkdownDocument({ kind: 'repository', path: 'plan.md' }, context);
+  const saved = await writeMarkdownDocument(
+    {
+      baseVersion: document.version,
+      content: '# Updated\n',
+      kind: 'repository',
+      path: 'plan.md',
+    },
+    context,
+  );
+
+  expect(saved.content).toBe('# Updated\n');
+  expect(saved.version).not.toBe(document.version);
+  expect(await readFile(path, 'utf8')).toBe('# Updated\n');
+});
+
+test('preserves repository Markdown file permissions when saving', async () => {
+  await using directory = await createTemporaryDirectory('codiff-markdown-mode-');
+  const path = join(directory.path, 'executable.md');
+  const context = { repositoryRoot: directory.path };
+
+  await writeFile(path, '# Original\n');
+  await chmod(path, 0o755);
+  const document = await readMarkdownDocument(
+    { kind: 'repository', path: 'executable.md' },
+    context,
+  );
+
+  await writeMarkdownDocument(
+    {
+      baseVersion: document.version,
+      content: '# Updated\n',
+      kind: 'repository',
+      path: 'executable.md',
+    },
+    context,
+  );
+
+  expect((await stat(path)).mode & 0o777).toBe(0o755);
+});
+
+test('writes through a symlinked plan without replacing the symlink', async () => {
+  await using directory = await createTemporaryDirectory('codiff-plan-symlink-');
+  const target = join(directory.path, 'target.md');
+  const planFile = join(directory.path, 'plan.md');
+  const context = { planFile, repositoryRoot: directory.path };
+
+  await writeFile(target, '# Original\n');
+  await symlink(target, planFile);
+  const document = await readMarkdownDocument({ kind: 'plan', path: planFile }, context);
+
+  await writeMarkdownDocument(
+    {
+      baseVersion: document.version,
+      content: '# Updated\n',
+      kind: 'plan',
+      path: planFile,
+    },
+    context,
+  );
+
+  expect((await lstat(planFile)).isSymbolicLink()).toBe(true);
+  expect(await readFile(target, 'utf8')).toBe('# Updated\n');
+});
+
+test('returns the disk document when a stale version attempts to overwrite it', async () => {
+  await using directory = await createTemporaryDirectory('codiff-markdown-conflict-');
+  const path = join(directory.path, 'plan.md');
+  const context = { repositoryRoot: directory.path };
+
+  await writeFile(path, '# Original\n');
+  const document = await readMarkdownDocument({ kind: 'repository', path: 'plan.md' }, context);
+  await writeFile(path, '# External edit\n');
+
+  await expect(
+    writeMarkdownDocument(
       {
         baseVersion: document.version,
-        content: '# Updated\n',
+        content: '# Local edit\n',
         kind: 'repository',
         path: 'plan.md',
       },
       context,
-    );
-
-    expect(saved.content).toBe('# Updated\n');
-    expect(saved.version).not.toBe(document.version);
-    expect(await readFile(path, 'utf8')).toBe('# Updated\n');
-  } finally {
-    await rm(root, { force: true, recursive: true });
-  }
-});
-
-test('preserves repository Markdown file permissions when saving', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'codiff-markdown-mode-'));
-  const path = join(root, 'executable.md');
-  const context = { repositoryRoot: root };
-
-  try {
-    await writeFile(path, '# Original\n');
-    await chmod(path, 0o755);
-    const document = await readMarkdownDocument(
-      { kind: 'repository', path: 'executable.md' },
-      context,
-    );
-
-    await writeMarkdownDocument(
-      {
-        baseVersion: document.version,
-        content: '# Updated\n',
-        kind: 'repository',
-        path: 'executable.md',
-      },
-      context,
-    );
-
-    expect((await stat(path)).mode & 0o777).toBe(0o755);
-  } finally {
-    await rm(root, { force: true, recursive: true });
-  }
-});
-
-test('writes through a symlinked plan without replacing the symlink', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'codiff-plan-symlink-'));
-  const target = join(root, 'target.md');
-  const planFile = join(root, 'plan.md');
-  const context = { planFile, repositoryRoot: root };
-
-  try {
-    await writeFile(target, '# Original\n');
-    await symlink(target, planFile);
-    const document = await readMarkdownDocument({ kind: 'plan', path: planFile }, context);
-
-    await writeMarkdownDocument(
-      {
-        baseVersion: document.version,
-        content: '# Updated\n',
-        kind: 'plan',
-        path: planFile,
-      },
-      context,
-    );
-
-    expect((await lstat(planFile)).isSymbolicLink()).toBe(true);
-    expect(await readFile(target, 'utf8')).toBe('# Updated\n');
-  } finally {
-    await rm(root, { force: true, recursive: true });
-  }
-});
-
-test('returns the disk document when a stale version attempts to overwrite it', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'codiff-markdown-conflict-'));
-  const path = join(root, 'plan.md');
-  const context = { repositoryRoot: root };
-
-  try {
-    await writeFile(path, '# Original\n');
-    const document = await readMarkdownDocument({ kind: 'repository', path: 'plan.md' }, context);
-    await writeFile(path, '# External edit\n');
-
-    await expect(
-      writeMarkdownDocument(
-        {
-          baseVersion: document.version,
-          content: '# Local edit\n',
-          kind: 'repository',
-          path: 'plan.md',
-        },
-        context,
-      ),
-    ).rejects.toMatchObject({
-      document: {
-        content: '# External edit\n',
-      },
-      name: 'MarkdownDocumentConflictError',
-    });
-  } finally {
-    await rm(root, { force: true, recursive: true });
-  }
+    ),
+  ).rejects.toMatchObject({
+    document: {
+      content: '# External edit\n',
+    },
+    name: 'MarkdownDocumentConflictError',
+  });
 });
 
 test('allows only the exact plan file and repository-contained Markdown paths', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'codiff-markdown-paths-'));
-  const planFile = join(root, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-markdown-paths-');
+  const planFile = join(directory.path, 'plan.md');
 
-  try {
-    await writeFile(planFile, '# Plan\n');
-    await expect(
-      readMarkdownDocument(
-        { kind: 'plan', path: join(root, 'other.md') },
-        { planFile, repositoryRoot: root },
-      ),
-    ).rejects.toThrow('does not belong to this window');
-    await expect(
-      readMarkdownDocument({ kind: 'repository', path: '../plan.md' }, { repositoryRoot: root }),
-    ).rejects.toThrow('escapes the repository');
-    await expect(
-      readMarkdownDocument({ kind: 'repository', path: 'plan.txt' }, { repositoryRoot: root }),
-    ).rejects.toThrow('Invalid repository Markdown path');
-  } finally {
-    await rm(root, { force: true, recursive: true });
-  }
+  await writeFile(planFile, '# Plan\n');
+  await expect(
+    readMarkdownDocument(
+      { kind: 'plan', path: join(directory.path, 'other.md') },
+      { planFile, repositoryRoot: directory.path },
+    ),
+  ).rejects.toThrow('does not belong to this window');
+  await expect(
+    readMarkdownDocument(
+      { kind: 'repository', path: '../plan.md' },
+      { repositoryRoot: directory.path },
+    ),
+  ).rejects.toThrow('escapes the repository');
+  await expect(
+    readMarkdownDocument(
+      { kind: 'repository', path: 'plan.txt' },
+      { repositoryRoot: directory.path },
+    ),
+  ).rejects.toThrow('Invalid repository Markdown path');
 });
 
 test('rejects repository Markdown paths that resolve outside through a symlink', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'codiff-markdown-symlink-root-'));
-  const outside = await mkdtemp(join(tmpdir(), 'codiff-markdown-symlink-outside-'));
-  const outsidePath = join(outside, 'outside.md');
+  await using root = await createTemporaryDirectory('codiff-markdown-symlink-root-');
+  await using outside = await createTemporaryDirectory('codiff-markdown-symlink-outside-');
+  const outsidePath = join(outside.path, 'outside.md');
 
-  try {
-    await writeFile(outsidePath, '# Outside\n');
-    await symlink(outside, join(root, 'docs'));
+  await writeFile(outsidePath, '# Outside\n');
+  await symlink(outside.path, join(root.path, 'docs'));
 
-    await expect(
-      readMarkdownDocument(
-        { kind: 'repository', path: 'docs/outside.md' },
-        { repositoryRoot: root },
-      ),
-    ).rejects.toThrow('escapes the repository');
-    expect(await readFile(outsidePath, 'utf8')).toBe('# Outside\n');
-  } finally {
-    await rm(root, { force: true, recursive: true });
-    await rm(outside, { force: true, recursive: true });
-  }
+  await expect(
+    readMarkdownDocument(
+      { kind: 'repository', path: 'docs/outside.md' },
+      { repositoryRoot: root.path },
+    ),
+  ).rejects.toThrow('escapes the repository');
+  expect(await readFile(outsidePath, 'utf8')).toBe('# Outside\n');
 });

--- a/electron/__tests__/opencode-session-context.test.ts
+++ b/electron/__tests__/opencode-session-context.test.ts
@@ -1,8 +1,11 @@
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { readOpenCodeSessionContext } = require('../opencode-session-context.cjs') as {
@@ -17,147 +20,107 @@ const { readOpenCodeSessionContext } = require('../opencode-session-context.cjs'
 const sessionId = 'ses_121b4816bffebMr9YE52O4870p';
 
 test('reads the linked session through the OpenCode export command', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-opencode-session-test-'));
-  const commandPath = join(directory, 'opencode');
-  const previousOpenCodePath = process.env.CODIFF_OPENCODE_PATH;
+  await using directory = await createTemporaryDirectory('codiff-opencode-session-test-');
+  const commandPath = join(directory.path, 'opencode');
+  await using _environment = createTemporaryEnvironment({ CODIFF_OPENCODE_PATH: commandPath });
 
-  try {
-    await writeFile(
-      commandPath,
-      `#!/bin/sh
+  await writeFile(
+    commandPath,
+    `#!/bin/sh
 printf '%s' '${JSON.stringify({
-        info: { id: sessionId },
-        messages: [
-          {
-            info: { role: 'user' },
-            parts: [{ text: 'Keep the creating session attached.', type: 'text' }],
-          },
-        ],
-      })}'
+      info: { id: sessionId },
+      messages: [
+        {
+          info: { role: 'user' },
+          parts: [{ text: 'Keep the creating session attached.', type: 'text' }],
+        },
+      ],
+    })}'
 `,
-    );
-    await chmod(commandPath, 0o755);
-    process.env.CODIFF_OPENCODE_PATH = commandPath;
+  );
+  await chmod(commandPath, 0o755);
 
-    await expect(readOpenCodeSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [{ role: 'user', text: 'Keep the creating session attached.' }],
-      source: {
-        threadId: sessionId,
-        type: 'opencode-session-excerpt',
-      },
-      version: 1,
-    });
-  } finally {
-    if (previousOpenCodePath == null) {
-      delete process.env.CODIFF_OPENCODE_PATH;
-    } else {
-      process.env.CODIFF_OPENCODE_PATH = previousOpenCodePath;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readOpenCodeSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [{ role: 'user', text: 'Keep the creating session attached.' }],
+    source: {
+      threadId: sessionId,
+      type: 'opencode-session-excerpt',
+    },
+    version: 1,
+  });
 });
 
 test('does not block the event loop while OpenCode exports a session', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-opencode-session-async-'));
-  const commandPath = join(directory, 'opencode');
-  const previousOpenCodePath = process.env.CODIFF_OPENCODE_PATH;
+  await using directory = await createTemporaryDirectory('codiff-opencode-session-async-');
+  const commandPath = join(directory.path, 'opencode');
+  await using _environment = createTemporaryEnvironment({ CODIFF_OPENCODE_PATH: commandPath });
 
-  try {
-    await writeFile(
-      commandPath,
-      `#!/bin/sh
+  await writeFile(
+    commandPath,
+    `#!/bin/sh
 sleep 0.1
 printf '%s' '${JSON.stringify({
-        info: { id: sessionId },
-        messages: [],
-      })}'
+      info: { id: sessionId },
+      messages: [],
+    })}'
 `,
-    );
-    await chmod(commandPath, 0o755);
-    process.env.CODIFF_OPENCODE_PATH = commandPath;
+  );
+  await chmod(commandPath, 0o755);
 
-    let settled = false;
-    const context = readOpenCodeSessionContext(sessionId).then((result) => {
-      settled = true;
-      return result;
-    });
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(settled).toBe(false);
-    await context;
-  } finally {
-    if (previousOpenCodePath == null) {
-      delete process.env.CODIFF_OPENCODE_PATH;
-    } else {
-      process.env.CODIFF_OPENCODE_PATH = previousOpenCodePath;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  let settled = false;
+  const context = readOpenCodeSessionContext(sessionId).then((result) => {
+    settled = true;
+    return result;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  expect(settled).toBe(false);
+  await context;
 });
 
 test('rejects invalid ids and mismatched session exports', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-opencode-session-mismatch-'));
-  const commandPath = join(directory, 'opencode');
-  const previousOpenCodePath = process.env.CODIFF_OPENCODE_PATH;
+  await using directory = await createTemporaryDirectory('codiff-opencode-session-mismatch-');
+  const commandPath = join(directory.path, 'opencode');
+  await using _environment = createTemporaryEnvironment({ CODIFF_OPENCODE_PATH: commandPath });
 
-  try {
-    await writeFile(
-      commandPath,
-      `#!/bin/sh
+  await writeFile(
+    commandPath,
+    `#!/bin/sh
 printf '%s' '${JSON.stringify({
-        info: { id: 'ses_differentSession123' },
-        messages: [
-          {
-            info: { role: 'user' },
-            parts: [{ text: 'Wrong session.', type: 'text' }],
-          },
-        ],
-      })}'
+      info: { id: 'ses_differentSession123' },
+      messages: [
+        {
+          info: { role: 'user' },
+          parts: [{ text: 'Wrong session.', type: 'text' }],
+        },
+      ],
+    })}'
 `,
-    );
-    await chmod(commandPath, 0o755);
-    process.env.CODIFF_OPENCODE_PATH = commandPath;
+  );
+  await chmod(commandPath, 0o755);
 
-    await expect(readOpenCodeSessionContext('../../sessions')).resolves.toBeNull();
-    await expect(readOpenCodeSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [],
-      risks: ['Codiff could not find recent readable messages for the linked OpenCode session.'],
-    });
-  } finally {
-    if (previousOpenCodePath == null) {
-      delete process.env.CODIFF_OPENCODE_PATH;
-    } else {
-      process.env.CODIFF_OPENCODE_PATH = previousOpenCodePath;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readOpenCodeSessionContext('../../sessions')).resolves.toBeNull();
+  await expect(readOpenCodeSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [],
+    risks: ['Codiff could not find recent readable messages for the linked OpenCode session.'],
+  });
 });
 
 test('rejects oversized OpenCode session exports', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-opencode-session-large-'));
-  const commandPath = join(directory, 'opencode');
-  const previousOpenCodePath = process.env.CODIFF_OPENCODE_PATH;
+  await using directory = await createTemporaryDirectory('codiff-opencode-session-large-');
+  const commandPath = join(directory.path, 'opencode');
+  await using _environment = createTemporaryEnvironment({ CODIFF_OPENCODE_PATH: commandPath });
 
-  try {
-    await writeFile(
-      commandPath,
-      `#!/bin/sh
+  await writeFile(
+    commandPath,
+    `#!/bin/sh
 printf '{"info":{"id":"${sessionId}"},"messages":[]}'
 dd if=/dev/zero bs=1048576 count=17 2>/dev/null
 `,
-    );
-    await chmod(commandPath, 0o755);
-    process.env.CODIFF_OPENCODE_PATH = commandPath;
+  );
+  await chmod(commandPath, 0o755);
 
-    await expect(readOpenCodeSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [],
-      risks: ['Codiff could not find recent readable messages for the linked OpenCode session.'],
-    });
-  } finally {
-    if (previousOpenCodePath == null) {
-      delete process.env.CODIFF_OPENCODE_PATH;
-    } else {
-      process.env.CODIFF_OPENCODE_PATH = previousOpenCodePath;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readOpenCodeSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [],
+    risks: ['Codiff could not find recent readable messages for the linked OpenCode session.'],
+  });
 });

--- a/electron/__tests__/opencode.test.ts
+++ b/electron/__tests__/opencode.test.ts
@@ -1,8 +1,11 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 import { createCommandTransport } from './helpers/command-transport.ts';
 
 type CommandTransport = ReturnType<typeof createCommandTransport>['transport'];
@@ -87,22 +90,15 @@ test('renders the selected model into the managed OpenCode command', () => {
   ).toThrow('exactly one');
 });
 
-test('detects OpenCode-not-found errors and invalid overrides', () => {
+test('detects OpenCode-not-found errors and invalid overrides', async () => {
   expect(isOpenCodeNotFoundError({ code: OPENCODE_NOT_FOUND_CODE })).toBe(true);
   expect(isOpenCodeNotFoundError({ code: 'ENOENT' })).toBe(true);
   expect(isOpenCodeNotFoundError(new Error('other'))).toBe(false);
 
-  const previousOpenCodePath = process.env.CODIFF_OPENCODE_PATH;
-  process.env.CODIFF_OPENCODE_PATH = '/tmp/codiff-missing-opencode';
-  try {
-    expect(() => getOpenCodeCommand()).toThrow('CODIFF_OPENCODE_PATH');
-  } finally {
-    if (previousOpenCodePath == null) {
-      delete process.env.CODIFF_OPENCODE_PATH;
-    } else {
-      process.env.CODIFF_OPENCODE_PATH = previousOpenCodePath;
-    }
-  }
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_OPENCODE_PATH: '/tmp/codiff-missing-opencode',
+  });
+  expect(() => getOpenCodeCommand()).toThrow('CODIFF_OPENCODE_PATH');
 });
 
 test('runs OpenCode as an external read-only call', async () => {
@@ -152,16 +148,15 @@ test('runs OpenCode as an external read-only call', async () => {
 });
 
 test('streams semantic progress from the OpenCode event server', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-opencode-progress-'));
-  const fakeOpenCodePath = join(directory, 'opencode');
-  const argsPath = join(directory, 'args.txt');
-  const requestPath = join(directory, 'request.json');
-  const previousOpenCodePath = process.env.CODIFF_OPENCODE_PATH;
+  await using directory = await createTemporaryDirectory('codiff-opencode-progress-');
+  const fakeOpenCodePath = join(directory.path, 'opencode');
+  const argsPath = join(directory.path, 'args.txt');
+  const requestPath = join(directory.path, 'request.json');
+  await using _environment = createTemporaryEnvironment({ CODIFF_OPENCODE_PATH: fakeOpenCodePath });
 
-  try {
-    await writeFile(
-      fakeOpenCodePath,
-      `#!/usr/bin/env node
+  await writeFile(
+    fakeOpenCodePath,
+    `#!/usr/bin/env node
 const { appendFileSync, writeFileSync } = require('node:fs');
 const http = require('node:http');
 const args = process.argv.slice(2);
@@ -252,42 +247,33 @@ server.listen(port, '127.0.0.1', () => {
 });
 process.on('SIGTERM', () => server.close(() => process.exit(0)));
 `,
-    );
-    await chmod(fakeOpenCodePath, 0o755);
-    process.env.CODIFF_OPENCODE_PATH = fakeOpenCodePath;
-    const phases: Array<string> = [];
+  );
+  await chmod(fakeOpenCodePath, 0o755);
+  const phases: Array<string> = [];
 
-    await expect(
-      runOpenCode(
-        directory,
-        'prompt',
-        { required: ['version'], type: 'object' },
-        undefined,
-        undefined,
-        {
-          onProgress: (phase) => phases.push(phase),
-        },
-      ),
-    ).resolves.toBe('{"version":1}');
+  await expect(
+    runOpenCode(
+      directory.path,
+      'prompt',
+      { required: ['version'], type: 'object' },
+      undefined,
+      undefined,
+      {
+        onProgress: (phase) => phases.push(phase),
+      },
+    ),
+  ).resolves.toBe('{"version":1}');
 
-    expect(phases).toEqual(['agent-generation', 'response-received']);
-    const calls = (await readFile(argsPath, 'utf8'))
-      .trim()
-      .split('\n')
-      .map((line) => JSON.parse(line));
-    expect(calls).toEqual([expect.arrayContaining(['serve', '--pure', '--hostname=127.0.0.1'])]);
-    const request = JSON.parse(await readFile(requestPath, 'utf8'));
-    expect(request.session.permission).toEqual([{ action: 'deny', pattern: '*', permission: '*' }]);
-    expect(request.prompt.parts[0].text).toContain('Follow this JSON Schema exactly');
-    expect(request.prompt.tools).toEqual({});
-  } finally {
-    if (previousOpenCodePath == null) {
-      delete process.env.CODIFF_OPENCODE_PATH;
-    } else {
-      process.env.CODIFF_OPENCODE_PATH = previousOpenCodePath;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  expect(phases).toEqual(['agent-generation', 'response-received']);
+  const calls = (await readFile(argsPath, 'utf8'))
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line));
+  expect(calls).toEqual([expect.arrayContaining(['serve', '--pure', '--hostname=127.0.0.1'])]);
+  const request = JSON.parse(await readFile(requestPath, 'utf8'));
+  expect(request.session.permission).toEqual([{ action: 'deny', pattern: '*', permission: '*' }]);
+  expect(request.prompt.parts[0].text).toContain('Follow this JSON Schema exactly');
+  expect(request.prompt.tools).toEqual({});
 });
 
 test('falls back to OpenCode CLI JSON mode when event streaming is unavailable', async () => {

--- a/electron/__tests__/pi-session-context.test.ts
+++ b/electron/__tests__/pi-session-context.test.ts
@@ -1,8 +1,11 @@
-import { appendFile, mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, truncate, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { readPiSessionContext } = require('../pi-session-context.cjs') as {
@@ -17,104 +20,84 @@ const { readPiSessionContext } = require('../pi-session-context.cjs') as {
 const sessionId = '019e5e57-e7d6-7392-9ad1-ad959319d2fb';
 
 test('extracts bounded readable messages from Pi session jsonl', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-pi-session-'));
-  const sessionDirectory = join(directory, 'agent', 'sessions', 'repo');
+  await using directory = await createTemporaryDirectory('codiff-pi-session-');
+  const sessionDirectory = join(directory.path, 'agent', 'sessions', 'repo');
   const sessionPath = join(sessionDirectory, `${sessionId}.jsonl`);
-  const previousPiHome = process.env.PI_HOME;
+  await using _environment = createTemporaryEnvironment({ PI_HOME: directory.path });
 
-  try {
-    await mkdir(sessionDirectory, { recursive: true });
-    await writeFile(
-      sessionPath,
-      [
-        JSON.stringify({ type: 'session' }),
-        JSON.stringify({
-          message: {
-            content: [{ text: 'Implement walkthrough session handoff.', type: 'text' }],
-            role: 'user',
-          },
-          type: 'message',
-        }),
-        JSON.stringify({
-          message: {
-            content: [
-              { thinking: 'planning', type: 'thinking' },
-              { text: 'Updated the Pi skill handoff.', type: 'text' },
-            ],
-            role: 'assistant',
-          },
-          type: 'message',
-        }),
-        JSON.stringify({
-          message: { content: [{ text: '/codiff', type: 'text' }], role: 'user' },
-          type: 'message',
-        }),
-      ].join('\n'),
-    );
-    process.env.PI_HOME = directory;
-
-    await expect(readPiSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [
-        { role: 'user', text: 'Implement walkthrough session handoff.' },
-        { role: 'assistant', text: 'Updated the Pi skill handoff.' },
-      ],
-    });
-  } finally {
-    if (previousPiHome == null) {
-      delete process.env.PI_HOME;
-    } else {
-      process.env.PI_HOME = previousPiHome;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
-});
-
-test('finds the active Pi session under PI_HOME', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-pi-home-'));
-  const previousPiHome = process.env.PI_HOME;
-
-  try {
-    const sessionDirectory = join(directory, 'agent', 'sessions', 'encoded-repo');
-    const sessionPath = join(sessionDirectory, `2026-06-10_${sessionId}.jsonl`);
-    await mkdir(sessionDirectory, { recursive: true });
-    await writeFile(
-      sessionPath,
-      `${JSON.stringify({
+  await mkdir(sessionDirectory, { recursive: true });
+  await writeFile(
+    sessionPath,
+    [
+      JSON.stringify({ type: 'session' }),
+      JSON.stringify({
         message: {
-          content: [
-            {
-              text: 'Keep Codiff in charge of the ephemeral walkthrough.',
-              type: 'text',
-            },
-          ],
+          content: [{ text: 'Implement walkthrough session handoff.', type: 'text' }],
           role: 'user',
         },
         type: 'message',
-      })}\n`,
-    );
-    process.env.PI_HOME = directory;
-
-    await expect(readPiSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [
-        {
-          role: 'user',
-          text: 'Keep Codiff in charge of the ephemeral walkthrough.',
+      }),
+      JSON.stringify({
+        message: {
+          content: [
+            { thinking: 'planning', type: 'thinking' },
+            { text: 'Updated the Pi skill handoff.', type: 'text' },
+          ],
+          role: 'assistant',
         },
-      ],
-      source: {
-        threadId: sessionId,
-        type: 'pi-session-excerpt',
+        type: 'message',
+      }),
+      JSON.stringify({
+        message: { content: [{ text: '/codiff', type: 'text' }], role: 'user' },
+        type: 'message',
+      }),
+    ].join('\n'),
+  );
+
+  await expect(readPiSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [
+      { role: 'user', text: 'Implement walkthrough session handoff.' },
+      { role: 'assistant', text: 'Updated the Pi skill handoff.' },
+    ],
+  });
+});
+
+test('finds the active Pi session under PI_HOME', async () => {
+  await using directory = await createTemporaryDirectory('codiff-pi-home-');
+  await using _environment = createTemporaryEnvironment({ PI_HOME: directory.path });
+
+  const sessionDirectory = join(directory.path, 'agent', 'sessions', 'encoded-repo');
+  const sessionPath = join(sessionDirectory, `2026-06-10_${sessionId}.jsonl`);
+  await mkdir(sessionDirectory, { recursive: true });
+  await writeFile(
+    sessionPath,
+    `${JSON.stringify({
+      message: {
+        content: [
+          {
+            text: 'Keep Codiff in charge of the ephemeral walkthrough.',
+            type: 'text',
+          },
+        ],
+        role: 'user',
       },
-      version: 1,
-    });
-  } finally {
-    if (previousPiHome == null) {
-      delete process.env.PI_HOME;
-    } else {
-      process.env.PI_HOME = previousPiHome;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+      type: 'message',
+    })}\n`,
+  );
+
+  await expect(readPiSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [
+      {
+        role: 'user',
+        text: 'Keep Codiff in charge of the ephemeral walkthrough.',
+      },
+    ],
+    source: {
+      threadId: sessionId,
+      type: 'pi-session-excerpt',
+    },
+    version: 1,
+  });
 });
 
 test('ignores invalid Pi session ids', async () => {
@@ -122,36 +105,26 @@ test('ignores invalid Pi session ids', async () => {
 });
 
 test('reads recent Pi messages from a large session without loading the whole file', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-pi-large-session-'));
-  const sessionDirectory = join(directory, 'agent', 'sessions', 'repo');
+  await using directory = await createTemporaryDirectory('codiff-pi-large-session-');
+  const sessionDirectory = join(directory.path, 'agent', 'sessions', 'repo');
   const sessionPath = join(sessionDirectory, `${sessionId}.jsonl`);
-  const previousPiHome = process.env.PI_HOME;
+  await using _environment = createTemporaryEnvironment({ PI_HOME: directory.path });
 
-  try {
-    await mkdir(sessionDirectory, { recursive: true });
-    await writeFile(sessionPath, '');
-    await truncate(sessionPath, 17 * 1024 * 1024);
-    await appendFile(
-      sessionPath,
-      `\n${JSON.stringify({
-        message: {
-          content: [{ text: 'Newest bounded Pi message.', type: 'text' }],
-          role: 'user',
-        },
-        type: 'message',
-      })}\n`,
-    );
-    process.env.PI_HOME = directory;
+  await mkdir(sessionDirectory, { recursive: true });
+  await writeFile(sessionPath, '');
+  await truncate(sessionPath, 17 * 1024 * 1024);
+  await appendFile(
+    sessionPath,
+    `\n${JSON.stringify({
+      message: {
+        content: [{ text: 'Newest bounded Pi message.', type: 'text' }],
+        role: 'user',
+      },
+      type: 'message',
+    })}\n`,
+  );
 
-    await expect(readPiSessionContext(sessionId)).resolves.toMatchObject({
-      messages: [{ role: 'user', text: 'Newest bounded Pi message.' }],
-    });
-  } finally {
-    if (previousPiHome == null) {
-      delete process.env.PI_HOME;
-    } else {
-      process.env.PI_HOME = previousPiHome;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readPiSessionContext(sessionId)).resolves.toMatchObject({
+    messages: [{ role: 'user', text: 'Newest bounded Pi message.' }],
+  });
 });

--- a/electron/__tests__/pi.test.ts
+++ b/electron/__tests__/pi.test.ts
@@ -1,8 +1,11 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const {
@@ -56,37 +59,29 @@ test('detects Pi-not-found errors by code', () => {
   expect(isPiNotFoundError(null)).toBe(false);
 });
 
-test('rejects invalid explicit Pi CLI overrides', () => {
-  const previousPiPath = process.env.CODIFF_PI_PATH;
-  process.env.CODIFF_PI_PATH = '/tmp/codiff-missing-pi';
+test('rejects invalid explicit Pi CLI overrides', async () => {
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_PI_PATH: '/tmp/codiff-missing-pi',
+  });
 
+  expect(() => getPiCommand()).toThrow('CODIFF_PI_PATH');
   try {
-    expect(() => getPiCommand()).toThrow('CODIFF_PI_PATH');
-    try {
-      getPiCommand();
-    } catch (error) {
-      expect(error).toMatchObject({ code: PI_NOT_FOUND_CODE });
-    }
-  } finally {
-    if (previousPiPath == null) {
-      delete process.env.CODIFF_PI_PATH;
-    } else {
-      process.env.CODIFF_PI_PATH = previousPiPath;
-    }
+    getPiCommand();
+  } catch (error) {
+    expect(error).toMatchObject({ code: PI_NOT_FOUND_CODE });
   }
 });
 
 test('runs Pi as an external read-only ephemeral CLI call', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-pi-'));
-  const fakePiPath = join(directory, 'pi');
-  const argsPath = join(directory, 'args.txt');
-  const stdinPath = join(directory, 'stdin.txt');
-  const previousPiPath = process.env.CODIFF_PI_PATH;
+  await using directory = await createTemporaryDirectory('codiff-pi-');
+  const fakePiPath = join(directory.path, 'pi');
+  const argsPath = join(directory.path, 'args.txt');
+  const stdinPath = join(directory.path, 'stdin.txt');
+  await using _environment = createTemporaryEnvironment({ CODIFF_PI_PATH: fakePiPath });
 
-  try {
-    await writeFile(
-      fakePiPath,
-      `#!/usr/bin/env node
+  await writeFile(
+    fakePiPath,
+    `#!/usr/bin/env node
 const { appendFileSync, writeFileSync } = require('node:fs');
 const argsPath = ${JSON.stringify(argsPath)};
 const stdinPath = ${JSON.stringify(stdinPath)};
@@ -102,32 +97,23 @@ process.stdin.on('end', () => {
   process.stdout.write('{"version":1}');
 });
 `,
-    );
-    await chmod(fakePiPath, 0o755);
-    process.env.CODIFF_PI_PATH = fakePiPath;
+  );
+  await chmod(fakePiPath, 0o755);
 
-    await expect(
-      runPi(directory, 'prompt', { required: ['version'], type: 'object' }, 'walkthrough.json'),
-    ).resolves.toBe('{"version":1}');
+  await expect(
+    runPi(directory.path, 'prompt', { required: ['version'], type: 'object' }, 'walkthrough.json'),
+  ).resolves.toBe('{"version":1}');
 
-    const args = (await readFile(argsPath, 'utf8')).trim().split('\n');
-    expect(args).toContain('--print');
-    expect(args).toContain('--no-session');
-    expect(args).toContain('--no-skills');
-    expect(args).toContain('--no-prompt-templates');
-    expect(args).toContain('--no-context-files');
-    expect(args).toContain('--tools');
-    expect(args).toContain('read,grep,find,ls');
-    expect(args).not.toContain('--model');
-    const stdin = await readFile(stdinPath, 'utf8');
-    expect(stdin).toContain('prompt');
-    expect(stdin).toContain('Follow this JSON Schema exactly');
-  } finally {
-    if (previousPiPath == null) {
-      delete process.env.CODIFF_PI_PATH;
-    } else {
-      process.env.CODIFF_PI_PATH = previousPiPath;
-    }
-    await rm(directory, { force: true, recursive: true });
-  }
+  const args = (await readFile(argsPath, 'utf8')).trim().split('\n');
+  expect(args).toContain('--print');
+  expect(args).toContain('--no-session');
+  expect(args).toContain('--no-skills');
+  expect(args).toContain('--no-prompt-templates');
+  expect(args).toContain('--no-context-files');
+  expect(args).toContain('--tools');
+  expect(args).toContain('read,grep,find,ls');
+  expect(args).not.toContain('--model');
+  const stdin = await readFile(stdinPath, 'utf8');
+  expect(stdin).toContain('prompt');
+  expect(stdin).toContain('Follow this JSON Schema exactly');
 });

--- a/electron/__tests__/plan-review.test.ts
+++ b/electron/__tests__/plan-review.test.ts
@@ -1,10 +1,10 @@
 import { execFile } from 'node:child_process';
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
+import { createTemporaryDirectory } from '../../core/__tests__/helpers/resources.ts';
 import type { PlanReview } from '../../core/types.ts';
 
 const execFileAsync = promisify(execFile);
@@ -93,22 +93,18 @@ const addThread = (review: PlanReview, id: string, body: string): PlanReview => 
 };
 
 test('plan reviews round trip through the sidecar store', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-review-'));
-  const planFile = join(directory, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-plan-review-');
+  const planFile = join(directory.path, 'plan.md');
   const review = createReview('Keep this requirement explicit.');
 
-  try {
-    await expect(readPlanReview(directory, planFile)).resolves.toBeNull();
-    await expect(writePlanReview(directory, planFile, review)).resolves.toEqual(review);
-    await expect(readPlanReview(directory, planFile)).resolves.toEqual(review);
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readPlanReview(directory.path, planFile)).resolves.toBeNull();
+  await expect(writePlanReview(directory.path, planFile, review)).resolves.toEqual(review);
+  await expect(readPlanReview(directory.path, planFile)).resolves.toEqual(review);
 });
 
 test('plan review resolution metadata round trips through the sidecar store', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-review-'));
-  const planFile = join(directory, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-plan-review-');
+  const planFile = join(directory.path, 'plan.md');
   const review = createReview('Keep this requirement explicit.');
   const resolvedReview = {
     ...review,
@@ -123,19 +119,15 @@ test('plan review resolution metadata round trips through the sidecar store', as
     })),
   };
 
-  try {
-    await expect(writePlanReview(directory, planFile, resolvedReview)).resolves.toEqual(
-      resolvedReview,
-    );
-    await expect(readPlanReview(directory, planFile)).resolves.toEqual(resolvedReview);
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(writePlanReview(directory.path, planFile, resolvedReview)).resolves.toEqual(
+    resolvedReview,
+  );
+  await expect(readPlanReview(directory.path, planFile)).resolves.toEqual(resolvedReview);
 });
 
 test('resolves selected open plan comments by review path', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-review-'));
-  const planFile = join(directory, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-plan-review-');
+  const planFile = join(directory.path, 'plan.md');
   const review = createReview('Handle this comment.');
   const secondThread = {
     ...review.threads[0],
@@ -155,117 +147,105 @@ test('resolves selected open plan comments by review path', async () => {
     status: 'resolved' as const,
     updatedAt: '2026-06-24T01:00:00.000Z',
   };
-  const reviewPath = getPlanReviewPath(directory, planFile);
+  const reviewPath = getPlanReviewPath(directory.path, planFile);
 
-  try {
-    await writePlanReview(directory, planFile, {
-      ...review,
-      threads: [review.threads[0]!, secondThread, alreadyResolved],
-    });
-    const result = await resolvePlanReviewThreadsAtPath(
-      reviewPath,
-      ['thread-1', 'thread-3', 'missing-thread'],
-      'agent-handled',
-    );
+  await writePlanReview(directory.path, planFile, {
+    ...review,
+    threads: [review.threads[0]!, secondThread, alreadyResolved],
+  });
+  const result = await resolvePlanReviewThreadsAtPath(
+    reviewPath,
+    ['thread-1', 'thread-3', 'missing-thread'],
+    'agent-handled',
+  );
 
-    expect(result.resolvedIds).toEqual(['thread-1']);
-    expect(result.missingIds).toEqual(['missing-thread']);
-    expect(result.review.threads).toEqual([
-      expect.objectContaining({
-        id: 'thread-1',
-        resolution: expect.objectContaining({
-          reason: 'agent-handled',
-          resolvedAt: expect.any(String),
-        }),
-        status: 'resolved',
-        updatedAt: expect.any(String),
+  expect(result.resolvedIds).toEqual(['thread-1']);
+  expect(result.missingIds).toEqual(['missing-thread']);
+  expect(result.review.threads).toEqual([
+    expect.objectContaining({
+      id: 'thread-1',
+      resolution: expect.objectContaining({
+        reason: 'agent-handled',
+        resolvedAt: expect.any(String),
       }),
-      secondThread,
-      alreadyResolved,
-    ]);
-    await expect(readPlanReview(directory, planFile)).resolves.toEqual(result.review);
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+      status: 'resolved',
+      updatedAt: expect.any(String),
+    }),
+    secondThread,
+    alreadyResolved,
+  ]);
+  await expect(readPlanReview(directory.path, planFile)).resolves.toEqual(result.review);
 });
 
 test('concurrent plan review saves and resolutions preserve both updates', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-review-race-'));
-  const planFile = join(directory, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-plan-review-race-');
+  const planFile = join(directory.path, 'plan.md');
   const review = createReview('Handle this comment.');
   const reviewWithNewThread = addThread(review, 'thread-2', 'Keep this new comment.');
-  const reviewPath = getPlanReviewPath(directory, planFile);
+  const reviewPath = getPlanReviewPath(directory.path, planFile);
 
-  try {
-    await writePlanReview(directory, planFile, review);
-    await Promise.all([
-      writePlanReview(directory, planFile, reviewWithNewThread),
-      resolvePlanReviewThreadsAtPath(reviewPath, ['thread-1'], 'agent-handled'),
-    ]);
+  await writePlanReview(directory.path, planFile, review);
+  await Promise.all([
+    writePlanReview(directory.path, planFile, reviewWithNewThread),
+    resolvePlanReviewThreadsAtPath(reviewPath, ['thread-1'], 'agent-handled'),
+  ]);
 
-    await expect(readPlanReview(directory, planFile)).resolves.toEqual(
-      expect.objectContaining({
-        threads: [
-          expect.objectContaining({
-            id: 'thread-1',
-            resolution: expect.objectContaining({ reason: 'agent-handled' }),
-            status: 'resolved',
-          }),
-          expect.objectContaining({
-            id: 'thread-2',
-            status: 'open',
-          }),
-        ],
-      }),
-    );
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readPlanReview(directory.path, planFile)).resolves.toEqual(
+    expect.objectContaining({
+      threads: [
+        expect.objectContaining({
+          id: 'thread-1',
+          resolution: expect.objectContaining({ reason: 'agent-handled' }),
+          status: 'resolved',
+        }),
+        expect.objectContaining({
+          id: 'thread-2',
+          status: 'open',
+        }),
+      ],
+    }),
+  );
 });
 
 test('a stale plan save cannot reopen an agent-resolved comment', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-review-resolution-'));
-  const planFile = join(directory, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-plan-review-resolution-');
+  const planFile = join(directory.path, 'plan.md');
   const review = createReview('Handle this comment.');
   const reviewWithNewThread = addThread(review, 'thread-2', 'Keep this new comment.');
-  const reviewPath = getPlanReviewPath(directory, planFile);
+  const reviewPath = getPlanReviewPath(directory.path, planFile);
 
-  try {
-    await writePlanReview(directory, planFile, review);
-    await resolvePlanReviewThreadsAtPath(reviewPath, ['thread-1'], 'agent-handled');
-    await writePlanReview(directory, planFile, reviewWithNewThread);
+  await writePlanReview(directory.path, planFile, review);
+  await resolvePlanReviewThreadsAtPath(reviewPath, ['thread-1'], 'agent-handled');
+  await writePlanReview(directory.path, planFile, reviewWithNewThread);
 
-    await expect(readPlanReview(directory, planFile)).resolves.toEqual(
-      expect.objectContaining({
-        threads: [
-          expect.objectContaining({
-            id: 'thread-1',
-            resolution: expect.objectContaining({ reason: 'agent-handled' }),
-            status: 'resolved',
-          }),
-          expect.objectContaining({
-            id: 'thread-2',
-            status: 'open',
-          }),
-        ],
-      }),
-    );
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  await expect(readPlanReview(directory.path, planFile)).resolves.toEqual(
+    expect.objectContaining({
+      threads: [
+        expect.objectContaining({
+          id: 'thread-1',
+          resolution: expect.objectContaining({ reason: 'agent-handled' }),
+          status: 'resolved',
+        }),
+        expect.objectContaining({
+          id: 'thread-2',
+          status: 'open',
+        }),
+      ],
+    }),
+  );
 });
 
 test('cross-process plan review saves preserve concurrent agent resolution', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-review-process-race-'));
-  const planFile = join(directory, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-plan-review-process-race-');
+  const planFile = join(directory.path, 'plan.md');
   const review = createReview('Handle this comment.');
   const reviewWithNewThread = addThread(
     review,
     'thread-2',
     `Keep this new comment.${' detail'.repeat(100_000)}`,
   );
-  const reviewPath = getPlanReviewPath(directory, planFile);
-  const inputPath = join(directory, 'updated-review.json');
+  const reviewPath = getPlanReviewPath(directory.path, planFile);
+  const inputPath = join(directory.path, 'updated-review.json');
   const modulePath = resolve('electron/plan-review.cjs');
   const writer = `
     const { readFile } = require('node:fs/promises');
@@ -286,66 +266,61 @@ test('cross-process plan review saves preserve concurrent agent resolution', asy
     });
   `;
 
-  try {
-    await writePlanReview(directory, planFile, review);
-    await writeFile(inputPath, `${JSON.stringify(reviewWithNewThread)}\n`);
-    await Promise.all([
-      execFileAsync(process.execPath, ['-e', writer, modulePath, directory, planFile, inputPath]),
-      execFileAsync(process.execPath, ['-e', resolver, modulePath, reviewPath]),
-    ]);
+  await writePlanReview(directory.path, planFile, review);
+  await writeFile(inputPath, `${JSON.stringify(reviewWithNewThread)}\n`);
+  await Promise.all([
+    execFileAsync(process.execPath, [
+      '-e',
+      writer,
+      modulePath,
+      directory.path,
+      planFile,
+      inputPath,
+    ]),
+    execFileAsync(process.execPath, ['-e', resolver, modulePath, reviewPath]),
+  ]);
 
-    const savedReview = JSON.parse(await readFile(reviewPath, 'utf8')) as PlanReview;
-    expect(savedReview.threads).toEqual([
-      expect.objectContaining({
-        id: 'thread-1',
-        resolution: expect.objectContaining({ reason: 'agent-handled' }),
-        status: 'resolved',
-      }),
-      expect.objectContaining({
-        id: 'thread-2',
-        status: 'open',
-      }),
-    ]);
-    expect(await readdir(dirname(reviewPath))).toEqual([reviewPath.split('/').at(-1)]);
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  const savedReview = JSON.parse(await readFile(reviewPath, 'utf8')) as PlanReview;
+  expect(savedReview.threads).toEqual([
+    expect.objectContaining({
+      id: 'thread-1',
+      resolution: expect.objectContaining({ reason: 'agent-handled' }),
+      status: 'resolved',
+    }),
+    expect.objectContaining({
+      id: 'thread-2',
+      status: 'open',
+    }),
+  ]);
+  expect(await readdir(dirname(reviewPath))).toEqual([reviewPath.split('/').at(-1)]);
 });
 
 test('queued plan review writes preserve invocation order and leave no temporary files', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-review-'));
-  const planFile = join(directory, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-plan-review-');
+  const planFile = join(directory.path, 'plan.md');
   const reviews = ['First', 'Second', 'Final'].map(createReview);
 
-  try {
-    await Promise.all(reviews.map((review) => writePlanReview(directory, planFile, review)));
-    await expect(readPlanReview(directory, planFile)).resolves.toEqual(reviews.at(-1));
+  await Promise.all(reviews.map((review) => writePlanReview(directory.path, planFile, review)));
+  await expect(readPlanReview(directory.path, planFile)).resolves.toEqual(reviews.at(-1));
 
-    const reviewPath = getPlanReviewPath(directory, planFile);
-    expect(await readdir(dirname(reviewPath))).toEqual([reviewPath.split('/').at(-1)]);
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  const reviewPath = getPlanReviewPath(directory.path, planFile);
+  expect(await readdir(dirname(reviewPath))).toEqual([reviewPath.split('/').at(-1)]);
 });
 
 test('invalid plan review schemas are rejected on write and read', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-review-'));
-  const planFile = join(directory, 'plan.md');
+  await using directory = await createTemporaryDirectory('codiff-plan-review-');
+  const planFile = join(directory.path, 'plan.md');
   const invalidReview = {
     ...createReview('Invalid'),
     threads: [{ id: 'missing-required-fields' }],
   };
 
-  try {
-    await expect(writePlanReview(directory, planFile, invalidReview)).rejects.toThrow(
-      'Invalid plan review.',
-    );
+  await expect(writePlanReview(directory.path, planFile, invalidReview)).rejects.toThrow(
+    'Invalid plan review.',
+  );
 
-    const reviewPath = getPlanReviewPath(directory, planFile);
-    await mkdir(dirname(reviewPath), { recursive: true });
-    await writeFile(reviewPath, `${JSON.stringify(invalidReview)}\n`);
-    await expect(readPlanReview(directory, planFile)).rejects.toThrow('Invalid plan review.');
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+  const reviewPath = getPlanReviewPath(directory.path, planFile);
+  await mkdir(dirname(reviewPath), { recursive: true });
+  await writeFile(reviewPath, `${JSON.stringify(invalidReview)}\n`);
+  await expect(readPlanReview(directory.path, planFile)).rejects.toThrow('Invalid plan review.');
 });

--- a/electron/__tests__/pull-request-review.test.ts
+++ b/electron/__tests__/pull-request-review.test.ts
@@ -1,11 +1,13 @@
 import { execFile } from 'node:child_process';
-import { chmod, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
-import { removeGitTestDirectory } from '../../core/__tests__/helpers/git.ts';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { submitPullRequestReview } = require('../git-state/pull-request.cjs') as {
@@ -26,29 +28,7 @@ const { submitPullRequestReview } = require('../git-state/pull-request.cjs') as 
 
 const execFileAsync = promisify(execFile);
 
-test('submits normalized GitHub review payloads through the GitHub CLI', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-pull-request-review-'));
-  const repo = join(directory, 'repo');
-  const fakeBin = join(directory, 'bin');
-  const fakeGh = join(fakeBin, 'gh');
-  const callsPath = join(directory, 'calls.jsonl');
-  const previousPath = process.env.PATH;
-  const previousCallsPath = process.env.CODIFF_GITHUB_REVIEW_TEST_CALLS;
-
-  try {
-    await Promise.all([mkdir(repo), mkdir(fakeBin)]);
-    await execFileAsync('git', ['-C', repo, 'init']);
-    await execFileAsync('git', [
-      '-C',
-      repo,
-      'remote',
-      'add',
-      'origin',
-      'git@github.com:nkzw-tech/codiff.git',
-    ]);
-    await writeFile(
-      fakeGh,
-      `#!/usr/bin/env node
+const FAKE_GH_SCRIPT = `#!/usr/bin/env node
 const { appendFileSync } = require('node:fs');
 const args = process.argv.slice(2);
 let input = '';
@@ -65,97 +45,105 @@ process.stdin.on('end', () => {
       : '{}',
   );
 });
-`,
-    );
-    await chmod(fakeGh, 0o755);
-    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
-    process.env.CODIFF_GITHUB_REVIEW_TEST_CALLS = callsPath;
+`;
 
-    const source = {
-      provider: 'github' as const,
-      type: 'pull-request' as const,
-      url: 'https://github.com/nkzw-tech/codiff/pull/12',
-    };
+test('submits normalized GitHub review payloads through the GitHub CLI', async () => {
+  await using directory = await createTemporaryDirectory('codiff-pull-request-review-');
+  const repo = join(directory.path, 'repo');
+  const fakeBin = join(directory.path, 'bin');
+  const fakeGh = join(fakeBin, 'gh');
+  const callsPath = join(directory.path, 'calls.jsonl');
 
-    await submitPullRequestReview(repo, {
-      comments: [
-        {
-          body: 'Please keep this explicit.',
-          filePath: 'src/app.ts',
-          lineNumber: 7,
-          side: 'additions',
+  await Promise.all([mkdir(repo), mkdir(fakeBin)]);
+  await execFileAsync('git', ['-C', repo, 'init']);
+  await execFileAsync('git', [
+    '-C',
+    repo,
+    'remote',
+    'add',
+    'origin',
+    'git@github.com:nkzw-tech/codiff.git',
+  ]);
+  await writeFile(fakeGh, FAKE_GH_SCRIPT);
+  await chmod(fakeGh, 0o755);
+
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_GITHUB_REVIEW_TEST_CALLS: callsPath,
+    PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+  });
+
+  const source = {
+    provider: 'github' as const,
+    type: 'pull-request' as const,
+    url: 'https://github.com/nkzw-tech/codiff/pull/12',
+  };
+
+  await submitPullRequestReview(repo, {
+    comments: [
+      {
+        body: 'Please keep this explicit.',
+        filePath: 'src/app.ts',
+        lineNumber: 7,
+        side: 'additions',
+      },
+    ],
+    event: 'COMMENT',
+    source,
+  });
+  await submitPullRequestReview(repo, {
+    body: '  General feedback.  ',
+    comments: [],
+    event: 'COMMENT',
+    source,
+  });
+  await expect(
+    submitPullRequestReview(repo, {
+      body: '   ',
+      comments: [],
+      event: 'COMMENT',
+      source,
+    }),
+  ).rejects.toThrow('A comment review requires an inline comment or a review comment.');
+  await submitPullRequestReview(repo, {
+    comments: [],
+    event: 'REQUEST_CHANGES',
+    source,
+  });
+
+  const calls = (await readFile(callsPath, 'utf8'))
+    .trim()
+    .split('\n')
+    .map(
+      (line) =>
+        JSON.parse(line) as {
+          args: ReadonlyArray<string>;
+          input: string;
         },
-      ],
-      event: 'COMMENT',
-      source,
-    });
-    await submitPullRequestReview(repo, {
-      body: '  General feedback.  ',
-      comments: [],
-      event: 'COMMENT',
-      source,
-    });
-    await expect(
-      submitPullRequestReview(repo, {
-        body: '   ',
-        comments: [],
-        event: 'COMMENT',
-        source,
-      }),
-    ).rejects.toThrow('A comment review requires an inline comment or a review comment.');
-    await submitPullRequestReview(repo, {
-      comments: [],
-      event: 'REQUEST_CHANGES',
-      source,
-    });
-
-    const calls = (await readFile(callsPath, 'utf8'))
-      .trim()
-      .split('\n')
-      .map(
-        (line) =>
-          JSON.parse(line) as {
-            args: ReadonlyArray<string>;
-            input: string;
-          },
-      );
-    const reviewCalls = calls.filter((call) =>
-      call.args.includes('repos/nkzw-tech/codiff/pulls/12/reviews'),
     );
-    expect(reviewCalls).toHaveLength(3);
-    expect(JSON.parse(reviewCalls[0].input)).toEqual({
-      body: '',
-      comments: [
-        {
-          body: 'Please keep this explicit.',
-          line: 7,
-          path: 'src/app.ts',
-          side: 'RIGHT',
-        },
-      ],
-      event: 'COMMENT',
-    });
-    expect(JSON.parse(reviewCalls[1].input)).toEqual({
-      body: 'General feedback.',
-      comments: [],
-      event: 'COMMENT',
-    });
-    expect(JSON.parse(reviewCalls[2].input)).toEqual({
-      body: 'Requesting changes.',
-      comments: [],
-      event: 'REQUEST_CHANGES',
-    });
-  } finally {
-    if (previousPath == null) {
-      delete process.env.PATH;
-    } else {
-      process.env.PATH = previousPath;
-    }
-    if (previousCallsPath == null) {
-      delete process.env.CODIFF_GITHUB_REVIEW_TEST_CALLS;
-    } else {
-      process.env.CODIFF_GITHUB_REVIEW_TEST_CALLS = previousCallsPath;
-    }
-    await removeGitTestDirectory(directory);
-  }
+  const reviewCalls = calls.filter((call) =>
+    call.args.includes('repos/nkzw-tech/codiff/pulls/12/reviews'),
+  );
+  expect(reviewCalls).toHaveLength(3);
+  expect(JSON.parse(reviewCalls[0].input)).toEqual({
+    body: '',
+    comments: [
+      {
+        body: 'Please keep this explicit.',
+        line: 7,
+        path: 'src/app.ts',
+        side: 'RIGHT',
+      },
+    ],
+    event: 'COMMENT',
+  });
+  expect(JSON.parse(reviewCalls[1].input)).toEqual({
+    body: 'General feedback.',
+    comments: [],
+    event: 'COMMENT',
+  });
+  expect(JSON.parse(reviewCalls[2].input)).toEqual({
+    body: 'Requesting changes.',
+    comments: [],
+    event: 'REQUEST_CHANGES',
+  });
 });

--- a/electron/__tests__/pull-request-review.test.ts
+++ b/electron/__tests__/pull-request-review.test.ts
@@ -28,25 +28,6 @@ const { submitPullRequestReview } = require('../git-state/pull-request.cjs') as 
 
 const execFileAsync = promisify(execFile);
 
-const FAKE_GH_SCRIPT = `#!/usr/bin/env node
-const { appendFileSync } = require('node:fs');
-const args = process.argv.slice(2);
-let input = '';
-process.stdin.setEncoding('utf8');
-process.stdin.on('data', (chunk) => { input += chunk; });
-process.stdin.on('end', () => {
-  appendFileSync(
-    process.env.CODIFF_GITHUB_REVIEW_TEST_CALLS,
-    JSON.stringify({ args, input }) + '\\n',
-  );
-  process.stdout.write(
-    args.includes('repos/nkzw-tech/codiff/pulls/12')
-      ? '{"head":{"sha":"0123456789abcdef0123456789abcdef01234567"}}'
-      : '{}',
-  );
-});
-`;
-
 test('submits normalized GitHub review payloads through the GitHub CLI', async () => {
   await using directory = await createTemporaryDirectory('codiff-pull-request-review-');
   const repo = join(directory.path, 'repo');
@@ -64,7 +45,27 @@ test('submits normalized GitHub review payloads through the GitHub CLI', async (
     'origin',
     'git@github.com:nkzw-tech/codiff.git',
   ]);
-  await writeFile(fakeGh, FAKE_GH_SCRIPT);
+  await writeFile(
+    fakeGh,
+    `#!/usr/bin/env node
+const { appendFileSync } = require('node:fs');
+const args = process.argv.slice(2);
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  appendFileSync(
+    process.env.CODIFF_GITHUB_REVIEW_TEST_CALLS,
+    JSON.stringify({ args, input }) + '\\n',
+  );
+  process.stdout.write(
+    args.includes('repos/nkzw-tech/codiff/pulls/12')
+      ? '{"head":{"sha":"0123456789abcdef0123456789abcdef01234567"}}'
+      : '{}',
+  );
+});
+`,
+  );
   await chmod(fakeGh, 0o755);
 
   await using _environment = createTemporaryEnvironment({

--- a/electron/__tests__/repository-watcher.test.ts
+++ b/electron/__tests__/repository-watcher.test.ts
@@ -1,11 +1,14 @@
 import { execFile } from 'node:child_process';
-import { mkdtemp, readFile, realpath, stat, utimes, writeFile } from 'node:fs/promises';
+import { readFile, realpath, stat, utimes, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
-import { getGitTestEnvironment, removeGitTestDirectory } from '../../core/__tests__/helpers/git.ts';
+import { getGitTestEnvironment } from '../../core/__tests__/helpers/git.ts';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 type Snapshot = {
   head: string;
@@ -373,21 +376,13 @@ test('uses focused, background, and hidden polling intervals', () => {
 });
 
 test('clean and large dirty repository watcher polls use one Git process', async () => {
-  const repository = await realpath(await mkdtemp(join(tmpdir(), 'codiff-repository-watcher-')));
+  await using directory = await createTemporaryDirectory('codiff-repository-watcher-');
+  const repository = await realpath(directory.path);
   const largePath = join(repository, 'large.bin');
   const countGitProcesses = async (label: string, knownDirtyPaths: ReadonlyArray<string>) => {
     const tracePath = join(repository, '.git', `trace-${label}.jsonl`);
-    const previousTrace = process.env.GIT_TRACE2_EVENT;
-    process.env.GIT_TRACE2_EVENT = tracePath;
-    try {
-      await readRepositoryWatcherSnapshot(repository, [], knownDirtyPaths);
-    } finally {
-      if (previousTrace == null) {
-        delete process.env.GIT_TRACE2_EVENT;
-      } else {
-        process.env.GIT_TRACE2_EVENT = previousTrace;
-      }
-    }
+    await using _traceEnvironment = createTemporaryEnvironment({ GIT_TRACE2_EVENT: tracePath });
+    await readRepositoryWatcherSnapshot(repository, [], knownDirtyPaths);
     return (await readFile(tracePath, 'utf8'))
       .trim()
       .split('\n')
@@ -396,63 +391,55 @@ test('clean and large dirty repository watcher polls use one Git process', async
       .filter(({ event }) => event === 'version').length;
   };
 
-  try {
-    await git(repository, ['init']);
-    await writeFile(largePath, Buffer.alloc(largeTestFileSize, 1));
-    await git(repository, ['add', 'large.bin']);
-    await git(repository, ['commit', '-m', 'initial']);
+  await git(repository, ['init']);
+  await writeFile(largePath, Buffer.alloc(largeTestFileSize, 1));
+  await git(repository, ['add', 'large.bin']);
+  await git(repository, ['commit', '-m', 'initial']);
 
-    const cleanProcessCount = await countGitProcesses('clean', []);
-    await writeFile(largePath, Buffer.alloc(largeTestFileSize, 2));
-    const initialDirtySnapshot = await readRepositoryWatcherSnapshot(repository);
-    const dirtyProcessCount = await countGitProcesses(
-      'dirty',
-      Object.keys(initialDirtySnapshot.pathSignatures),
-    );
-    await writeFile(join(repository, 'new.txt'), 'new\n');
-    const combinedSnapshot = await readRepositoryWatcherSnapshot(repository, [], ['large.bin']);
-    const snapshot = await readRepositoryWatcherSnapshot(repository, ['large.bin'], ['large.bin']);
+  const cleanProcessCount = await countGitProcesses('clean', []);
+  await writeFile(largePath, Buffer.alloc(largeTestFileSize, 2));
+  const initialDirtySnapshot = await readRepositoryWatcherSnapshot(repository);
+  const dirtyProcessCount = await countGitProcesses(
+    'dirty',
+    Object.keys(initialDirtySnapshot.pathSignatures),
+  );
+  await writeFile(join(repository, 'new.txt'), 'new\n');
+  const combinedSnapshot = await readRepositoryWatcherSnapshot(repository, [], ['large.bin']);
+  const snapshot = await readRepositoryWatcherSnapshot(repository, ['large.bin'], ['large.bin']);
 
-    expect(cleanProcessCount).toBe(1);
-    expect(dirtyProcessCount).toBe(1);
-    expect(initialDirtySnapshot.pathVersions).toEqual({});
-    expect(Object.keys(combinedSnapshot.pathSignatures).sort()).toEqual(['large.bin', 'new.txt']);
-    expect(snapshot.pathSignatures['large.bin'].split('\0')).toHaveLength(7);
-    expect(snapshot.pathVersions?.['large.bin']).toHaveLength(16);
-  } finally {
-    delete process.env.GIT_TRACE2_EVENT;
-    await removeGitTestDirectory(repository);
-  }
+  expect(cleanProcessCount).toBe(1);
+  expect(dirtyProcessCount).toBe(1);
+  expect(initialDirtySnapshot.pathVersions).toEqual({});
+  expect(Object.keys(combinedSnapshot.pathSignatures).sort()).toEqual(['large.bin', 'new.txt']);
+  expect(snapshot.pathSignatures['large.bin'].split('\0')).toHaveLength(7);
+  expect(snapshot.pathVersions?.['large.bin']).toHaveLength(16);
 }, 15_000);
 
 test('detects same-size edits when the modification time is preserved', async () => {
-  const repository = await realpath(await mkdtemp(join(tmpdir(), 'codiff-preserved-mtime-')));
+  await using directory = await createTemporaryDirectory('codiff-preserved-mtime-');
+  const repository = await realpath(directory.path);
   const path = join(repository, 'same-size.txt');
   const fixedTime = 1_700_000_000;
 
-  try {
-    await git(repository, ['init']);
-    await writeFile(path, 'first\n');
-    await utimes(path, fixedTime, fixedTime);
-    const before = await readRepositoryWatcherSnapshot(repository);
-    const beforeStat = await stat(path);
+  await git(repository, ['init']);
+  await writeFile(path, 'first\n');
+  await utimes(path, fixedTime, fixedTime);
+  const before = await readRepositoryWatcherSnapshot(repository);
+  const beforeStat = await stat(path);
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    await writeFile(path, 'other\n');
-    await utimes(path, fixedTime, fixedTime);
-    const afterStat = await stat(path);
-    const after = await readRepositoryWatcherSnapshot(
-      repository,
-      [],
-      Object.keys(before.pathSignatures),
-    );
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  await writeFile(path, 'other\n');
+  await utimes(path, fixedTime, fixedTime);
+  const afterStat = await stat(path);
+  const after = await readRepositoryWatcherSnapshot(
+    repository,
+    [],
+    Object.keys(before.pathSignatures),
+  );
 
-    expect(afterStat.size).toBe(beforeStat.size);
-    expect(afterStat.mtimeMs).toBe(beforeStat.mtimeMs);
-    expect(after.signature).not.toBe(before.signature);
-  } finally {
-    await removeGitTestDirectory(repository);
-  }
+  expect(afterStat.size).toBe(beforeStat.size);
+  expect(afterStat.mtimeMs).toBe(beforeStat.mtimeMs);
+  expect(after.signature).not.toBe(before.signature);
 });
 
 test('preserves literal backslashes in POSIX repository paths', async () => {
@@ -460,23 +447,20 @@ test('preserves literal backslashes in POSIX repository paths', async () => {
     return;
   }
 
-  const repository = await realpath(await mkdtemp(join(tmpdir(), 'codiff-backslash-path-')));
+  await using directory = await createTemporaryDirectory('codiff-backslash-path-');
+  const repository = await realpath(directory.path);
   const path = 'foo\\bar.txt';
 
-  try {
-    await git(repository, ['init']);
-    await writeFile(join(repository, path), 'dirty\n');
-    const before = await readRepositoryWatcherSnapshot(repository);
-    const after = await readRepositoryWatcherSnapshot(
-      repository,
-      [],
-      Object.keys(before.pathSignatures),
-    );
+  await git(repository, ['init']);
+  await writeFile(join(repository, path), 'dirty\n');
+  const before = await readRepositoryWatcherSnapshot(repository);
+  const after = await readRepositoryWatcherSnapshot(
+    repository,
+    [],
+    Object.keys(before.pathSignatures),
+  );
 
-    expect(Object.keys(before.pathSignatures)).toEqual([path]);
-    expect(Object.keys(after.pathSignatures)).toEqual([path]);
-    expect(after.signature).toBe(before.signature);
-  } finally {
-    await removeGitTestDirectory(repository);
-  }
+  expect(Object.keys(before.pathSignatures)).toEqual([path]);
+  expect(Object.keys(after.pathSignatures)).toEqual([path]);
+  expect(after.signature).toBe(before.signature);
 });

--- a/electron/__tests__/system-certificates.test.ts
+++ b/electron/__tests__/system-certificates.test.ts
@@ -45,20 +45,21 @@ test.sequential('merges default, extra, and system certificates once', () => {
     },
     setDefaultCACertificates,
   });
+  using _cleanup = {
+    [Symbol.dispose]() {
+      restore();
+    },
+  };
 
-  try {
-    expect(trustSystemCertificates()).toEqual({ status: 'applied' });
-    expect(trustSystemCertificates()).toEqual({ status: 'applied' });
-    expect(setDefaultCACertificates).toHaveBeenCalledOnce();
-    expect(setDefaultCACertificates).toHaveBeenCalledWith([
-      'default-ca',
-      'shared-ca',
-      'extra-ca',
-      'system-ca',
-    ]);
-  } finally {
-    restore();
-  }
+  expect(trustSystemCertificates()).toEqual({ status: 'applied' });
+  expect(trustSystemCertificates()).toEqual({ status: 'applied' });
+  expect(setDefaultCACertificates).toHaveBeenCalledOnce();
+  expect(setDefaultCACertificates).toHaveBeenCalledWith([
+    'default-ca',
+    'shared-ca',
+    'extra-ca',
+    'system-ca',
+  ]);
 });
 
 test.sequential('does not mark certificate trust as initialized after a failed apply', () => {
@@ -72,37 +73,40 @@ test.sequential('does not mark certificate trust as initialized after a failed a
     getCACertificates: (source) => (source === 'system' ? ['system-ca'] : []),
     setDefaultCACertificates,
   });
+  using _cleanup = {
+    [Symbol.dispose]() {
+      restore();
+    },
+  };
 
-  try {
-    expect(trustSystemCertificates()).toEqual({ reason: 'keychain busy', status: 'failed' });
-    expect(trustSystemCertificates()).toEqual({ status: 'applied' });
-    expect(setDefaultCACertificates).toHaveBeenCalledTimes(2);
-  } finally {
-    restore();
-  }
+  expect(trustSystemCertificates()).toEqual({ reason: 'keychain busy', status: 'failed' });
+  expect(trustSystemCertificates()).toEqual({ status: 'applied' });
+  expect(setDefaultCACertificates).toHaveBeenCalledTimes(2);
 });
 
 test.sequential('reports unavailable and empty system certificate stores', () => {
   const unavailable = loadTrustSystemCertificates({});
-  try {
-    expect(unavailable.trustSystemCertificates()).toEqual({
-      reason: 'this Node/Electron runtime does not expose system certificate APIs',
-      status: 'unavailable',
-    });
-  } finally {
-    unavailable.restore();
-  }
+  using _unavailableCleanup = {
+    [Symbol.dispose]() {
+      unavailable.restore();
+    },
+  };
+  expect(unavailable.trustSystemCertificates()).toEqual({
+    reason: 'this Node/Electron runtime does not expose system certificate APIs',
+    status: 'unavailable',
+  });
 
   const empty = loadTrustSystemCertificates({
     getCACertificates: () => [],
     setDefaultCACertificates: vi.fn(),
   });
-  try {
-    expect(empty.trustSystemCertificates()).toEqual({
-      reason: 'the system certificate store was empty',
-      status: 'empty-system',
-    });
-  } finally {
-    empty.restore();
-  }
+  using _emptyCleanup = {
+    [Symbol.dispose]() {
+      empty.restore();
+    },
+  };
+  expect(empty.trustSystemCertificates()).toEqual({
+    reason: 'the system certificate store was empty',
+    status: 'empty-system',
+  });
 });

--- a/electron/__tests__/walkthrough-commit.test.ts
+++ b/electron/__tests__/walkthrough-commit.test.ts
@@ -4,7 +4,10 @@ import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
-import { getGitTestEnvironment, withGitTestEnvironment } from '../../core/__tests__/helpers/git.ts';
+import {
+  getGitTestEnvironmentForSubprocess,
+  withGitTestEnvironment,
+} from '../../core/__tests__/helpers/git.ts';
 import {
   createTemporaryDirectory,
   createTemporaryEnvironment,
@@ -24,7 +27,7 @@ const execFileAsync = promisify(execFile);
 const git = async (repoPath: string, args: ReadonlyArray<string>) => {
   const { stdout } = await execFileAsync('git', ['-C', repoPath, ...args], {
     encoding: 'utf8',
-    env: getGitTestEnvironment(),
+    env: getGitTestEnvironmentForSubprocess(),
   });
   return stdout;
 };

--- a/electron/__tests__/walkthrough-commit.test.ts
+++ b/electron/__tests__/walkthrough-commit.test.ts
@@ -5,7 +5,10 @@ import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
 import { getGitTestEnvironment, withGitTestEnvironment } from '../../core/__tests__/helpers/git.ts';
-import { createTemporaryDirectory } from '../../core/__tests__/helpers/resources.ts';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { createWalkthroughCommit } = require('../walkthrough-commit.cjs') as {
@@ -100,6 +103,9 @@ test('streams hook output and returns stripped failure text', async () => {
     );
     await chmod(join(repoPath, '.git/hooks/pre-commit'), 0o755);
     await writeFile(join(repoPath, 'example.txt'), 'after\n');
+    await using _localHooks = createTemporaryEnvironment({
+      GIT_CONFIG_VALUE_3: join(repoPath, '.git/hooks'),
+    });
 
     const output: Array<string> = [];
     const result = await createWalkthroughCommit(

--- a/electron/__tests__/walkthrough-commit.test.ts
+++ b/electron/__tests__/walkthrough-commit.test.ts
@@ -1,15 +1,14 @@
 import { execFile } from 'node:child_process';
-import { chmod, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
+import { getGitTestEnvironment, withGitTestEnvironment } from '../../core/__tests__/helpers/git.ts';
 import {
-  getGitTestEnvironment,
-  removeGitTestDirectory,
-  withGitTestEnvironment,
-} from '../../core/__tests__/helpers/git.ts';
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { createWalkthroughCommit } = require('../walkthrough-commit.cjs') as {
@@ -32,13 +31,9 @@ const git = async (repoPath: string, args: ReadonlyArray<string>) => {
 
 const withRepo = async (testBody: (repoPath: string) => Promise<void>) => {
   await withGitTestEnvironment(async () => {
-    const repoPath = await mkdtemp(join(tmpdir(), 'codiff-walkthrough-commit-'));
-    try {
-      await git(repoPath, ['init']);
-      await testBody(repoPath);
-    } finally {
-      await removeGitTestDirectory(repoPath);
-    }
+    await using directory = await createTemporaryDirectory('codiff-walkthrough-commit-');
+    await git(directory.path, ['init']);
+    await testBody(directory.path);
   });
 };
 
@@ -108,6 +103,9 @@ test('streams hook output and returns stripped failure text', async () => {
     );
     await chmod(join(repoPath, '.git/hooks/pre-commit'), 0o755);
     await writeFile(join(repoPath, 'example.txt'), 'after\n');
+    await using _localHooks = createTemporaryEnvironment({
+      GIT_CONFIG_VALUE_3: join(repoPath, '.git/hooks'),
+    });
 
     const output: Array<string> = [];
     const result = await createWalkthroughCommit(

--- a/electron/__tests__/walkthrough-commit.test.ts
+++ b/electron/__tests__/walkthrough-commit.test.ts
@@ -5,10 +5,7 @@ import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
 import { getGitTestEnvironment, withGitTestEnvironment } from '../../core/__tests__/helpers/git.ts';
-import {
-  createTemporaryDirectory,
-  createTemporaryEnvironment,
-} from '../../core/__tests__/helpers/resources.ts';
+import { createTemporaryDirectory } from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { createWalkthroughCommit } = require('../walkthrough-commit.cjs') as {
@@ -103,9 +100,6 @@ test('streams hook output and returns stripped failure text', async () => {
     );
     await chmod(join(repoPath, '.git/hooks/pre-commit'), 0o755);
     await writeFile(join(repoPath, 'example.txt'), 'after\n');
-    await using _localHooks = createTemporaryEnvironment({
-      GIT_CONFIG_VALUE_3: join(repoPath, '.git/hooks'),
-    });
 
     const output: Array<string> = [];
     const result = await createWalkthroughCommit(

--- a/electron/__tests__/walkthrough-diagnosis.test.ts
+++ b/electron/__tests__/walkthrough-diagnosis.test.ts
@@ -1,11 +1,11 @@
 import { execFile } from 'node:child_process';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
-import { getGitTestEnvironment, removeGitTestDirectory } from '../../core/__tests__/helpers/git.ts';
+import { getGitTestEnvironment } from '../../core/__tests__/helpers/git.ts';
+import { createTemporaryDirectory } from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { diagnoseWalkthroughMismatch } = require('../walkthrough-diagnosis.cjs') as {
@@ -25,12 +25,6 @@ const git = async (repo: string, args: ReadonlyArray<string>) => {
   });
 };
 
-const makeRepo = async () => {
-  const repo = await mkdtemp(join(tmpdir(), 'codiff-diagnosis-'));
-  await git(repo, ['init']);
-  return repo;
-};
-
 const walkthroughFor = (path: string, extra: Record<string, unknown> = {}) => ({
   source: { kind: 'working-tree' },
   chapters: [{ stops: [{ anchors: [{ path }] }] }],
@@ -45,95 +39,80 @@ const v4WalkthroughFor = (path: string, extra: Record<string, unknown> = {}) => 
 });
 
 test('reports changes committed after the walkthrough was authored', async () => {
-  const repo = await makeRepo();
-  try {
-    await writeFile(join(repo, 'feature.ts'), 'export const value = 1;\n');
-    await git(repo, ['add', 'feature.ts']);
-    await git(repo, ['commit', '-m', 'Add the feature']);
+  await using directory = await createTemporaryDirectory('codiff-diagnosis-');
+  await git(directory.path, ['init']);
+  await writeFile(join(directory.path, 'feature.ts'), 'export const value = 1;\n');
+  await git(directory.path, ['add', 'feature.ts']);
+  await git(directory.path, ['commit', '-m', 'Add the feature']);
 
-    const reason = await diagnoseWalkthroughMismatch({
-      hasFiles: false,
-      // Authored well before the commit above, so it counts as committed-after.
-      input: walkthroughFor('feature.ts', { generatedAt: '2000-01-01T00:00:00.000Z' }),
-      repositoryRoot: repo,
-    });
+  const reason = await diagnoseWalkthroughMismatch({
+    hasFiles: false,
+    // Authored well before the commit above, so it counts as committed-after.
+    input: walkthroughFor('feature.ts', { generatedAt: '2000-01-01T00:00:00.000Z' }),
+    repositoryRoot: directory.path,
+  });
 
-    expect(reason).toContain('committed since the walkthrough was authored');
-    expect(reason).toContain('Add the feature');
-  } finally {
-    await removeGitTestDirectory(repo);
-  }
+  expect(reason).toContain('committed since the walkthrough was authored');
+  expect(reason).toContain('Add the feature');
 });
 
 test('reports v4 hunk-id changes committed after the walkthrough was authored', async () => {
-  const repo = await makeRepo();
-  try {
-    await writeFile(join(repo, 'feature.ts'), 'export const value = 1;\n');
-    await git(repo, ['add', 'feature.ts']);
-    await git(repo, ['commit', '-m', 'Add the v4 feature']);
+  await using directory = await createTemporaryDirectory('codiff-diagnosis-');
+  await git(directory.path, ['init']);
+  await writeFile(join(directory.path, 'feature.ts'), 'export const value = 1;\n');
+  await git(directory.path, ['add', 'feature.ts']);
+  await git(directory.path, ['commit', '-m', 'Add the v4 feature']);
 
-    const reason = await diagnoseWalkthroughMismatch({
-      hasFiles: false,
-      input: v4WalkthroughFor('feature.ts', { generatedAt: '2000-01-01T00:00:00.000Z' }),
-      repositoryRoot: repo,
-    });
+  const reason = await diagnoseWalkthroughMismatch({
+    hasFiles: false,
+    input: v4WalkthroughFor('feature.ts', { generatedAt: '2000-01-01T00:00:00.000Z' }),
+    repositoryRoot: directory.path,
+  });
 
-    expect(reason).toContain('committed since the walkthrough was authored');
-    expect(reason).toContain('Add the v4 feature');
-  } finally {
-    await removeGitTestDirectory(repo);
-  }
+  expect(reason).toContain('committed since the walkthrough was authored');
+  expect(reason).toContain('Add the v4 feature');
 });
 
 test('treats a commit that predates authoring as reverted, not committed', async () => {
-  const repo = await makeRepo();
-  try {
-    await writeFile(join(repo, 'feature.ts'), 'export const value = 1;\n');
-    await git(repo, ['add', 'feature.ts']);
-    await git(repo, ['commit', '-m', 'Old commit']);
+  await using directory = await createTemporaryDirectory('codiff-diagnosis-');
+  await git(directory.path, ['init']);
+  await writeFile(join(directory.path, 'feature.ts'), 'export const value = 1;\n');
+  await git(directory.path, ['add', 'feature.ts']);
+  await git(directory.path, ['commit', '-m', 'Old commit']);
 
-    const reason = await diagnoseWalkthroughMismatch({
-      hasFiles: false,
-      // Authored far in the future relative to the only commit touching the file.
-      input: walkthroughFor('feature.ts', { generatedAt: '2999-01-01T00:00:00.000Z' }),
-      repositoryRoot: repo,
-    });
+  const reason = await diagnoseWalkthroughMismatch({
+    hasFiles: false,
+    // Authored far in the future relative to the only commit touching the file.
+    input: walkthroughFor('feature.ts', { generatedAt: '2999-01-01T00:00:00.000Z' }),
+    repositoryRoot: directory.path,
+  });
 
-    expect(reason).toContain('reverted');
-    expect(reason).not.toContain('committed since');
-  } finally {
-    await removeGitTestDirectory(repo);
-  }
+  expect(reason).toContain('reverted');
+  expect(reason).not.toContain('committed since');
 });
 
 test('reports never-committed paths as reverted or discarded', async () => {
-  const repo = await makeRepo();
-  try {
-    await git(repo, ['commit', '--allow-empty', '-m', 'initial']);
+  await using directory = await createTemporaryDirectory('codiff-diagnosis-');
+  await git(directory.path, ['init']);
+  await git(directory.path, ['commit', '--allow-empty', '-m', 'initial']);
 
-    const reason = await diagnoseWalkthroughMismatch({
-      hasFiles: false,
-      input: walkthroughFor('untracked.ts'),
-      repositoryRoot: repo,
-    });
+  const reason = await diagnoseWalkthroughMismatch({
+    hasFiles: false,
+    input: walkthroughFor('untracked.ts'),
+    repositoryRoot: directory.path,
+  });
 
-    expect(reason).toContain('reverted or discarded');
-  } finally {
-    await removeGitTestDirectory(repo);
-  }
+  expect(reason).toContain('reverted or discarded');
 });
 
 test('defers to the caller when the diff still has files', async () => {
-  const repo = await makeRepo();
-  try {
-    expect(
-      await diagnoseWalkthroughMismatch({
-        hasFiles: true,
-        input: walkthroughFor('feature.ts'),
-        repositoryRoot: repo,
-      }),
-    ).toBeNull();
-  } finally {
-    await removeGitTestDirectory(repo);
-  }
+  await using directory = await createTemporaryDirectory('codiff-diagnosis-');
+  await git(directory.path, ['init']);
+  expect(
+    await diagnoseWalkthroughMismatch({
+      hasFiles: true,
+      input: walkthroughFor('feature.ts'),
+      repositoryRoot: directory.path,
+    }),
+  ).toBeNull();
 });

--- a/electron/__tests__/window-identity.test.ts
+++ b/electron/__tests__/window-identity.test.ts
@@ -1,11 +1,14 @@
 import { execFile } from 'node:child_process';
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from 'vite-plus/test';
-import { getGitTestEnvironment, removeGitTestDirectory } from '../../core/__tests__/helpers/git.ts';
+import { getGitTestEnvironment } from '../../core/__tests__/helpers/git.ts';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { findMatchingWindowIdentity, getWindowIdentity, getWindowIdentityForRepositoryState } =
@@ -54,214 +57,187 @@ const git = async (repo: string, args: ReadonlyArray<string>) => {
   return result.stdout.trim();
 };
 
-const createRepository = async () => {
-  const repositoryPath = await mkdtemp(join(tmpdir(), 'codiff-window-identity-'));
-  await git(repositoryPath, ['init']);
-  await git(repositoryPath, ['commit', '--allow-empty', '-m', 'initial']);
-  return repositoryPath;
+const initRepository = async (path: string) => {
+  await git(path, ['init']);
+  await git(path, ['commit', '--allow-empty', '-m', 'initial']);
 };
 
 test.sequential('plan window identities do not invoke Git outside repositories', async () => {
-  const directory = await mkdtemp(join(tmpdir(), 'codiff-plan-window-identity-'));
-  const fakeBin = join(directory, 'bin');
-  const gitMarker = join(directory, 'git-invoked');
-  const planFile = join(directory, 'plan.md');
-  const previousPath = process.env.PATH;
+  await using directory = await createTemporaryDirectory('codiff-plan-window-identity-');
+  const fakeBin = join(directory.path, 'bin');
+  const gitMarker = join(directory.path, 'git-invoked');
+  const planFile = join(directory.path, 'plan.md');
+  await using _environment = createTemporaryEnvironment({
+    PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+  });
 
-  try {
-    await mkdir(fakeBin);
-    await writeFile(join(fakeBin, 'git'), `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`);
-    await chmod(join(fakeBin, 'git'), 0o755);
-    await writeFile(planFile, '# Plan\n');
-    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
-    const realDirectory = await realpath(directory);
-    const realPlanFile = await realpath(planFile);
+  await mkdir(fakeBin);
+  await writeFile(join(fakeBin, 'git'), `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`);
+  await chmod(join(fakeBin, 'git'), 0o755);
+  await writeFile(planFile, '# Plan\n');
+  const realDirectory = await realpath(directory.path);
+  const realPlanFile = await realpath(planFile);
 
-    expect(
-      getWindowIdentity(directory, {
-        planFile,
-        planResultFile: join(directory, 'result.json'),
-      }),
-    ).toMatchObject({
-      repositoryRoot: realDirectory,
-      sourceKey: `plan:${realPlanFile}`,
-    });
-    expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
-  } finally {
-    process.env.PATH = previousPath;
-    await removeGitTestDirectory(directory);
-  }
+  expect(
+    getWindowIdentity(directory.path, {
+      planFile,
+      planResultFile: join(directory.path, 'result.json'),
+    }),
+  ).toMatchObject({
+    repositoryRoot: realDirectory,
+    sourceKey: `plan:${realPlanFile}`,
+  });
+  expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
 });
 
 test('window identities match working-tree launches inside the same repository', async () => {
-  const repositoryPath = await createRepository();
+  await using directory = await createTemporaryDirectory('codiff-window-identity-');
+  await initRepository(directory.path);
 
-  try {
-    const nestedPath = join(repositoryPath, 'src');
-    await mkdir(nestedPath);
+  const nestedPath = join(directory.path, 'src');
+  await mkdir(nestedPath);
 
-    expect(getWindowIdentity(nestedPath)?.key).toBe(getWindowIdentity(repositoryPath)?.key);
-  } finally {
-    await removeGitTestDirectory(repositoryPath);
-  }
+  expect(getWindowIdentity(nestedPath)?.key).toBe(getWindowIdentity(directory.path)?.key);
 });
 
 test('window identities resolve commit refs to the same commit sha', async () => {
-  const repositoryPath = await createRepository();
+  await using directory = await createTemporaryDirectory('codiff-window-identity-');
+  await initRepository(directory.path);
 
-  try {
-    const head = await git(repositoryPath, ['rev-parse', 'HEAD']);
+  const head = await git(directory.path, ['rev-parse', 'HEAD']);
 
-    expect(
-      getWindowIdentity(repositoryPath, {
-        source: { ref: 'HEAD', type: 'commit' },
-      })?.sourceKey,
-    ).toBe(`commit:${head}`);
-    expect(
-      getWindowIdentity(repositoryPath, {
-        source: { ref: head.slice(0, 8), type: 'commit' },
-      })?.key,
-    ).toBe(
-      getWindowIdentity(repositoryPath, {
-        source: { ref: 'HEAD', type: 'commit' },
-      })?.key,
-    );
-  } finally {
-    await removeGitTestDirectory(repositoryPath);
-  }
+  expect(
+    getWindowIdentity(directory.path, {
+      source: { ref: 'HEAD', type: 'commit' },
+    })?.sourceKey,
+  ).toBe(`commit:${head}`);
+  expect(
+    getWindowIdentity(directory.path, {
+      source: { ref: head.slice(0, 8), type: 'commit' },
+    })?.key,
+  ).toBe(
+    getWindowIdentity(directory.path, {
+      source: { ref: 'HEAD', type: 'commit' },
+    })?.key,
+  );
 });
 
 test.sequential('resolved repository states build identities without invoking Git', async () => {
-  const repositoryPath = await createRepository();
-  const fakeBin = await mkdtemp(join(tmpdir(), 'codiff-resolved-window-identity-'));
-  const gitMarker = join(fakeBin, 'git-invoked');
-  const previousPath = process.env.PATH;
+  await using repository = await createTemporaryDirectory('codiff-window-identity-');
+  await initRepository(repository.path);
+  await using fakeBin = await createTemporaryDirectory('codiff-resolved-window-identity-');
+  const gitMarker = join(fakeBin.path, 'git-invoked');
+  await using _environment = createTemporaryEnvironment({
+    PATH: `${fakeBin.path}:${process.env.PATH ?? ''}`,
+  });
 
-  try {
-    const head = await git(repositoryPath, ['rev-parse', 'HEAD']);
-    await writeFile(join(fakeBin, 'git'), `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`);
-    await chmod(join(fakeBin, 'git'), 0o755);
-    process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+  const head = await git(repository.path, ['rev-parse', 'HEAD']);
+  await writeFile(
+    join(fakeBin.path, 'git'),
+    `#!/bin/sh\nprintf invoked > "${gitMarker}"\nexit 99\n`,
+  );
+  await chmod(join(fakeBin.path, 'git'), 0o755);
 
-    expect(
-      getWindowIdentityForRepositoryState({
-        root: repositoryPath,
-        source: { ref: head, type: 'commit' },
-      }),
-    ).toMatchObject({
-      repositoryRoot: await realpath(repositoryPath),
-      sourceKey: `commit:${head}`,
-    });
-    expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
-  } finally {
-    process.env.PATH = previousPath;
-    await removeGitTestDirectory(fakeBin);
-    await removeGitTestDirectory(repositoryPath);
-  }
+  expect(
+    getWindowIdentityForRepositoryState({
+      root: repository.path,
+      source: { ref: head, type: 'commit' },
+    }),
+  ).toMatchObject({
+    repositoryRoot: await realpath(repository.path),
+    sourceKey: `commit:${head}`,
+  });
+  expect(await readFile(gitMarker, 'utf8').catch(() => null)).toBeNull();
 });
 
 test('implicit walkthrough identities use HEAD only when the working tree is clean', async () => {
-  const repositoryPath = await createRepository();
+  await using directory = await createTemporaryDirectory('codiff-window-identity-');
+  await initRepository(directory.path);
 
-  try {
-    const headIdentity = getWindowIdentity(repositoryPath, {
-      source: { ref: 'HEAD', type: 'commit' },
-    });
-    expect(getWindowIdentity(repositoryPath, { walkthrough: true })?.key).toBe(headIdentity?.key);
+  const headIdentity = getWindowIdentity(directory.path, {
+    source: { ref: 'HEAD', type: 'commit' },
+  });
+  expect(getWindowIdentity(directory.path, { walkthrough: true })?.key).toBe(headIdentity?.key);
 
-    await writeFile(join(repositoryPath, 'local.txt'), 'change\n');
-    expect(getWindowIdentity(repositoryPath, { walkthrough: true })?.sourceKey).toBe(
-      'working-tree',
-    );
+  await writeFile(join(directory.path, 'local.txt'), 'change\n');
+  expect(getWindowIdentity(directory.path, { walkthrough: true })?.sourceKey).toBe('working-tree');
 
-    await rm(join(repositoryPath, 'local.txt'));
-    expect(
-      getWindowIdentity(repositoryPath, {
-        walkthrough: true,
-        walkthroughFile: '/tmp/walkthrough.json',
-      })?.sourceKey,
-    ).toBe('working-tree');
-  } finally {
-    await removeGitTestDirectory(repositoryPath);
-  }
+  await rm(join(directory.path, 'local.txt'));
+  expect(
+    getWindowIdentity(directory.path, {
+      walkthrough: true,
+      walkthroughFile: '/tmp/walkthrough.json',
+    })?.sourceKey,
+  ).toBe('working-tree');
 });
 
 test('window identities distinguish branch history launches', async () => {
-  const repositoryPath = await createRepository();
+  await using directory = await createTemporaryDirectory('codiff-window-identity-');
+  await initRepository(directory.path);
 
-  try {
-    await git(repositoryPath, ['checkout', '-b', 'feature']);
-    const head = (await git(repositoryPath, ['rev-parse', 'HEAD'])).trim().toLowerCase();
+  await git(directory.path, ['checkout', '-b', 'feature']);
+  const head = (await git(directory.path, ['rev-parse', 'HEAD'])).trim().toLowerCase();
 
-    expect(
-      getWindowIdentity(repositoryPath, {
-        source: { ref: 'feature', type: 'branch' },
-      })?.sourceKey,
-    ).toBe(`branch-diff:feature:${head}:${head}`);
+  expect(
+    getWindowIdentity(directory.path, {
+      source: { ref: 'feature', type: 'branch' },
+    })?.sourceKey,
+  ).toBe(`branch-diff:feature:${head}:${head}`);
 
-    await git(repositoryPath, ['commit', '--allow-empty', '-m', 'feature update']);
-    const nextHead = (await git(repositoryPath, ['rev-parse', 'HEAD'])).trim().toLowerCase();
+  await git(directory.path, ['commit', '--allow-empty', '-m', 'feature update']);
+  const nextHead = (await git(directory.path, ['rev-parse', 'HEAD'])).trim().toLowerCase();
 
-    expect(
-      getWindowIdentity(repositoryPath, {
-        source: { baseRef: head, headRef: nextHead, ref: 'feature', type: 'branch-diff' },
-      })?.sourceKey,
-    ).toBe(`branch-diff:feature:${head}:${nextHead}`);
-  } finally {
-    await removeGitTestDirectory(repositoryPath);
-  }
+  expect(
+    getWindowIdentity(directory.path, {
+      source: { baseRef: head, headRef: nextHead, ref: 'feature', type: 'branch-diff' },
+    })?.sourceKey,
+  ).toBe(`branch-diff:feature:${head}:${nextHead}`);
 });
 
 test('window identities normalize GitHub pull request sources', async () => {
-  const repositoryPath = await createRepository();
+  await using directory = await createTemporaryDirectory('codiff-window-identity-');
+  await initRepository(directory.path);
 
-  try {
-    expect(
-      getWindowIdentity(repositoryPath, {
-        source: {
-          type: 'pull-request',
-          url: 'https://github.com/NKZW-Tech/Codiff/pull/8',
-        },
-      })?.sourceKey,
-    ).toBe('pull-request:nkzw-tech/codiff#8');
-    expect(
-      getWindowIdentity(repositoryPath, {
-        source: {
-          number: 8,
-          owner: 'nkzw-tech',
-          repo: 'codiff',
-          type: 'pull-request',
-          url: 'https://github.com/nkzw-tech/codiff/pull/8',
-        },
-      })?.key,
-    ).toBe(
-      getWindowIdentity(repositoryPath, {
-        source: {
-          type: 'pull-request',
-          url: 'https://github.com/NKZW-Tech/Codiff/pull/8',
-        },
-      })?.key,
-    );
-  } finally {
-    await removeGitTestDirectory(repositoryPath);
-  }
+  expect(
+    getWindowIdentity(directory.path, {
+      source: {
+        type: 'pull-request',
+        url: 'https://github.com/NKZW-Tech/Codiff/pull/8',
+      },
+    })?.sourceKey,
+  ).toBe('pull-request:nkzw-tech/codiff#8');
+  expect(
+    getWindowIdentity(directory.path, {
+      source: {
+        number: 8,
+        owner: 'nkzw-tech',
+        repo: 'codiff',
+        type: 'pull-request',
+        url: 'https://github.com/nkzw-tech/codiff/pull/8',
+      },
+    })?.key,
+  ).toBe(
+    getWindowIdentity(directory.path, {
+      source: {
+        type: 'pull-request',
+        url: 'https://github.com/NKZW-Tech/Codiff/pull/8',
+      },
+    })?.key,
+  );
 });
 
 test('window identities normalize GitLab merge request sources', async () => {
-  const repositoryPath = await createRepository();
+  await using directory = await createTemporaryDirectory('codiff-window-identity-');
+  await initRepository(directory.path);
 
-  try {
-    expect(
-      getWindowIdentity(repositoryPath, {
-        source: {
-          type: 'pull-request',
-          url: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/8',
-        },
-      })?.sourceKey,
-    ).toBe('pull-request:gitlab:gitlab.example.com/group/subgroup/project#8');
-  } finally {
-    await removeGitTestDirectory(repositoryPath);
-  }
+  expect(
+    getWindowIdentity(directory.path, {
+      source: {
+        type: 'pull-request',
+        url: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/8',
+      },
+    })?.sourceKey,
+  ).toBe('pull-request:gitlab:gitlab.example.com/group/subgroup/project#8');
 });
 
 test('window identity matching requires exact identity matches', () => {

--- a/electron/__tests__/window-state.test.ts
+++ b/electron/__tests__/window-state.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vite-plus/test';
+import { createTemporaryDirectory } from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
 const { readWindowState, validateWindowStateOnScreen, writeWindowState } =
@@ -46,96 +46,67 @@ const validState = {
 const primaryDisplay = { workArea: { height: 900, width: 1440, x: 0, y: 0 } };
 
 test('readWindowState returns null when file does not exist', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
-  try {
-    expect(readWindowState(dir)).toBeNull();
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
+  await using directory = await createTemporaryDirectory('codiff-ws-');
+  expect(readWindowState(directory.path)).toBeNull();
 });
 
 test('readWindowState returns null for corrupt JSON', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
-  try {
-    await writeFile(join(dir, 'window-state.json'), '{not valid json');
-    expect(readWindowState(dir)).toBeNull();
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
+  await using directory = await createTemporaryDirectory('codiff-ws-');
+  await writeFile(join(directory.path, 'window-state.json'), '{not valid json');
+  expect(readWindowState(directory.path)).toBeNull();
 });
 
 test('readWindowState returns null for invalid fields', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
-  try {
-    await writeFile(join(dir, 'window-state.json'), JSON.stringify({ x: 'not a number' }));
-    expect(readWindowState(dir)).toBeNull();
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
+  await using directory = await createTemporaryDirectory('codiff-ws-');
+  await writeFile(join(directory.path, 'window-state.json'), JSON.stringify({ x: 'not a number' }));
+  expect(readWindowState(directory.path)).toBeNull();
 });
 
 test('readWindowState returns null when width is below minimum', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
-  try {
-    await writeFile(join(dir, 'window-state.json'), JSON.stringify({ ...validState, width: 500 }));
-    expect(readWindowState(dir)).toBeNull();
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
+  await using directory = await createTemporaryDirectory('codiff-ws-');
+  await writeFile(
+    join(directory.path, 'window-state.json'),
+    JSON.stringify({ ...validState, width: 500 }),
+  );
+  expect(readWindowState(directory.path)).toBeNull();
 });
 
 test('readWindowState returns null when height is below minimum', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
-  try {
-    await writeFile(join(dir, 'window-state.json'), JSON.stringify({ ...validState, height: 400 }));
-    expect(readWindowState(dir)).toBeNull();
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
+  await using directory = await createTemporaryDirectory('codiff-ws-');
+  await writeFile(
+    join(directory.path, 'window-state.json'),
+    JSON.stringify({ ...validState, height: 400 }),
+  );
+  expect(readWindowState(directory.path)).toBeNull();
 });
 
 test('readWindowState returns valid state', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
-  try {
-    await writeFile(join(dir, 'window-state.json'), JSON.stringify(validState));
-    expect(readWindowState(dir)).toEqual(validState);
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
+  await using directory = await createTemporaryDirectory('codiff-ws-');
+  await writeFile(join(directory.path, 'window-state.json'), JSON.stringify(validState));
+  expect(readWindowState(directory.path)).toEqual(validState);
 });
 
 test('readWindowState defaults isMaximized and isFullScreen to false when missing', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
-  try {
-    const { isMaximized: _, isFullScreen: __, ...partial } = validState;
-    await writeFile(join(dir, 'window-state.json'), JSON.stringify(partial));
-    const result = readWindowState(dir);
-    expect(result?.isMaximized).toBe(false);
-    expect(result?.isFullScreen).toBe(false);
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
+  await using directory = await createTemporaryDirectory('codiff-ws-');
+  const { isMaximized: _, isFullScreen: __, ...partial } = validState;
+  await writeFile(join(directory.path, 'window-state.json'), JSON.stringify(partial));
+  const result = readWindowState(directory.path);
+  expect(result?.isMaximized).toBe(false);
+  expect(result?.isFullScreen).toBe(false);
 });
 
 test('writeWindowState creates directory and file', async () => {
-  const dir = join(await mkdtemp(join(tmpdir(), 'codiff-ws-')), 'nested');
-  try {
-    writeWindowState(validState, dir);
-    expect(readWindowState(dir)).toEqual(validState);
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
+  await using directory = await createTemporaryDirectory('codiff-ws-');
+  const nested = join(directory.path, 'nested');
+  writeWindowState(validState, nested);
+  expect(readWindowState(nested)).toEqual(validState);
 });
 
 test('write then read round-trips correctly', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'codiff-ws-'));
-  try {
-    const state = { ...validState, isFullScreen: true, isMaximized: true };
-    writeWindowState(state, dir);
-    expect(readWindowState(dir)).toEqual(state);
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
+  await using directory = await createTemporaryDirectory('codiff-ws-');
+  const state = { ...validState, isFullScreen: true, isMaximized: true };
+  writeWindowState(state, directory.path);
+  expect(readWindowState(directory.path)).toEqual(state);
 });
 
 test('validateWindowStateOnScreen returns state when visible on primary display', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "incremental": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext", "esnext.disposable"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "noEmit": true,


### PR DESCRIPTION
## Summary

<img width="500" height="500" alt="awtr0v" src="https://github.com/user-attachments/assets/bbec9ac7-8629-483a-940a-923a66b4073e" />

No functional changes as far as I can tell

## Test plan

- [x] `pnpm exec vp check --fix`
- [x] `pnpm exec vpr build`
- [x] `pnpm exec vp test` — 627/627 passed
- [x] Verified zero `finally {` blocks remain under `core/__tests__` and `electron/__tests__`