### PR TITLE
Show the configured author on the commit screen

### DIFF
--- a/core/App.tsx
+++ b/core/App.tsx
@@ -2910,6 +2910,7 @@ export default function App() {
           <CommitView
             branch={state.branch}
             draft={narrativeNavigation}
+            gitIdentity={gitIdentity}
             model={plainCommitModel}
             onCommit={commitWalkthrough}
             onCommitOutput={subscribeToCommitOutput}
@@ -2919,6 +2920,7 @@ export default function App() {
           <NarrativeWalkthroughView
             changedPaths={walkthroughOutdatedPaths}
             files={state.files}
+            gitIdentity={gitIdentity}
             navigation={narrativeNavigation}
             onActiveReviewTargetChange={updateActiveWalkthroughReviewTarget}
             onCommit={commitWalkthrough}

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -493,6 +493,11 @@ test('showWhitespace config changes reload the current repository state', async 
 
 test('sidebar commit button toggles back to tree when commit view is open', async () => {
   window.codiff = createCodiffMock({
+    getGitIdentity: vi.fn(async () => ({
+      email: '182032677+salmonumbrella@users.noreply.github.com',
+      name: 'salmonumbrella',
+      username: 'salmonumbrella',
+    })),
     getRepositoryState: vi.fn(async () => ({
       ...repositoryState,
       files: [createChangedFile('src/change.ts')],
@@ -518,6 +523,9 @@ test('sidebar commit button toggles back to tree when commit view is open', asyn
   await waitFor(() => {
     expect(container.querySelector('.wt-commit')).not.toBeNull();
     expect(container.querySelector('.sidebar-commit-button')?.textContent).toBe('Tree');
+    expect(container.querySelector('.wt-commit-bar-identity')?.textContent).toContain(
+      '@salmonumbrella',
+    );
   });
 
   await act(async () => {

--- a/core/app/components/walkthrough/CommitView.tsx
+++ b/core/app/components/walkthrough/CommitView.tsx
@@ -7,12 +7,13 @@ import {
   type CommitModel,
 } from '../../../lib/narrative-walkthrough.ts';
 import type {
+  GitIdentity,
   WalkthroughCommitMessageRequest,
   WalkthroughCommitMessageResult,
   WalkthroughCommitRequest,
   WalkthroughCommitResult,
 } from '../../../types.ts';
-import { ArrowsClockwise, Check, GitBranch, X } from './icons.tsx';
+import { ArrowsClockwise, Check, GitBranch, User, X } from './icons.tsx';
 import { ChapterIcon, WalkthroughLineCount } from './parts.tsx';
 
 export type CommitHandler = (request: WalkthroughCommitRequest) => Promise<WalkthroughCommitResult>;
@@ -326,6 +327,7 @@ function MessageDraft({
 export function CommitView({
   branch,
   draft,
+  gitIdentity,
   model,
   onCommit,
   onCommitOutput,
@@ -333,6 +335,7 @@ export function CommitView({
 }: {
   branch: string | null;
   draft: CommitDraftState;
+  gitIdentity?: GitIdentity | null;
   model: CommitModel;
   onCommit: CommitHandler;
   onCommitOutput?: CommitOutputSubscriber;
@@ -346,6 +349,14 @@ export function CommitView({
   );
   const subject = draft.commitSubject;
   const allSelected = selectedFiles.length === model.files.length;
+  const identityLabel = gitIdentity?.username
+    ? `@${gitIdentity.username}`
+    : gitIdentity?.name || gitIdentity?.email;
+  const identityTitle = gitIdentity
+    ? `Commit author: ${gitIdentity.name || gitIdentity.email}${
+        gitIdentity.name && gitIdentity.email ? ` <${gitIdentity.email}>` : ''
+      }`
+    : undefined;
 
   const [status, setStatus] = useState<'idle' | 'submitting'>('idle');
   const [result, setResult] = useState<WalkthroughCommitResult | null>(null);
@@ -439,6 +450,11 @@ export function CommitView({
         {branch ? (
           <span className="wt-commit-bar-branch">
             <GitBranch size={13} /> {branch}
+          </span>
+        ) : null}
+        {identityLabel ? (
+          <span className="wt-commit-bar-identity" title={identityTitle}>
+            <User size={13} /> {identityLabel}
           </span>
         ) : null}
         <span className="wt-commit-bar-meta">

--- a/core/app/components/walkthrough/NarrativeWalkthroughView.tsx
+++ b/core/app/components/walkthrough/NarrativeWalkthroughView.tsx
@@ -15,7 +15,12 @@ import {
   type WalkthroughView,
   type WalkthroughStopView,
 } from '../../../lib/narrative-walkthrough.ts';
-import type { ChangedFile, NarrativeWalkthrough, WalkthroughHunkGroup } from '../../../types.ts';
+import type {
+  ChangedFile,
+  GitIdentity,
+  NarrativeWalkthrough,
+  WalkthroughHunkGroup,
+} from '../../../types.ts';
 import type { ReviewDiffBlock } from '../ReviewCodeView.tsx';
 import {
   CommitView,
@@ -564,6 +569,7 @@ export function NarrativeWalkthroughView({
   allowCommit = true,
   changedPaths,
   files,
+  gitIdentity,
   navigation,
   onActiveReviewTargetChange,
   onCommit,
@@ -580,6 +586,7 @@ export function NarrativeWalkthroughView({
   allowCommit?: boolean;
   changedPaths?: ReadonlySet<string>;
   files: ReadonlyArray<ChangedFile>;
+  gitIdentity?: GitIdentity | null;
   navigation: NarrativeNavigation;
   onActiveReviewTargetChange: (target: WalkthroughReviewTarget | null) => void;
   onCommit: CommitHandler;
@@ -770,6 +777,7 @@ export function NarrativeWalkthroughView({
         <CommitView
           branch={walkthrough.repo.branch}
           draft={navigation}
+          gitIdentity={gitIdentity}
           model={buildCommitModel(walkthroughView, files)}
           onCommit={onCommit}
           onCommitOutput={onCommitOutput}

--- a/core/app/components/walkthrough/icons.tsx
+++ b/core/app/components/walkthrough/icons.tsx
@@ -13,6 +13,7 @@ import { GitBranchIcon as GitBranch } from '@phosphor-icons/react/GitBranch';
 import { PathIcon as Path } from '@phosphor-icons/react/Path';
 import { ReadCvLogoIcon as Doc } from '@phosphor-icons/react/ReadCvLogo';
 import { ShareNetworkIcon as ShareNetwork } from '@phosphor-icons/react/ShareNetwork';
+import { UserIcon as User } from '@phosphor-icons/react/User';
 import { WrenchIcon as Wrench } from '@phosphor-icons/react/Wrench';
 import { XIcon as X } from '@phosphor-icons/react/X';
 import type { ComponentType } from 'react';
@@ -46,5 +47,6 @@ export {
   GitBranch,
   Path,
   ShareNetwork,
+  User,
   X,
 };

--- a/core/walkthrough.css
+++ b/core/walkthrough.css
@@ -774,6 +774,19 @@
   gap: 4px;
   padding: 4px 8px;
 }
+.wt-commit-bar-identity {
+  align-items: center;
+  background: color-mix(in srgb, var(--muted) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--muted) 18%, transparent);
+  border-radius: 24px;
+  color: var(--muted);
+  corner-shape: squircle;
+  display: inline-flex;
+  flex: none;
+  font: 600 11px/1 var(--font-mono);
+  gap: 4px;
+  padding: 3px 8px;
+}
 .wt-commit-bar-meta {
   color: var(--muted);
   display: inline-flex;

--- a/electron/__tests__/git-identity.test.ts
+++ b/electron/__tests__/git-identity.test.ts
@@ -8,7 +8,7 @@ import { expect, test } from 'vite-plus/test';
 
 const require = createRequire(import.meta.url);
 const { readGitIdentity } = require('../git-state/working-tree.cjs') as {
-  readGitIdentity: (path: string) => Promise<{ email: string; name: string }>;
+  readGitIdentity: (path: string) => Promise<{ email: string; name: string; username?: string }>;
 };
 
 const execFileAsync = promisify(execFile);
@@ -69,5 +69,22 @@ test('reads the global git identity outside a repository', async () => {
       process.env.GIT_CONFIG_GLOBAL = previousGlobalConfig;
     }
     await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test('derives a GitHub username from a noreply commit email', async () => {
+  const repo = await mkdtemp(join(tmpdir(), 'codiff-github-identity-'));
+  try {
+    await git(repo, ['init']);
+    await git(repo, ['config', 'user.name', 'Mona Lisa']);
+    await git(repo, ['config', 'user.email', '12345+octocat@users.noreply.github.com']);
+
+    await expect(readGitIdentity(repo)).resolves.toMatchObject({
+      email: '12345+octocat@users.noreply.github.com',
+      name: 'Mona Lisa',
+      username: 'octocat',
+    });
+  } finally {
+    await rm(repo, { force: true, recursive: true });
   }
 });

--- a/electron/git-state/working-tree.cjs
+++ b/electron/git-state/working-tree.cjs
@@ -446,6 +446,7 @@ const readGitIdentity = async (launchPath) => {
   ]);
   const email = configuredEmail.trim();
   const name = configuredName.trim();
+  const username = email.match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/i)?.[1];
 
   return {
     email,
@@ -453,6 +454,7 @@ const readGitIdentity = async (launchPath) => {
       ? `https://www.gravatar.com/avatar/${getGravatarHash(email)}?s=80&d=identicon`
       : undefined,
     name,
+    ...(username ? { username } : {}),
   };
 };
 


### PR DESCRIPTION
## Summary

- show the configured Git commit identity in a subtle pill beside the branch
- derive GitHub usernames from noreply commit addresses when available
- fall back to the configured author name or email

## Verification

- `vp check --fix`
- focused Git identity and commit-view render tests
- `vp build`