### PR TITLE
Launch the terminal helper correctly on Linux

### DIFF
--- a/bin/codiff-app
+++ b/bin/codiff-app
@@ -14,7 +14,46 @@ while [ -L "$source_path" ]; do
 done
 
 script_dir="$(CDPATH= cd -P "$(dirname "$source_path")" >/dev/null 2>&1 && pwd)"
+# On macOS the helper ships inside <app>.app/Contents/Resources/app/bin, so four
+# levels up is the bundle that `open` expects. On Linux the layout is
+# <root>/resources/app/bin and the Electron binary sits directly in <root>.
 app_path="$(CDPATH= cd -P "$script_dir/../../../.." >/dev/null 2>&1 && pwd)"
+package_root="$(CDPATH= cd -P "$script_dir/../../.." >/dev/null 2>&1 && pwd)"
+
+is_macos() {
+  [ "$(uname -s 2>/dev/null)" = "Darwin" ]
+}
+
+# Print the Electron executable, or nothing when it cannot be found. It doubles
+# as the Node runtime when invoked with ELECTRON_RUN_AS_NODE=1.
+codiff_runtime() {
+  if [ -n "${CODIFF_NODE_COMMAND:-}" ]; then
+    printf '%s' "$CODIFF_NODE_COMMAND"
+    return 0
+  fi
+
+  if [ -n "${CODIFF_APP_COMMAND:-}" ]; then
+    printf '%s' "$CODIFF_APP_COMMAND"
+    return 0
+  fi
+
+  if is_macos; then
+    macos_exec="$(ls "$app_path/Contents/MacOS/" 2>/dev/null | head -n 1)"
+    if [ -n "$macos_exec" ] && [ -x "$app_path/Contents/MacOS/$macos_exec" ]; then
+      printf '%s' "$app_path/Contents/MacOS/$macos_exec"
+    fi
+    return 0
+  fi
+
+  # `codiff` is the executable name produced by electron-forge on Linux; the
+  # capitalized variant covers installs that keep the product name.
+  for candidate in "$package_root/codiff" "$package_root/Codiff"; do
+    if [ -f "$candidate" ] && [ -x "$candidate" ]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+}
 
 codiff_version() {
   sed -n 's/^  "version": "\([^"]*\)".*/\1/p' "$script_dir/../package.json"
@@ -66,13 +105,7 @@ show_help() {
 
 for arg in "$@"; do
   if [ "$arg" = "--share" ] || [ "$arg" = "--public" ]; then
-    runtime="${CODIFF_NODE_COMMAND:-}"
-    if [ -z "$runtime" ]; then
-      electron_exec="$(ls "$app_path/Contents/MacOS/" 2>/dev/null | head -n 1)"
-      if [ -n "$electron_exec" ]; then
-        runtime="$app_path/Contents/MacOS/$electron_exec"
-      fi
-    fi
+    runtime="$(codiff_runtime)"
     if [ -z "$runtime" ] || [ ! -x "$runtime" ]; then
       printf '%s\n' "codiff: could not find the bundled runtime for --share." >&2
       exit 1
@@ -248,9 +281,9 @@ for arg in "$@"; do
     --walkthrough-guide)
       # The guide is pure text assembled by the Node entry; run it with the
       # bundled Electron as Node so no separate node install is required.
-      electron_exec="$(ls "$app_path/Contents/MacOS/" 2>/dev/null | head -n 1)"
-      if [ -n "$electron_exec" ] && [ -f "$script_dir/codiff.js" ]; then
-        ELECTRON_RUN_AS_NODE=1 "$app_path/Contents/MacOS/$electron_exec" \
+      runtime="$(codiff_runtime)"
+      if [ -n "$runtime" ] && [ -x "$runtime" ] && [ -f "$script_dir/codiff.js" ]; then
+        ELECTRON_RUN_AS_NODE=1 "$runtime" \
           "$script_dir/codiff.js" --walkthrough-guide
       else
         cat "$script_dir/walkthrough-guide.md"
@@ -468,7 +501,23 @@ open_codiff() {
     set -- --pi-session "$pi_session_id" "$@"
   fi
 
-  open -n "$app_path" --args "$@"
+  # macOS launches a fresh instance of the .app bundle; `open` returns
+  # immediately and the app keeps running detached.
+  if is_macos && [ -z "${CODIFF_APP_COMMAND:-}" ]; then
+    open -n "$app_path" --args "$@"
+    return 0
+  fi
+
+  # Elsewhere the Electron binary is executed directly: xdg-open has no
+  # equivalent of `-n`/`--args`, so it cannot launch a new instance with
+  # arguments. Detach so the shell prompt returns like it does on macOS.
+  runtime="$(codiff_runtime)"
+  if [ -z "$runtime" ] || [ ! -x "$runtime" ]; then
+    printf '%s\n' "codiff: could not find the Codiff executable next to $package_root." >&2
+    exit 1
+  fi
+
+  "$runtime" "$@" >/dev/null 2>&1 &
 }
 
 if [ -n "$plan_file_path" ]; then

--- a/core/__tests__/codiff-cli.test.ts
+++ b/core/__tests__/codiff-cli.test.ts
@@ -21,7 +21,11 @@ import {
   resolvePullRequestUrl,
 } from '../../bin/arguments.js';
 import type { PlanReview } from '../types.ts';
-import { createFakeCommandLogger, createFakeOpenLogger } from './helpers/cli.ts';
+import {
+  createFakeAppCommandLogger,
+  createFakeCommandLogger,
+  createFakeOpenLogger,
+} from './helpers/cli.ts';
 import { removeGitTestDirectory } from './helpers/git.ts';
 import { getGitTestEnvironment } from './helpers/git.ts';
 import {
@@ -487,6 +491,52 @@ test('packaged terminal helper forwards --commit HEAD to Electron', async () => 
     'HEAD',
     repositoryPath,
   ]);
+});
+
+test('packaged terminal helper executes the Electron binary directly off macOS', async () => {
+  await using logger = await createFakeAppCommandLogger();
+  const repositoryPath = join(logger.directory, 'repo');
+
+  await mkdir(repositoryPath);
+
+  await execFileAsync(resolve('bin/codiff-app'), ['--commit', 'HEAD', repositoryPath], {
+    env: logger.env,
+  });
+
+  // No `-n`, bundle path, or `--args`: xdg-open cannot launch a new instance
+  // with arguments, so the arguments reach the binary unwrapped.
+  expect(await logger.readArgs()).toEqual(['--commit', 'HEAD', repositoryPath]);
+});
+
+test('packaged terminal helper forwards walkthrough options to the Electron binary', async () => {
+  await using logger = await createFakeAppCommandLogger();
+  const repositoryPath = join(logger.directory, 'repo');
+
+  await mkdir(repositoryPath);
+
+  await execFileAsync(resolve('bin/codiff-app'), ['-w', '--branch', 'main', repositoryPath], {
+    env: logger.env,
+  });
+
+  expect(await logger.readArgs()).toEqual([
+    '--walkthrough',
+    '--branch',
+    'main',
+    repositoryPath,
+  ]);
+});
+
+test('packaged terminal helper reports a missing Electron binary', async () => {
+  const repositoryPath = await realpath(await mkdtemp(join(tmpdir(), 'codiff-app-missing-')));
+
+  await expect(
+    execFileAsync(resolve('bin/codiff-app'), [repositoryPath], {
+      env: {
+        ...process.env,
+        CODIFF_APP_COMMAND: join(repositoryPath, 'does-not-exist'),
+      },
+    }),
+  ).rejects.toThrow('could not find the Codiff executable');
 });
 
 test('packaged terminal helper resolves GitHub PR branches to canonical URLs', async () => {

--- a/core/__tests__/helpers/cli.ts
+++ b/core/__tests__/helpers/cli.ts
@@ -30,6 +30,46 @@ export const createFakeOpenLogger = async () => {
   };
 };
 
+// Away from macOS the helper executes the Electron binary directly instead of
+// going through `open`. `CODIFF_APP_COMMAND` points that lookup at a fake
+// executable so the forwarded arguments can be inspected on any platform.
+export const createFakeAppCommandLogger = async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'codiff-app-command-'));
+  const logPath = join(directory, 'app-args.txt');
+  const commandPath = join(directory, 'codiff-app-command');
+
+  await writeFile(commandPath, loggerScript);
+  await chmod(commandPath, 0o755);
+
+  return {
+    commandPath,
+    directory,
+    env: {
+      ...process.env,
+      CODIFF_APP_COMMAND: commandPath,
+      OPEN_ARGS_FILE: logPath,
+    },
+    // The helper detaches the app, so the log file appears asynchronously.
+    readArgs: async () => {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        try {
+          const contents = (await readFile(logPath, 'utf8')).trim();
+          if (contents) {
+            return contents.split('\n');
+          }
+        } catch {
+          // The fake command has not written the log yet.
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      throw new Error(`Timed out waiting for ${logPath}.`);
+    },
+    async [Symbol.asyncDispose]() {
+      await rm(directory, { force: true, recursive: true });
+    },
+  };
+};
+
 export const createFakeCommandLogger = async (prefix: string, commandName: string) => {
   const directory = await mkdtemp(join(tmpdir(), prefix));
   const commandPath = join(directory, commandName);


### PR DESCRIPTION
The packaged `codiff` terminal helper does not work on Linux. Running `codiff` from a `.deb`/`.rpm` install fails with:

```
xdg-open: unexpected option '-n'
```

Two macOS-only assumptions cause this:

- `app_path` walks four directories up from the helper. On macOS that lands on the `.app` bundle, but the Linux layout is `<root>/resources/app/bin`, so it overshoots the install root (for example resolving to `/usr` instead of `/usr/lib/codiff`).
- The app is launched with `open -n "$app_path" --args`. On Linux `open` is xdg-open, which has no `-n` or `--args` and cannot launch a new instance with arguments at all.

## Changes

Off macOS the Electron executable is resolved from `<root>` and executed directly, detached so the shell prompt returns the way `open -n` does. The platform is selected with `uname` rather than by probing for `Contents/MacOS`, so a source checkout behaves like a packaged bundle instead of silently taking the Linux branch.

This also fixes two paths that were broken off macOS in a less visible way. `--share` and `--walkthrough-guide` looked for a Node runtime under `Contents/MacOS`, which never exists on Linux: `--share` failed with "could not find the bundled runtime", and `--walkthrough-guide` silently fell back to `cat`-ing the raw Markdown instead of the guide assembled by `codiff.js`. Both now go through a single `codiff_runtime` lookup. The bundled Electron binary works as the Node runtime via `ELECTRON_RUN_AS_NODE=1`, so no separate Node install is needed.

macOS behavior is unchanged: same `open -n <bundle> --args <args>` invocation, so the existing terminal-helper assertions still hold.

## Testing

`CODIFF_APP_COMMAND` overrides the resolved executable, following the existing `CODIFF_OPENCODE_PATH` pattern, so the direct-launch path is testable on any platform. Added coverage for argument forwarding, walkthrough options, and the missing-binary error.

Verified against a real 1.9.1 Linux install (`/usr/lib/codiff`): the app window opens, `codiff main` forwards `--branch main <repo>`, `--walkthrough-guide` prints the assembled guide, and the `--plan` handoff still prints `CODIFF_PLAN_RESULT` and exits 0. I also confirmed the macOS branch still emits the identical `open` arguments by stubbing `uname` to report Darwin.

I was not able to run the full Vite+ suite locally (the toolchain expects Node 24 and `vp`, and this machine has neither), so the new tests have not been executed under vitest. I validated each assertion by driving `bin/codiff-app` directly in a shell with the same fake-executable technique the helpers use. Worth a CI run.

## AI assistance

This PR was written primarily with Claude Code: the diagnosis, the change, the tests, and this description. I reviewed and tested the result on my own Linux install.
