### PR TITLE
Open PR/branch/commit from UI

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -260,7 +260,6 @@
 
 .workspace-top-bar {
   -webkit-app-region: drag;
-  -webkit-backdrop-filter: blur(28px) saturate(1.3);
   align-items: center;
   backdrop-filter: blur(28px) saturate(1.3);
   background: var(--sidebar-bg);
@@ -274,7 +273,6 @@
 }
 
 html[data-codiff-platform='darwin'] .workspace-top-bar {
-  -webkit-backdrop-filter: none;
   backdrop-filter: none;
   background: var(--sidebar-vibrancy-tint);
 }
@@ -1100,7 +1098,6 @@ a.review-top-bar-source:focus-visible {
 
 .diff-search-panel {
   -webkit-app-region: no-drag;
-  -webkit-backdrop-filter: blur(24px) saturate(1.35);
   align-items: center;
   backdrop-filter: blur(24px) saturate(1.35);
   background: color-mix(in srgb, var(--code-bg) 76%, transparent);
@@ -1204,7 +1201,6 @@ a.review-top-bar-source:focus-visible {
 }
 
 .sidebar {
-  -webkit-backdrop-filter: blur(28px) saturate(1.3);
   backdrop-filter: blur(28px) saturate(1.3);
   background: var(--sidebar-bg);
   border: 0;
@@ -1220,7 +1216,6 @@ a.review-top-bar-source:focus-visible {
 }
 
 html[data-codiff-platform='darwin'] .sidebar {
-  -webkit-backdrop-filter: none;
   backdrop-filter: none;
   background: var(--sidebar-vibrancy-tint);
 }
@@ -2632,7 +2627,6 @@ html[data-codiff-platform='darwin'] .sidebar {
 
 .codiff-file-header {
   -webkit-app-region: no-drag;
-  -webkit-backdrop-filter: blur(4px) saturate(1.18);
   align-items: center;
   backdrop-filter: blur(4px) saturate(1.18);
   background: var(--file-bg);
@@ -3548,7 +3542,6 @@ diffs-container .review-comment-thread {
 }
 
 .copy-comments-button {
-  -webkit-backdrop-filter: blur(22px) saturate(1.35);
   align-items: center;
   backdrop-filter: blur(22px) saturate(1.35);
   background: color-mix(in srgb, var(--code-bg) 78%, transparent);
@@ -3900,7 +3893,7 @@ diffs-container .review-comment-thread {
 }
 
 .shortcuts-help-overlay {
-  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
   align-items: center;
   backdrop-filter: blur(4px);
   background: rgb(255 255 255 / 0.28);
@@ -3923,7 +3916,6 @@ diffs-container .review-comment-thread {
 }
 
 .shortcuts-help {
-  -webkit-backdrop-filter: blur(28px) saturate(1.4);
   backdrop-filter: blur(28px) saturate(1.4);
   background: color-mix(in srgb, var(--code-bg) 88%, transparent);
   border: 1px solid var(--file-border);
@@ -4025,7 +4017,7 @@ diffs-container .review-comment-thread {
 }
 
 .command-bar-overlay {
-  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
   align-items: flex-start;
   backdrop-filter: blur(4px);
   background: rgb(255 255 255 / 0.28);
@@ -4048,7 +4040,6 @@ diffs-container .review-comment-thread {
 }
 
 .command-bar {
-  -webkit-backdrop-filter: blur(28px) saturate(1.4);
   backdrop-filter: blur(28px) saturate(1.4);
   background: color-mix(in srgb, var(--code-bg) 88%, transparent);
   border: 1px solid var(--file-border);
@@ -4150,6 +4141,117 @@ diffs-container .review-comment-thread {
   flex: none;
   font: 11px/1 var(--font-mono);
   padding: 3px 6px;
+}
+
+.open-review-source-overlay {
+  align-items: flex-start;
+  backdrop-filter: blur(4px);
+  background: rgb(255 255 255 / 0.28);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding-top: 180px;
+  position: fixed;
+  z-index: 101;
+}
+
+:root[data-theme='dark'] .open-review-source-overlay {
+  background: rgb(0 0 0 / 0.16);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .open-review-source-overlay {
+    background: rgb(0 0 0 / 0.16);
+  }
+}
+
+.open-review-source-dialog {
+  backdrop-filter: blur(28px) saturate(1.4);
+  background: color-mix(in srgb, var(--code-bg) 88%, transparent);
+  border: 1px solid var(--file-border);
+  border-radius: 28px;
+  box-shadow:
+    0 0 0 1px rgb(255 255 255 / 0.12) inset,
+    0 18px 80px -54px rgb(0 0 0 / 0.78),
+    0 16px 46px -30px rgb(0 0 0 / 0.72),
+    0 12px 24px -18px rgb(0 0 0 / 0.9);
+  corner-shape: squircle;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px;
+  width: min(440px, 90vw);
+}
+
+.open-review-source-heading {
+  display: grid;
+  gap: 4px;
+}
+
+.open-review-source-heading h2 {
+  font: 600 16px/1.35 var(--font-sans);
+}
+
+.open-review-source-heading p,
+.open-review-source-error {
+  color: var(--muted);
+  font: 13px/1.4 var(--font-sans);
+}
+
+.open-review-source-label {
+  font: 600 12px/1.35 var(--font-sans);
+  margin-top: 4px;
+}
+
+.open-review-source-input {
+  background: rgb(127 127 127 / 0.1);
+  border: 0;
+  border-radius: 12px;
+  color: var(--text);
+  corner-shape: squircle;
+  font: 14px/1.35 var(--font-sans);
+  height: 36px;
+  outline: none;
+  padding: 0 12px;
+  width: 100%;
+}
+
+.open-review-source-input:focus {
+  box-shadow: 0 0 0 2px rgb(61 135 245 / 0.32);
+}
+
+.open-review-source-input::placeholder {
+  color: var(--muted);
+}
+
+.open-review-source-error {
+  color: var(--danger);
+}
+
+.open-review-source-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+
+.open-review-source-actions button {
+  background: rgb(127 127 127 / 0.1);
+  border-radius: 10px;
+  corner-shape: squircle;
+  cursor: pointer;
+  font: 13px/1.35 var(--font-sans);
+  padding: 7px 12px;
+}
+
+.open-review-source-actions button:last-child {
+  background: var(--tree-selection-focus);
+  color: white;
+}
+
+.open-review-source-actions button:disabled {
+  cursor: default;
+  opacity: 0.55;
 }
 
 @media (max-width: 720px) {

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -6,6 +6,7 @@ import type { FileDiffLoadedFiles } from '@pierre/diffs';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CommandBar } from './app/components/CommandBar.tsx';
 import { KeyboardShortcutsHelp } from './app/components/KeyboardShortcutsHelp.tsx';
+import { OpenReviewSourceDialog } from './app/components/OpenReviewSourceDialog.tsx';
 import {
   AgentUnavailablePanel,
   CopyCommentsButton,
@@ -111,6 +112,7 @@ import type {
   CodiffPreferences,
   GitIdentity,
   HistoryEntry,
+  OpenReviewSourceKind,
   RepositoryState,
   ReviewSource,
   TerminalHelperStatus,
@@ -193,6 +195,9 @@ export default function App() {
   const [planDocument, setPlanDocument] = useState<CodiffMarkdownDocument | null>(null);
   const [planLoadError, setPlanLoadError] = useState<string | null>(null);
   const [loadingSectionIds, setLoadingSectionIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [openReviewSourceKind, setOpenReviewSourceKind] = useState<OpenReviewSourceKind | null>(
+    null,
+  );
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
   const [state, setState] = useState<RepositoryState | null>(null);
   const [terminalHelperInstalling, setTerminalHelperInstalling] = useState(false);
@@ -1460,11 +1465,38 @@ export default function App() {
     ],
   );
 
+  const openReviewSource = useCallback(
+    async (kind: OpenReviewSourceKind, value: string) => {
+      if (kind === 'pull-request') {
+        const url = await window.codiff.resolvePullRequestUrl(value);
+        selectSource({ type: 'pull-request', url });
+        return;
+      }
+
+      selectSource(
+        kind === 'branch'
+          ? { ref: value, type: 'branch-working-tree' }
+          : { ref: value, type: 'commit' },
+      );
+    },
+    [selectSource],
+  );
+
+  const showOpenReviewSourceDialog = useCallback((kind: OpenReviewSourceKind) => {
+    setOpenReviewSourceKind(kind);
+  }, []);
+
+  useEffect(
+    () => window.codiff.onOpenReviewSource(showOpenReviewSourceDialog),
+    [showOpenReviewSourceDialog],
+  );
+
   const commandBarCommands = useAppCommands({
     changeSidebarMode,
     focusFileFilter,
     getReviewCommandTarget,
     onOpenDiffSearch: openDiffSearch,
+    onOpenReviewSource: showOpenReviewSourceDialog,
     onOpenSelectedFile: openSelectedFile,
     onRefreshRepository: refreshRepository,
     onToggleSidebar: toggleSidebar,
@@ -1813,6 +1845,13 @@ export default function App() {
         onClose={closeCommandBar}
         visible={commandBarVisible}
       />
+      {openReviewSourceKind ? (
+        <OpenReviewSourceDialog
+          kind={openReviewSourceKind}
+          onClose={() => setOpenReviewSourceKind(null)}
+          onOpen={(value) => openReviewSource(openReviewSourceKind, value)}
+        />
+      ) : null}
       <KeyboardShortcutsHelp keymap={codiffConfig.keymap} visible={shortcutsHelpVisible} />
       {!isSwitchingSource ? (
         <div className="review-action-bar">

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -227,6 +227,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
   onCopyPendingCommentsRequest: vi.fn(() => () => {}),
   onFindInDiffs: vi.fn(() => () => {}),
   onMarkdownDocumentChanged: vi.fn(() => () => {}),
+  onOpenReviewSource: vi.fn(() => () => {}),
   onPlanCloseRequested: vi.fn(() => () => {}),
   onRefreshRequest: vi.fn(() => () => {}),
   onRepositoryChanged: vi.fn(() => () => {}),
@@ -236,6 +237,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
   openConfigFile: vi.fn(async () => {}),
   openFile: vi.fn(async () => {}),
   resetCodeFontSize: vi.fn(async () => {}),
+  resolvePullRequestUrl: vi.fn(async () => 'https://github.com/owner/repo/pull/1'),
   saveMarkdownDocument: vi.fn(async (request) => ({
     document: {
       content: request.content,

--- a/core/__tests__/OpenReviewSourceDialog.test.tsx
+++ b/core/__tests__/OpenReviewSourceDialog.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from 'react';
+import { expect, test, vi } from 'vite-plus/test';
+import { OpenReviewSourceDialog } from '../app/components/OpenReviewSourceDialog.tsx';
+import { renderReact, setInputValue, waitFor } from './helpers/react.tsx';
+
+test('submits a trimmed pull request number and closes the dialog', async () => {
+  const onClose = vi.fn();
+  const onOpen = vi.fn().mockResolvedValue(undefined);
+  await using view = await renderReact(
+    <OpenReviewSourceDialog kind="pull-request" onClose={onClose} onOpen={onOpen} />,
+  );
+
+  const input = view.container.querySelector<HTMLInputElement>('#open-review-source-input');
+  const form = view.container.querySelector('form');
+  if (!input || !form) {
+    throw new Error('Expected the open review source form.');
+  }
+
+  await setInputValue(input, '  #42  ');
+  await act(async () => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  });
+
+  await waitFor(() => expect(onOpen).toHaveBeenCalledWith('#42'));
+  expect(onClose).toHaveBeenCalledOnce();
+});
+
+test('keeps the dialog open and explains when no source is entered', async () => {
+  const onClose = vi.fn();
+  const onOpen = vi.fn();
+  await using view = await renderReact(
+    <OpenReviewSourceDialog kind="branch" onClose={onClose} onOpen={onOpen} />,
+  );
+
+  const form = view.container.querySelector('form');
+  if (!form) {
+    throw new Error('Expected the open review source form.');
+  }
+
+  await act(async () => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  });
+
+  expect(view.container.querySelector('[role="alert"]')?.textContent).toBe('Enter a branch name.');
+  expect(onOpen).not.toHaveBeenCalled();
+  expect(onClose).not.toHaveBeenCalled();
+});

--- a/core/__tests__/app-command-hooks.test.tsx
+++ b/core/__tests__/app-command-hooks.test.tsx
@@ -68,6 +68,7 @@ test('app commands register the complete command set and delegate dynamic action
   const focusFileFilter = vi.fn();
   const getReviewCommandTarget = vi.fn(() => target);
   const onOpenDiffSearch = vi.fn();
+  const onOpenReviewSource = vi.fn();
   const onOpenSelectedFile = vi.fn();
   const onRefreshRepository = vi.fn();
   const onToggleSidebar = vi.fn();
@@ -82,6 +83,7 @@ test('app commands register the complete command set and delegate dynamic action
         focusFileFilter,
         getReviewCommandTarget,
         onOpenDiffSearch,
+        onOpenReviewSource,
         onOpenSelectedFile,
         onRefreshRepository,
         onToggleSidebar,
@@ -98,6 +100,9 @@ test('app commands register the complete command set and delegate dynamic action
   expect(commands.map((command) => command.id)).toEqual([
     'file-filter',
     'diff-search',
+    'open-pull-request',
+    'open-commit',
+    'open-branch',
     'sidebar-tree',
     'sidebar-history',
     'sidebar-walkthrough',
@@ -124,6 +129,9 @@ test('app commands register the complete command set and delegate dynamic action
   };
   command('file-filter').execute();
   command('diff-search').execute();
+  command('open-pull-request').execute();
+  command('open-commit').execute();
+  command('open-branch').execute();
   command('sidebar-history').execute();
   command('open-file').execute();
   command('toggle-sidebar').execute();
@@ -132,6 +140,7 @@ test('app commands register the complete command set and delegate dynamic action
   command('toggle-viewed').execute();
   expect(focusFileFilter).toHaveBeenCalledOnce();
   expect(onOpenDiffSearch).toHaveBeenCalledOnce();
+  expect(onOpenReviewSource.mock.calls).toEqual([['pull-request'], ['commit'], ['branch']]);
   expect(changeSidebarMode).toHaveBeenCalledWith('history');
   expect(onOpenSelectedFile).toHaveBeenCalledOnce();
   expect(onToggleSidebar).toHaveBeenCalledOnce();

--- a/core/app/components/OpenReviewSourceDialog.tsx
+++ b/core/app/components/OpenReviewSourceDialog.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useState, type FormEvent } from 'react';
+import type { OpenReviewSourceKind } from '../../types.ts';
+
+const dialogCopy: Record<
+  OpenReviewSourceKind,
+  { description: string; label: string; placeholder: string; title: string }
+> = {
+  branch: {
+    description: 'Compare the current working tree with a branch.',
+    label: 'Branch name',
+    placeholder: 'main',
+    title: 'Open Branch',
+  },
+  commit: {
+    description: 'Review a commit by SHA or revision, such as HEAD~1.',
+    label: 'Commit',
+    placeholder: 'HEAD~1 or a commit SHA',
+    title: 'Open Commit',
+  },
+  'pull-request': {
+    description: 'Paste a PR number or a GitHub or GitLab pull request link.',
+    label: 'Pull request',
+    placeholder: '#123 or https://github.com/owner/repo/pull/123',
+    title: 'Open PR',
+  },
+};
+
+export function OpenReviewSourceDialog({
+  kind,
+  onClose,
+  onOpen,
+}: {
+  kind: OpenReviewSourceKind;
+  onClose: () => void;
+  onOpen: (value: string) => Promise<void>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [value, setValue] = useState('');
+  const copy = dialogCopy[kind];
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const source = value.trim();
+      if (!source) {
+        setError(`Enter a ${copy.label.toLowerCase()}.`);
+        return;
+      }
+
+      setError(null);
+      setSubmitting(true);
+      try {
+        // The parent owns source loading so palette and native-menu requests use the same path.
+        await onOpen(source);
+        onClose();
+      } catch (error) {
+        setError(error instanceof Error ? error.message : `Could not open ${copy.title}.`);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [copy.label, copy.title, onClose, onOpen, value],
+  );
+
+  return (
+    <div
+      className="open-review-source-overlay"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget && !submitting) {
+          onClose();
+        }
+      }}
+    >
+      <form
+        aria-describedby="open-review-source-description"
+        aria-labelledby="open-review-source-title"
+        aria-modal="true"
+        className="open-review-source-dialog"
+        onKeyDown={(event) => {
+          if (event.key === 'Escape' && !submitting) {
+            event.preventDefault();
+            onClose();
+          }
+        }}
+        onSubmit={handleSubmit}
+        role="dialog"
+      >
+        <div className="open-review-source-heading">
+          <h2 id="open-review-source-title">{copy.title}</h2>
+          <p id="open-review-source-description">{copy.description}</p>
+        </div>
+        <label className="open-review-source-label" htmlFor="open-review-source-input">
+          {copy.label}
+        </label>
+        <input
+          aria-describedby={error ? 'open-review-source-error' : undefined}
+          autoFocus
+          className="open-review-source-input"
+          disabled={submitting}
+          id="open-review-source-input"
+          onChange={(event) => {
+            setValue(event.currentTarget.value);
+            setError(null);
+          }}
+          placeholder={copy.placeholder}
+          spellCheck={false}
+          type="text"
+          value={value}
+        />
+        {error ? (
+          <p className="open-review-source-error" id="open-review-source-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <div className="open-review-source-actions">
+          <button disabled={submitting} onClick={onClose} type="button">
+            Cancel
+          </button>
+          <button disabled={submitting} type="submit">
+            {submitting ? 'Opening…' : 'Open'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/core/app/hooks/useAppCommands.ts
+++ b/core/app/hooks/useAppCommands.ts
@@ -4,13 +4,19 @@ import { createCommandRegistry, type Command } from '../../lib/command-registry.
 import type { ReviewCommandTarget } from '../../lib/review-command-target.ts';
 import { buildReviewCommentsMarkdown } from '../../lib/review-comments.ts';
 import { isReviewIdentityViewed } from '../../lib/review-identity.ts';
-import type { ChangedFile, CodiffPreferences, RepositoryState } from '../../types.ts';
+import type {
+  ChangedFile,
+  CodiffPreferences,
+  OpenReviewSourceKind,
+  RepositoryState,
+} from '../../types.ts';
 
 type UseAppCommandsOptions = {
   changeSidebarMode: (mode: SidebarMode) => void;
   focusFileFilter: () => void;
   getReviewCommandTarget: () => ReviewCommandTarget | null;
   onOpenDiffSearch: () => void;
+  onOpenReviewSource: (kind: OpenReviewSourceKind) => void;
   onOpenSelectedFile: () => void;
   onRefreshRepository: () => void;
   onToggleSidebar: () => void;
@@ -27,6 +33,7 @@ export function useAppCommands({
   focusFileFilter,
   getReviewCommandTarget,
   onOpenDiffSearch,
+  onOpenReviewSource,
   onOpenSelectedFile,
   onRefreshRepository,
   onToggleSidebar,
@@ -54,6 +61,21 @@ export function useAppCommands({
         id: 'diff-search',
         keymapAction: 'diffSearch',
         title: 'Find in Diffs',
+      }),
+      registry.register({
+        execute: () => onOpenReviewSource('pull-request'),
+        id: 'open-pull-request',
+        title: 'Open PR',
+      }),
+      registry.register({
+        execute: () => onOpenReviewSource('commit'),
+        id: 'open-commit',
+        title: 'Open Commit',
+      }),
+      registry.register({
+        execute: () => onOpenReviewSource('branch'),
+        id: 'open-branch',
+        title: 'Open Branch',
       }),
       registry.register({
         execute: () => changeSidebarMode('tree'),
@@ -212,6 +234,7 @@ export function useAppCommands({
     focusFileFilter,
     getReviewCommandTarget,
     onOpenDiffSearch,
+    onOpenReviewSource,
     onOpenSelectedFile,
     onRefreshRepository,
     onToggleSidebar,

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -12,6 +12,7 @@ import type {
   GitIdentity,
   NarrativeWalkthroughRequestOptions,
   NarrativeWalkthroughResult,
+  OpenReviewSourceKind,
   PlanHandoffStatus,
   PlanReview,
   RepositoryHistory,
@@ -81,6 +82,7 @@ declare global {
             | { deleted: false; document: CodiffMarkdownDocument; id: string },
         ) => void,
       ) => () => void;
+      onOpenReviewSource: (callback: (kind: OpenReviewSourceKind) => void) => () => void;
       onPlanCloseRequested: (callback: () => void) => () => void;
       onRefreshRequest: (callback: () => void) => () => void;
       onRepositoryChanged: (callback: (change: { root: string }) => void) => () => void;
@@ -90,6 +92,7 @@ declare global {
       openConfigFile: () => Promise<void>;
       openFile: (path: string) => Promise<void>;
       resetCodeFontSize: () => Promise<void>;
+      resolvePullRequestUrl: (value: string) => Promise<string>;
       saveMarkdownDocument: (
         request: SaveMarkdownDocumentRequest,
       ) => Promise<SaveMarkdownDocumentResult>;

--- a/core/types.ts
+++ b/core/types.ts
@@ -168,6 +168,9 @@ export type ReviewSource =
       url: string;
     };
 
+/** Sources that can be entered from the palette or native application menu. */
+export type OpenReviewSourceKind = 'branch' | 'commit' | 'pull-request';
+
 export type HistoryEntry = {
   author: string;
   committedAt: number;

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -54,6 +54,7 @@ const {
   writeConfig,
 } = require('./config.cjs');
 const { readReviewAssistantReply } = require('./review-assist.cjs');
+const { parseReviewUrl, resolveReviewUrl } = require('./review-source.cjs');
 const {
   findMatchingWindowIdentity,
   getWindowIdentity,
@@ -545,6 +546,17 @@ const getInstallSkillMenuItem = () =>
     (skill, browserWindow) => void skillInstallers.get(skill.id)?.install(browserWindow),
   );
 
+/**
+ * Native menus live in the main process, so this event lets the renderer own
+ * the actual source dialog and reuse it with the command palette.
+ * @param {import('electron').BrowserWindow | undefined} browserWindow
+ * @param {import('../core/types.ts').OpenReviewSourceKind} kind
+ */
+const requestOpenReviewSource = (browserWindow, kind) => {
+  if (browserWindow instanceof BrowserWindow && !browserWindow.isDestroyed()) {
+    browserWindow.webContents.send('codiff:openReviewSource', kind);
+  }
+};
 /** @returns {import('electron').Menu} */
 const buildApplicationMenu = () =>
   Menu.buildFromTemplate(
@@ -555,6 +567,22 @@ const buildApplicationMenu = () =>
               label: 'Codiff',
               submenu: [
                 { role: 'about' },
+                { type: 'separator' },
+                {
+                  click: (_menuItem, browserWindow) =>
+                    requestOpenReviewSource(browserWindow, 'pull-request'),
+                  label: 'Open PR',
+                },
+                {
+                  click: (_menuItem, browserWindow) =>
+                    requestOpenReviewSource(browserWindow, 'commit'),
+                  label: 'Open Commit',
+                },
+                {
+                  click: (_menuItem, browserWindow) =>
+                    requestOpenReviewSource(browserWindow, 'branch'),
+                  label: 'Open Branch',
+                },
                 { type: 'separator' },
                 {
                   label: 'Agent',
@@ -1274,6 +1302,23 @@ ipcMain.handle('codiff:getRepositoryState', async (event, source) => {
   rememberLastRepositoryPath(state.root);
   void resetRepositoryWatcher(event.sender.id, state.root);
   return state;
+});
+
+ipcMain.handle('codiff:resolvePullRequestUrl', (event, value) => {
+  const input = typeof value === 'string' ? value.trim() : '';
+  const parsedUrl = parseReviewUrl(input);
+  if (parsedUrl) {
+    return parsedUrl.url;
+  }
+
+  const number = input.match(/^#?([1-9]\d*)$/);
+  if (!number) {
+    throw new Error('Enter a pull request number or a GitHub or GitLab pull request link.');
+  }
+
+  // Reuse the CLI resolver so a bare number follows the repository's preferred remote.
+  const repositoryPath = windowRepositories.get(event.sender.id) || getLaunchPath();
+  return resolveReviewUrl(repositoryPath, Number(number[1]));
 });
 
 ipcMain.handle('codiff:getMarkdownDocument', async (event, request) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -72,6 +72,12 @@ const codiff = {
     ipcRenderer.on('codiff:findInDiffs', listener);
     return () => ipcRenderer.removeListener('codiff:findInDiffs', listener);
   },
+  onOpenReviewSource: (callback) => {
+    /** @param {Electron.IpcRendererEvent} _event @param {import('../core/types.ts').OpenReviewSourceKind} kind */
+    const listener = (_event, kind) => callback(kind);
+    ipcRenderer.on('codiff:openReviewSource', listener);
+    return () => ipcRenderer.removeListener('codiff:openReviewSource', listener);
+  },
   onMarkdownDocumentChanged: (callback) => {
     const listener = (_event, change) => callback(change);
     ipcRenderer.on('codiff:markdownDocumentChanged', listener);
@@ -113,6 +119,7 @@ const codiff = {
   },
   openConfigFile: () => ipcRenderer.invoke('codiff:openConfigFile'),
   openFile: (path) => ipcRenderer.invoke('codiff:openFile', path),
+  resolvePullRequestUrl: (value) => ipcRenderer.invoke('codiff:resolvePullRequestUrl', value),
   setDiffStyle: (value) => ipcRenderer.invoke('codiff:setDiffStyle', value),
   setShowOutdated: (value) => ipcRenderer.invoke('codiff:setShowOutdated', value),
   setWordWrap: (value) => ipcRenderer.invoke('codiff:setWordWrap', value),


### PR DESCRIPTION
This PR wires the currently CLI-only actions to open a branch/PR/commit into the UI (cmd+shift+p and the macos menu).

Screenshots:
<img width="255" height="427" alt="image" src="https://github.com/user-attachments/assets/a47e4629-e59a-4014-aa38-40fb86185f42" />
<img width="2313" height="1254" alt="image" src="https://github.com/user-attachments/assets/3ab53365-d6bb-42f8-b9c4-9bf453ca14f4" />
<img width="2313" height="1254" alt="image" src="https://github.com/user-attachments/assets/6ae6faed-ff5e-491b-9544-2c008d3a1cb6" />
<img width="2313" height="1254" alt="image" src="https://github.com/user-attachments/assets/d4d29261-e717-4697-878a-7559fc336e1c" />
<img width="2313" height="1254" alt="image" src="https://github.com/user-attachments/assets/360221d5-988a-4e99-a043-531f497e6f02" />

(I also removed the `-webkit` prefix that is not needed on the current electron version https://caniuse.com/css-backdrop-filter)