### PR TITLE
fix: accept review URLs copied from a review tab

### DIFF
--- a/bin/arguments.js
+++ b/bin/arguments.js
@@ -256,7 +256,8 @@ const getReviewProviderMarker = (arg) =>
       ? 'gitlab'
       : null;
 
-const isPullRequestUrlArgument = (arg) => parseReviewUrl(arg) != null;
+// Store the canonical form so pasted review tabs, queries and anchors never reach the Git layer.
+const parsePullRequestUrlArgument = (arg) => parseReviewUrl(arg)?.url ?? null;
 
 export const resolvePullRequestUrl = (repositoryPath, number, provider) =>
   resolveReviewUrl(repositoryPath, number, provider);
@@ -342,8 +343,9 @@ export const parseArguments = (args) => {
       requestedPath ??= arg;
       continue;
     }
-    if (!pullRequestUrl && isPullRequestUrlArgument(arg)) {
-      pullRequestUrl = arg;
+    const parsedPullRequestUrl = pullRequestUrl ? null : parsePullRequestUrlArgument(arg);
+    if (parsedPullRequestUrl) {
+      pullRequestUrl = parsedPullRequestUrl;
       continue;
     }
 
@@ -363,9 +365,11 @@ export const parseArguments = (args) => {
         index += 1;
         continue;
       }
-      if (markerProvider && nextValue && isPullRequestUrlArgument(nextValue)) {
+      const parsedNextValue =
+        markerProvider && nextValue ? parsePullRequestUrlArgument(nextValue) : null;
+      if (parsedNextValue) {
         pullRequestProvider = markerProvider;
-        pullRequestUrl = nextValue;
+        pullRequestUrl = parsedNextValue;
         index += 1;
         continue;
       }

--- a/bin/codiff-app
+++ b/bin/codiff-app
@@ -141,6 +141,12 @@ is_explicit_path_arg() {
   return 1
 }
 
+# Matches review links as pasted from a browser: an optional scheme, an optional `/-/` separator,
+# and any trailing tab segment, query or anchor. Electron canonicalizes the link it receives.
+is_review_url_arg() {
+  printf '%s' "$1" | grep -Eq '^(https?://[^/]+|[^/[:space:]:@]+\.[^/[:space:]:@]+(:[0-9]+)?)/(.+/)?[^/]+/(-/)?(merge_requests|pull)/[1-9][0-9]*([/?#].*)?$'
+}
+
 is_git_branch_ref() {
   git -C "$1" show-ref --verify --quiet "refs/heads/$2" 2>/dev/null ||
     git -C "$1" show-ref --verify --quiet "refs/remotes/$2" 2>/dev/null
@@ -225,6 +231,11 @@ for arg in "$@"; do
     if printf '%s' "$arg" | grep -Eq '^#?[1-9][0-9]*$'; then
       pull_request_source="#$arg"
       pull_request_source="$(printf '%s' "$pull_request_source" | tr -d '#')"
+      expect_pull_request_value=0
+      continue
+    fi
+    if is_review_url_arg "$arg"; then
+      pull_request_source="$arg"
       expect_pull_request_value=0
       continue
     fi
@@ -343,7 +354,7 @@ for arg in "$@"; do
         expect_pull_request_value=1
       elif [ -z "$pull_request_source" ] && printf '%s' "$arg" | grep -Eq '^#[1-9][0-9]*$'; then
         pull_request_source="$arg"
-      elif [ -z "$pull_request_source" ] && printf '%s' "$arg" | grep -Eq '^https?://[^/]+/(.+/)?[^/]+/(-/merge_requests|pull)/[0-9]+/?$'; then
+      elif [ -z "$pull_request_source" ] && is_review_url_arg "$arg"; then
         pull_request_source="$arg"
       elif [ -z "$commit_ref" ] && [ -z "$branch_ref" ] && [ -z "$source_ref" ] && ! is_explicit_path_arg "$arg"; then
         source_ref="$arg"

--- a/core/__tests__/codiff-cli.test.ts
+++ b/core/__tests__/codiff-cli.test.ts
@@ -125,6 +125,28 @@ test('parseArguments treats HEAD positional revisions as commit refs', () => {
   });
 });
 
+test('parseArguments canonicalizes review URLs copied from a review tab', () => {
+  for (const value of [
+    'https://github.com/nkzw-tech/codiff/pull/1728/changes#r4821',
+    'https://github.com/nkzw-tech/codiff/pull/1728/files',
+    'https://www.github.com/nkzw-tech/codiff/pull/1728?diff=split',
+    'github.com/nkzw-tech/codiff/pull/1728',
+  ]) {
+    expect(parseArguments([value])).toMatchObject({
+      pullRequestUrl: 'https://github.com/nkzw-tech/codiff/pull/1728',
+    });
+  }
+
+  for (const value of [
+    'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23/diffs#note_991',
+    'https://gitlab.example.com/group/subgroup/project/merge_requests/23',
+  ]) {
+    expect(parseArguments([value])).toMatchObject({
+      pullRequestUrl: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
+    });
+  }
+});
+
 test('parseArguments treats plain branch refs as branch refs', async () => {
   await withCwd(refRepositoryPath, () => {
     expect(parseArguments(['feature'])).toEqual({
@@ -549,6 +571,31 @@ test('packaged terminal helper forwards GitLab MR markers to Electron', async ()
     '23',
     process.cwd(),
   ]);
+});
+
+test('packaged terminal helper forwards review URLs copied from a review tab', async () => {
+  for (const value of [
+    'https://github.com/nkzw-tech/codiff/pull/1728/changes#r4821',
+    'https://github.com/nkzw-tech/codiff/pull/1728/files',
+    'https://www.github.com/nkzw-tech/codiff/pull/1728?diff=split',
+    'github.com/nkzw-tech/codiff/pull/1728',
+    'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23/diffs#note_991',
+    'https://gitlab.example.com/group/subgroup/project/merge_requests/23',
+  ]) {
+    await using logger = await createFakeOpenLogger();
+
+    await execFileAsync(resolve('bin/codiff-app'), [value], {
+      env: logger.env,
+    });
+
+    expect(await logger.readArgs()).toEqual([
+      '-n',
+      resolve('bin/../../../..'),
+      '--args',
+      value,
+      process.cwd(),
+    ]);
+  }
 });
 
 test('packaged terminal helper forwards HEAD^1 to Electron as a commit', async () => {

--- a/core/__tests__/git-state.test.ts
+++ b/core/__tests__/git-state.test.ts
@@ -396,6 +396,35 @@ test('parseGitHubPullRequestUrl reads canonical pull request URLs', () => {
   });
 });
 
+test('parseGitHubPullRequestUrl canonicalizes URLs copied from a review tab', () => {
+  for (const value of [
+    'https://github.com/nkzw-tech/codiff/pull/3/changes#r4821',
+    'https://github.com/nkzw-tech/codiff/pull/3/files',
+    'https://github.com/nkzw-tech/codiff/pull/3/commits/0f1e2d3c',
+    'https://www.github.com/nkzw-tech/codiff/pull/3?diff=split',
+    'github.com/nkzw-tech/codiff/pull/3',
+  ]) {
+    expect(parseGitHubPullRequestUrl(value)).toEqual({
+      number: 3,
+      owner: 'nkzw-tech',
+      repo: 'codiff',
+      url: 'https://github.com/nkzw-tech/codiff/pull/3',
+    });
+  }
+});
+
+test('parseGitHubPullRequestUrl rejects values that are not GitHub pull requests', () => {
+  expect(() => parseGitHubPullRequestUrl('not a url')).toThrow(
+    'Codiff expected a GitHub pull request URL.',
+  );
+  expect(() => parseGitHubPullRequestUrl('https://github.com/nkzw-tech/codiff')).toThrow(
+    'Codiff expected a GitHub pull request URL.',
+  );
+  expect(() =>
+    parseGitHubPullRequestUrl('https://gitlab.example.com/group/project/-/merge_requests/3'),
+  ).toThrow('Codiff only supports GitHub pull request URLs.');
+});
+
 test('validateRepositoryPath returns normalized repository paths', () => {
   expect(validateRepositoryPath('src/./file.ts')).toBe(join('src', 'file.ts'));
   expect(validateRepositoryPath('src//nested/file.ts')).toBe(join('src', 'nested', 'file.ts'));

--- a/core/__tests__/gitlab.test.ts
+++ b/core/__tests__/gitlab.test.ts
@@ -143,6 +143,24 @@ describe('GitLab merge requests', () => {
     });
   });
 
+  test('canonicalizes merge request URLs copied from a review tab', () => {
+    for (const value of [
+      'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23/diffs#note_991',
+      'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23/commits',
+      'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23?commit_id=0f1e2d3c',
+      'https://gitlab.example.com/group/subgroup/project/merge_requests/23',
+      'gitlab.example.com/group/subgroup/project/-/merge_requests/23/diffs',
+    ]) {
+      expect(parseGitLabMergeRequestUrl(value)).toMatchObject({
+        host: 'gitlab.example.com',
+        number: 23,
+        projectPath: 'group/subgroup/project',
+        provider: 'gitlab',
+        url: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
+      });
+    }
+  });
+
   test('builds local head and target branch fetch refspecs', () => {
     expect(
       createMergeRequestFetchRefspecs(

--- a/electron/__tests__/command-line.test.ts
+++ b/electron/__tests__/command-line.test.ts
@@ -360,6 +360,35 @@ test('parses full GitHub pull request URLs as launch sources', () => {
   });
 });
 
+test('canonicalizes GitHub pull request URLs copied from a review tab', () => {
+  for (const value of [
+    'https://github.com/nkzw-tech/codiff/pull/11/changes#r4821',
+    'https://github.com/nkzw-tech/codiff/pull/11/files',
+    'https://www.github.com/nkzw-tech/codiff/pull/11?diff=split',
+    'github.com/nkzw-tech/codiff/pull/11/commits',
+  ]) {
+    expect(readCommandLine(['codiff', value, '/repo']).launchOptions.source).toEqual({
+      provider: 'github',
+      type: 'pull-request',
+      url: 'https://github.com/nkzw-tech/codiff/pull/11',
+    });
+  }
+});
+
+test('canonicalizes GitLab merge request URLs copied from a review tab', () => {
+  for (const value of [
+    'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23/diffs#note_991',
+    'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23/commits',
+    'https://gitlab.example.com/group/subgroup/project/merge_requests/23',
+  ]) {
+    expect(readCommandLine(['codiff', value, '/repo']).launchOptions.source).toEqual({
+      provider: 'gitlab',
+      type: 'pull-request',
+      url: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
+    });
+  }
+});
+
 test('resolves GitHub and GitLab review markers through repository remotes', async () => {
   await using directory = await createTemporaryDirectory('codiff-review-markers-');
   const githubRepo = join(directory.path, 'github');

--- a/electron/__tests__/review-source.test.ts
+++ b/electron/__tests__/review-source.test.ts
@@ -1,0 +1,131 @@
+import { createRequire } from 'node:module';
+import { expect, test } from 'vite-plus/test';
+
+const require = createRequire(import.meta.url);
+
+const { parseReviewUrl } = require('../review-source.cjs') as {
+  parseReviewUrl: (value: string) => {
+    host: string;
+    number: number;
+    owner?: string;
+    projectPath: string;
+    provider: 'github' | 'gitlab';
+    repo?: string;
+    url: string;
+  } | null;
+};
+
+test('parseReviewUrl reads canonical GitHub pull request URLs', () => {
+  expect(parseReviewUrl('https://github.com/nkzw-tech/codiff/pull/1728')).toEqual({
+    host: 'github.com',
+    number: 1728,
+    owner: 'nkzw-tech',
+    projectPath: 'nkzw-tech/codiff',
+    provider: 'github',
+    repo: 'codiff',
+    url: 'https://github.com/nkzw-tech/codiff/pull/1728',
+  });
+});
+
+test('parseReviewUrl ignores GitHub tab segments, queries and fragments', () => {
+  for (const value of [
+    'https://github.com/nkzw-tech/codiff/pull/1728/',
+    'https://github.com/nkzw-tech/codiff/pull/1728/changes#r2231',
+    'https://github.com/nkzw-tech/codiff/pull/1728/files',
+    'https://github.com/nkzw-tech/codiff/pull/1728/files#diff-8a1b2c',
+    'https://github.com/nkzw-tech/codiff/pull/1728/commits/0f1e2d3c',
+    'https://github.com/nkzw-tech/codiff/pull/1728?diff=split&w=1',
+    'https://github.com/nkzw-tech/codiff/pull/1728#issuecomment-4412',
+  ]) {
+    expect(parseReviewUrl(value)).toMatchObject({
+      number: 1728,
+      provider: 'github',
+      url: 'https://github.com/nkzw-tech/codiff/pull/1728',
+    });
+  }
+});
+
+test('parseReviewUrl accepts GitHub URLs pasted without a scheme or with `www`', () => {
+  for (const value of [
+    'github.com/nkzw-tech/codiff/pull/1728/changes',
+    'www.github.com/nkzw-tech/codiff/pull/1728',
+    'https://www.github.com/nkzw-tech/codiff/pull/1728/files',
+    'HTTPS://GitHub.com/nkzw-tech/codiff/pull/1728',
+    '<https://github.com/nkzw-tech/codiff/pull/1728>',
+    '  https://github.com/nkzw-tech/codiff/pull/1728/files  ',
+  ]) {
+    expect(parseReviewUrl(value)).toMatchObject({
+      host: 'github.com',
+      number: 1728,
+      owner: 'nkzw-tech',
+      repo: 'codiff',
+      url: 'https://github.com/nkzw-tech/codiff/pull/1728',
+    });
+  }
+});
+
+test('parseReviewUrl strips a `.git` suffix from GitHub repositories', () => {
+  expect(parseReviewUrl('https://github.com/nkzw-tech/codiff.git/pull/1728')).toMatchObject({
+    projectPath: 'nkzw-tech/codiff',
+    repo: 'codiff',
+    url: 'https://github.com/nkzw-tech/codiff/pull/1728',
+  });
+});
+
+test('parseReviewUrl reads GitLab merge request URLs on arbitrary hosts', () => {
+  expect(
+    parseReviewUrl('https://gitlab.example.com/group/subgroup/project/-/merge_requests/23'),
+  ).toEqual({
+    host: 'gitlab.example.com',
+    number: 23,
+    projectPath: 'group/subgroup/project',
+    provider: 'gitlab',
+    url: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
+  });
+});
+
+test('parseReviewUrl ignores GitLab tab segments, queries and fragments', () => {
+  for (const value of [
+    'https://gitlab.example.com/group/project/-/merge_requests/23/',
+    'https://gitlab.example.com/group/project/-/merge_requests/23/diffs',
+    'https://gitlab.example.com/group/project/-/merge_requests/23/diffs#note_9182',
+    'https://gitlab.example.com/group/project/-/merge_requests/23/commits',
+    'https://gitlab.example.com/group/project/-/merge_requests/23/pipelines',
+    'https://gitlab.example.com/group/project/-/merge_requests/23?commit_id=0f1e2d3c',
+    'gitlab.example.com/group/project/-/merge_requests/23/diffs',
+  ]) {
+    expect(parseReviewUrl(value)).toMatchObject({
+      number: 23,
+      projectPath: 'group/project',
+      provider: 'gitlab',
+      url: 'https://gitlab.example.com/group/project/-/merge_requests/23',
+    });
+  }
+});
+
+test('parseReviewUrl reads legacy GitLab merge request URLs without the `/-/` segment', () => {
+  expect(
+    parseReviewUrl('https://gitlab.example.com/group/project/merge_requests/23/diffs'),
+  ).toMatchObject({
+    number: 23,
+    projectPath: 'group/project',
+    provider: 'gitlab',
+    url: 'https://gitlab.example.com/group/project/-/merge_requests/23',
+  });
+});
+
+test('parseReviewUrl rejects values that are not review URLs', () => {
+  for (const value of [
+    '',
+    'main',
+    'feature/pull/1',
+    'https://github.com/nkzw-tech/codiff',
+    'https://github.com/nkzw-tech/codiff/pull/0',
+    'https://github.com/nkzw-tech/codiff/pull/abc',
+    'https://github.com/nkzw-tech/codiff/issues/1728',
+    'https://example.com/nkzw-tech/codiff/pull/1728',
+    'some/local/path/merge_requests/23',
+  ]) {
+    expect(parseReviewUrl(value)).toBe(null);
+  }
+});

--- a/electron/__tests__/window-identity.test.ts
+++ b/electron/__tests__/window-identity.test.ts
@@ -226,6 +226,28 @@ test('window identities normalize GitHub pull request sources', async () => {
   );
 });
 
+test('window identities normalize pull request URLs copied from a review tab', async () => {
+  await using directory = await createTemporaryDirectory('codiff-window-identity-');
+  await initRepository(directory.path);
+
+  expect(
+    getWindowIdentity(directory.path, {
+      source: {
+        type: 'pull-request',
+        url: 'https://github.com/NKZW-Tech/Codiff/pull/8/changes#r4821',
+      },
+    })?.sourceKey,
+  ).toBe('pull-request:nkzw-tech/codiff#8');
+  expect(
+    getWindowIdentity(directory.path, {
+      source: {
+        type: 'pull-request',
+        url: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/8/diffs',
+      },
+    })?.sourceKey,
+  ).toBe('pull-request:gitlab:gitlab.example.com/group/subgroup/project#8');
+});
+
 test('window identities normalize GitLab merge request sources', async () => {
   await using directory = await createTemporaryDirectory('codiff-window-identity-');
   await initRepository(directory.path);

--- a/electron/git-state/pull-request.cjs
+++ b/electron/git-state/pull-request.cjs
@@ -14,6 +14,7 @@ const {
   validateRepositoryPath,
 } = require('./common.cjs');
 const { readGitFiles } = require('./git-files.cjs');
+const { parseReviewUrl } = require('../review-source.cjs');
 
 /**
  * @typedef {import('../../core/types.ts').ChangedFile} ChangedFile
@@ -37,28 +38,20 @@ const { readGitFiles } = require('./git-files.cjs');
 
 /** @param {string} value @returns {PullRequestReference} */
 const parseGitHubPullRequestUrl = (value) => {
-  let url;
-  try {
-    url = new URL(value);
-  } catch {
+  const parsed = parseReviewUrl(value);
+  if (!parsed) {
     throw new Error('Codiff expected a GitHub pull request URL.');
   }
 
-  if (url.hostname.toLowerCase() !== 'github.com') {
+  if (parsed.provider !== 'github') {
     throw new Error('Codiff only supports GitHub pull request URLs.');
   }
 
-  const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/);
-  if (!match) {
-    throw new Error('Codiff expected a GitHub pull request URL.');
-  }
-
-  const [, owner, repo, number] = match;
   return {
-    number: Number(number),
-    owner,
-    repo,
-    url: `https://github.com/${owner}/${repo}/pull/${number}`,
+    number: parsed.number,
+    owner: parsed.owner,
+    repo: parsed.repo,
+    url: parsed.url,
   };
 };
 

--- a/electron/main/command-line.cjs
+++ b/electron/main/command-line.cjs
@@ -95,8 +95,9 @@ const getReviewProviderMarker = (arg) =>
       ? 'gitlab'
       : null;
 
-/** @param {string} arg */
-const isPullRequestUrlArgument = (arg) => parseReviewUrl(arg) != null;
+/** Stores the canonical form so pasted review tabs, queries and anchors never reach the Git layer.
+ * @param {string} arg */
+const parsePullRequestUrlArgument = (arg) => parseReviewUrl(arg)?.url ?? null;
 
 /** @param {string} repositoryPath @param {number} number */
 const resolvePullRequestUrl = (repositoryPath, number, provider) =>
@@ -169,8 +170,9 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
       repositoryPath ??= arg;
       continue;
     }
-    if (!pullRequestUrl && isPullRequestUrlArgument(arg)) {
-      pullRequestUrl = arg;
+    const parsedPullRequestUrl = pullRequestUrl ? null : parsePullRequestUrlArgument(arg);
+    if (parsedPullRequestUrl) {
+      pullRequestUrl = parsedPullRequestUrl;
       continue;
     }
 
@@ -300,7 +302,12 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
   const sourceRef = envCommitRef || commitRef;
   const sourceBranchRef = envBranchRef || branchRef;
   const sourceRange = envRange || range;
-  const sourcePullRequestUrl = envPullRequestUrl || pullRequestUrl;
+  const sourcePullRequestUrl = envPullRequestUrl
+    ? parsePullRequestUrlArgument(envPullRequestUrl) || envPullRequestUrl
+    : pullRequestUrl;
+  const sourcePullRequestProvider = sourcePullRequestUrl
+    ? parseReviewUrl(sourcePullRequestUrl)?.provider
+    : null;
   const repositoryPathProvided = Boolean(
     repositoryPath || (useEnvironment && process.env.CODIFF_REPOSITORY_PATH),
   );
@@ -324,9 +331,7 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
             }
           : sourcePullRequestUrl
             ? {
-                ...(parseReviewUrl(sourcePullRequestUrl)?.provider
-                  ? { provider: parseReviewUrl(sourcePullRequestUrl).provider }
-                  : {}),
+                ...(sourcePullRequestProvider ? { provider: sourcePullRequestProvider } : {}),
                 type: 'pull-request',
                 url: sourcePullRequestUrl,
               }

--- a/electron/review-source.cjs
+++ b/electron/review-source.cjs
@@ -4,39 +4,80 @@ const { execFileSync } = require('node:child_process');
 
 /** @typedef {'github' | 'gitlab'} ReviewProvider */
 
+// Reviews are usually pasted straight from a browser, so anything after the review number is a tab
+// (`/files`, `/changes`, `/diffs`), a query, or an anchor, and none of it identifies the review.
+const gitHubPullRequestPattern = /^\/([^/]+)\/([^/]+)\/pull\/([1-9]\d*)(?:\/.*)?$/;
+const gitLabMergeRequestPattern = /^\/(.+?)\/-\/merge_requests\/([1-9]\d*)(?:\/.*)?$/;
+// GitLab only introduced the `/-/` separator in 11.0; older instances and links still omit it.
+const legacyGitLabMergeRequestPattern = /^\/(.+?)\/merge_requests\/([1-9]\d*)(?:\/.*)?$/;
+const markdownAutolinkPattern = /^<(.+)>$/;
+const schemePattern = /^[A-Za-z][A-Za-z\d+.-]*:/;
+// A scheme-less paste only counts as a URL when it starts with something host-shaped, so relative
+// paths and refs are never mistaken for links.
+const hostPrefixPattern = /^[^/\s:@]+\.[^/\s:@]+(?::\d+)?\//;
+
 /** @param {string} value */
-const parseReviewUrl = (value) => {
-  let url;
-  try {
-    url = new URL(value);
-  } catch {
+const stripGitSuffix = (value) => value.replace(/\.git$/i, '');
+
+/** @param {string} value */
+const toReviewUrl = (value) => {
+  const trimmed = value.trim();
+  const unwrapped = trimmed.match(markdownAutolinkPattern)?.[1] ?? trimmed;
+  const candidate = schemePattern.test(unwrapped)
+    ? unwrapped
+    : hostPrefixPattern.test(unwrapped)
+      ? `https://${unwrapped}`
+      : null;
+  if (!candidate) {
     return null;
   }
 
-  const host = url.host.toLowerCase();
-  const github = url.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/([1-9]\d*)\/?$/);
-  if (url.hostname.toLowerCase() === 'github.com' && github) {
+  try {
+    const url = new URL(candidate);
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url : null;
+  } catch {
+    return null;
+  }
+};
+
+/** @param {URL} url */
+const isGitHubHost = (url) => {
+  const hostname = url.hostname.toLowerCase();
+  return hostname === 'github.com' || hostname === 'www.github.com';
+};
+
+/** @param {string} value */
+const parseReviewUrl = (value) => {
+  const url = toReviewUrl(value);
+  if (!url) {
+    return null;
+  }
+
+  const github = isGitHubHost(url) ? url.pathname.match(gitHubPullRequestPattern) : null;
+  const repo = github ? stripGitSuffix(github[2]) : '';
+  if (github && repo) {
     return {
-      host,
+      host: 'github.com',
       number: Number(github[3]),
       owner: github[1],
-      projectPath: `${github[1]}/${github[2]}`,
+      projectPath: `${github[1]}/${repo}`,
       provider: /** @type {const} */ ('github'),
-      repo: github[2],
-      url: `https://github.com/${github[1]}/${github[2]}/pull/${github[3]}`,
+      repo,
+      url: `https://github.com/${github[1]}/${repo}/pull/${github[3]}`,
     };
   }
 
-  const gitlab = url.pathname.match(/^\/(.+?)\/-\/merge_requests\/([1-9]\d*)\/?$/);
-  if (gitlab) {
+  const gitlab =
+    url.pathname.match(gitLabMergeRequestPattern) ??
+    url.pathname.match(legacyGitLabMergeRequestPattern);
+  const projectPath = gitlab ? stripGitSuffix(gitlab[1]) : '';
+  if (gitlab && projectPath) {
     return {
-      host,
+      host: url.host.toLowerCase(),
       number: Number(gitlab[2]),
-      projectPath: gitlab[1].replace(/\.git$/i, ''),
+      projectPath,
       provider: /** @type {const} */ ('gitlab'),
-      url: `${url.protocol}//${url.host}/${gitlab[1].replace(/\.git$/i, '')}/-/merge_requests/${
-        gitlab[2]
-      }`,
+      url: `${url.protocol}//${url.host}/${projectPath}/-/merge_requests/${gitlab[2]}`,
     };
   }
 

--- a/electron/window-identity.cjs
+++ b/electron/window-identity.cjs
@@ -77,27 +77,6 @@ const resolveMergeBase = (repositoryRoot, baseRef, headRef) => {
   }
 };
 
-/** @param {string} value @returns {ParsedPullRequest | null} */
-const parseGitHubPullRequestUrl = (value) => {
-  try {
-    const url = new URL(value);
-    if (url.hostname.toLowerCase() !== 'github.com') {
-      return null;
-    }
-
-    const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/([1-9]\d*)\/?$/);
-    return match
-      ? {
-          number: Number(match[3]),
-          owner: match[1],
-          repo: match[2].replace(/\.git$/i, ''),
-        }
-      : null;
-  } catch {
-    return null;
-  }
-};
-
 /** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
 const getPullRequestSourceKey = (source) => {
   const review = parseReviewUrl(source.url);
@@ -113,7 +92,13 @@ const getPullRequestSourceKey = (source) => {
           owner: source.owner,
           repo: source.repo,
         }
-      : parseGitHubPullRequestUrl(source.url);
+      : review?.provider === 'github'
+        ? /** @type {ParsedPullRequest} */ ({
+            number: review.number,
+            owner: review.owner,
+            repo: review.repo,
+          })
+        : null;
 
   return pullRequest
     ? `pull-request:${pullRequest.owner.toLowerCase()}/${pullRequest.repo.toLowerCase()}#${


### PR DESCRIPTION
This PR was written primarily with Opus 5 xhigh.

Pasting a link like `https://github.com/org/repo/pull/1728/changes#r4821` doesn't open the PR, Codiff falls back to treating it as a branch name so the walkthrough never gets generated.

`parseReviewUrl` anchored both the GitHub and GitLab patterns at the end of the path with only an optional trailing slash, so any segment after the number broke the match. The `#r4821` fragment was never the problem, `new URL` already puts that in `.hash`.

This PR makes the parser tolerant and canonicalizes to `https://github.com/owner/repo/pull/N` or `https://host/path/-/merge_requests/N` before anything downstream sees the URL. Now accepted:

- trailing tab segments: `/changes`, `/files`, `/commits/<sha>`, `/diffs`, `/pipelines`
- query strings and anchors: `?diff=split`, `#note_991`
- `www.github.com`
- links pasted without a scheme: `github.com/owner/repo/pull/1728`
- markdown autolinks: `<https://...>`
- a `.git` suffix on the repo or project path
- legacy GitLab URLs without the `/-/` separator: `/group/project/merge_requests/23`

Nothing that used to be rejected became valid. `pull/0`, non-numeric numbers, `/pull/` paths on non-GitHub hosts and non-http(s) schemes still return `null`, and a scheme-less paste only counts as a link when it starts with a dotted, host-shaped authority, so relative paths and refs aren't mistaken for URLs.

The same strictness existed in a few other spots, each with its own copy of the regex:

- `electron/git-state/pull-request.cjs` and `electron/window-identity.cjs` now delegate to `parseReviewUrl` instead of re-implementing it
- `electron/main/command-line.cjs` and `bin/arguments.js` stored the raw argument as `source.url`, so a tolerant parser on its own wouldn't have fixed anything, the raw link still reached the Git layer. Both store the canonical URL now, including the `CODIFF_PULL_REQUEST_URL` path
- `bin/codiff-app` classifies the argument before Electron ever sees it, so its shell regex needed the same treatment. It also recognizes `codiff pr <url>` directly now instead of falling through to a `gh pr view` branch lookup

`service/api.ts` already tolerated trailing segments and only ever sees URLs Codiff wrote itself, so I left it alone.

Tests go through each entry point: the parser, both CLIs, the shell launcher and window identity. They're in a separate commit ahead of the fix.

🍌 🍌 🍌 😁