### PR TITLE
ci: run tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,20 @@ on:
   push:
     branches:
       - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [24]


### PR DESCRIPTION
The `test` workflow only runs on pushes to `main`, so pull requests get no CI signal and breakage only shows up after merge.

This PR:
- adds the `pull_request` trigger to `test.yml`
- adds `workflow_dispatch` so a run can be kicked off manually
- scopes the token to `contents: read`, the job only checks out, builds, and tests
- adds a concurrency group that cancels superseded PR runs, `main` is left alone so every commit there keeps its own result
- adds a 20 minute job timeout as a hang guard, runs currently finish in around two minutes

No duplicate runs, `push` stays filtered to `main`, so a PR branch push only fires the `pull_request` event.

This one triggers its own check. `pull_request` workflows run from the PR's merge ref, so the run that shows up here is the change working.

Used Opus 5 xhigh to make these changes.