### PR TITLE
fix: resolve the gh executable instead of spawning it by name

### DIFF
--- a/electron/__tests__/pull-request-command.test.ts
+++ b/electron/__tests__/pull-request-command.test.ts
@@ -1,0 +1,180 @@
+import { execFile } from 'node:child_process';
+import { chmod, mkdir, readFile, symlink, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { expect, test } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
+
+const require = createRequire(import.meta.url);
+const { GH_NOT_FOUND_CODE, getGhCommand, submitPullRequestReview } =
+  require('../git-state/pull-request.cjs') as {
+    GH_NOT_FOUND_CODE: string;
+    getGhCommand: () => string;
+    submitPullRequestReview: (
+      launchPath: string,
+      request: {
+        body?: string;
+        comments: ReadonlyArray<Record<string, unknown>>;
+        event: 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES';
+        source: {
+          provider: 'github';
+          type: 'pull-request';
+          url: string;
+        };
+      },
+    ) => Promise<void>;
+  };
+
+const execFileAsync = promisify(execFile);
+
+test('resolves the GitHub CLI from an explicit override', async () => {
+  await using directory = await createTemporaryDirectory('codiff-gh-command-');
+  const fakeGh = join(directory.path, 'gh');
+  await writeFile(fakeGh, '#!/bin/sh\nexit 0\n');
+  await chmod(fakeGh, 0o755);
+
+  await using _environment = createTemporaryEnvironment({ CODIFF_GH_PATH: fakeGh });
+
+  expect(getGhCommand()).toBe(fakeGh);
+});
+
+test('rejects invalid explicit GitHub CLI overrides', async () => {
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_GH_PATH: '/tmp/codiff-missing-gh',
+  });
+
+  expect(() => getGhCommand()).toThrow('CODIFF_GH_PATH');
+  try {
+    getGhCommand();
+  } catch (error) {
+    expect(error).toMatchObject({ code: GH_NOT_FOUND_CODE });
+  }
+});
+
+test('falls back to a standard install directory when gh is off PATH', async () => {
+  await using directory = await createTemporaryDirectory('codiff-gh-fallback-');
+  const localBin = join(directory.path, '.local/bin');
+  const emptyBin = join(directory.path, 'empty-bin');
+  const fallbackGh = join(localBin, 'gh');
+
+  await Promise.all([mkdir(localBin, { recursive: true }), mkdir(emptyBin)]);
+  await writeFile(fallbackGh, '#!/bin/sh\nexit 0\n');
+  await chmod(fallbackGh, 0o755);
+
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_GH_PATH: undefined,
+    HOME: directory.path,
+    PATH: emptyBin,
+  });
+
+  expect(getGhCommand()).toBe(fallbackGh);
+});
+
+test('reports a missing GitHub CLI when the resolved executable cannot be spawned', async () => {
+  await using directory = await createTemporaryDirectory('codiff-gh-unspawnable-');
+  const repo = join(directory.path, 'repo');
+  const fakeGh = join(directory.path, 'gh');
+
+  await mkdir(repo);
+  await execFileAsync('git', ['-C', repo, 'init']);
+  await execFileAsync('git', [
+    '-C',
+    repo,
+    'remote',
+    'add',
+    'origin',
+    'git@github.com:nkzw-tech/codiff.git',
+  ]);
+
+  // Executable enough to pass resolution, but its interpreter is missing, so
+  // the spawn itself fails the same way a deleted `gh` would.
+  await writeFile(fakeGh, '#!/codiff-missing-interpreter\n');
+  await chmod(fakeGh, 0o755);
+
+  await using _environment = createTemporaryEnvironment({ CODIFF_GH_PATH: fakeGh });
+
+  await expect(
+    submitPullRequestReview(repo, {
+      body: 'General feedback.',
+      comments: [],
+      event: 'COMMENT',
+      source: {
+        provider: 'github',
+        type: 'pull-request',
+        url: 'https://github.com/nkzw-tech/codiff/pull/12',
+      },
+    }),
+  ).rejects.toThrow('GitHub support requires gh');
+});
+
+test('reaches the GitHub CLI when it is not on PATH', async () => {
+  await using directory = await createTemporaryDirectory('codiff-gh-off-path-');
+  const repo = join(directory.path, 'repo');
+  const pathBin = join(directory.path, 'path-bin');
+  const fakeGh = join(directory.path, 'gh');
+  const callsPath = join(directory.path, 'calls.txt');
+
+  await Promise.all([mkdir(repo), mkdir(pathBin)]);
+  await execFileAsync('git', ['-C', repo, 'init']);
+  await execFileAsync('git', [
+    '-C',
+    repo,
+    'remote',
+    'add',
+    'origin',
+    'git@github.com:nkzw-tech/codiff.git',
+  ]);
+
+  // A PATH carrying only the commands this test itself needs reproduces how the
+  // packaged app is launched: Homebrew's directory is absent, so `gh` cannot be
+  // spawned by name.
+  for (const command of ['cat', 'git']) {
+    const { stdout } = await execFileAsync('sh', ['-c', `command -v ${command}`]);
+    await symlink(stdout.trim(), join(pathBin, command));
+  }
+
+  // Records the arguments and the stdin payload of every call, so the review
+  // body has to survive the pipe rather than merely reaching the executable.
+  await writeFile(
+    fakeGh,
+    `#!/bin/sh
+printf '%s | %s\\n' "$*" "$(cat)" >> "$CODIFF_GITHUB_COMMAND_TEST_CALLS"
+for arg in "$@"; do
+  if [ "$arg" = 'repos/nkzw-tech/codiff/pulls/12' ]; then
+    printf '%s' '{"head":{"sha":"0123456789abcdef0123456789abcdef01234567"}}'
+    exit 0
+  fi
+done
+printf '%s' '{}'
+`,
+  );
+  await chmod(fakeGh, 0o755);
+
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_GH_PATH: fakeGh,
+    CODIFF_GITHUB_COMMAND_TEST_CALLS: callsPath,
+    PATH: pathBin,
+  });
+
+  await submitPullRequestReview(repo, {
+    body: 'General feedback.',
+    comments: [],
+    event: 'COMMENT',
+    source: {
+      provider: 'github',
+      type: 'pull-request',
+      url: 'https://github.com/nkzw-tech/codiff/pull/12',
+    },
+  });
+
+  const calls = (await readFile(callsPath, 'utf8')).trim().split('\n');
+  expect(calls).toEqual([
+    'api repos/nkzw-tech/codiff/pulls/12 | ',
+    'api -X POST repos/nkzw-tech/codiff/pulls/12/reviews --input - | ' +
+      '{"body":"General feedback.","comments":[],"event":"COMMENT"}',
+  ]);
+});

--- a/electron/git-state/pull-request.cjs
+++ b/electron/git-state/pull-request.cjs
@@ -1,6 +1,9 @@
 // @ts-check
 
 const { spawn } = require('node:child_process');
+const { homedir } = require('node:os');
+const { join } = require('node:path');
+const { findExecutableOnPath, isExecutableFile } = require('../agent-shared.cjs');
 const {
   IMAGE_FILE_LIMIT,
   bufferToImageRevision,
@@ -34,6 +37,52 @@ const { readGitFiles } = require('./git-files.cjs');
  * @typedef {{[key: string]: any}} GitHubReviewComment
  * @typedef {{comments?: {nodes?: ReadonlyArray<{databaseId?: number | null}>} | null; isResolved?: boolean}} GitHubReviewThread
  */
+
+const GH_NOT_FOUND_CODE = 'GH_NOT_FOUND';
+const GH_NOT_FOUND_MESSAGE =
+  'GitHub support requires gh. Install gh, authenticate it, and verify `gh --version` works in Terminal. Codiff searches PATH, ~/.local/bin/gh, /opt/homebrew/bin/gh, and /usr/local/bin/gh. If gh is installed somewhere else, quit Codiff, then launch it with `CODIFF_GH_PATH=/absolute/path/to/gh codiff`.';
+
+/** @param {string} [detail] */
+const createGhNotFoundError = (detail) =>
+  Object.assign(new Error(detail ? `${GH_NOT_FOUND_MESSAGE} ${detail}` : GH_NOT_FOUND_MESSAGE), {
+    code: GH_NOT_FOUND_CODE,
+  });
+
+/**
+ * A Dock or Spotlight launch gives the app a minimal PATH that omits the
+ * directories Homebrew and manual installs use, and later `codiff` invocations
+ * hand their arguments to that first process rather than replacing it, so `gh`
+ * has to be located the same way the other CLIs Codiff shells out to are.
+ */
+const getGhCommand = () => {
+  const ghPath = process.env.CODIFF_GH_PATH?.trim();
+  if (ghPath) {
+    if (isExecutableFile(ghPath)) {
+      return ghPath;
+    }
+
+    throw createGhNotFoundError(
+      `CODIFF_GH_PATH is set to ${JSON.stringify(ghPath)}, but that file is not executable.`,
+    );
+  }
+
+  const pathCommand = findExecutableOnPath('gh');
+  if (pathCommand) {
+    return pathCommand;
+  }
+
+  for (const path of [
+    join(homedir(), '.local/bin/gh'),
+    '/opt/homebrew/bin/gh',
+    '/usr/local/bin/gh',
+  ]) {
+    if (isExecutableFile(path)) {
+      return path;
+    }
+  }
+
+  throw createGhNotFoundError();
+};
 
 /** @param {string} value @returns {PullRequestReference} */
 const parseGitHubPullRequestUrl = (value) => {
@@ -226,14 +275,17 @@ const fetchPullRequestHistoryRefs = (repoRoot, remote, pullRequest, metadata) =>
   ]);
 
 /**
+ * Runs `gh api` and reports how it exited. Callers decide which exit codes are
+ * failures because a missing file is a valid answer for content lookups.
+ *
  * @param {string} repoRoot
  * @param {ReadonlyArray<string>} args
  * @param {unknown} [input]
- * @returns {Promise<string>}
+ * @returns {Promise<{code: number | null; stderr: string; stdout: Buffer}>}
  */
-const ghApi = (repoRoot, args, input) =>
+const runGhApi = (repoRoot, args, input) =>
   new Promise((resolve, reject) => {
-    const child = spawn('gh', ['api', ...args], {
+    const child = spawn(getGhCommand(), ['api', ...args], {
       cwd: repoRoot,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -244,59 +296,50 @@ const ghApi = (repoRoot, args, input) =>
 
     child.stdout.on('data', (chunk) => stdout.push(chunk));
     child.stderr.on('data', (chunk) => stderr.push(chunk));
-    child.on('error', reject);
-    child.on('close', (code) => {
-      const output = Buffer.concat(stdout).toString('utf8');
-      if (code === 0) {
-        resolve(output);
-        return;
-      }
+    child.on('error', (error) => reject(error.code === 'ENOENT' ? createGhNotFoundError() : error));
+    child.on('close', (code) =>
+      resolve({
+        code,
+        stderr: Buffer.concat(stderr).toString('utf8'),
+        stdout: Buffer.concat(stdout),
+      }),
+    );
 
-      const errorOutput = Buffer.concat(stderr).toString('utf8').trim();
-      reject(new Error(errorOutput || `gh api exited with code ${code}.`));
-    });
-
-    if (input == null) {
-      child.stdin.end();
-    } else {
-      child.stdin.end(JSON.stringify(input));
-    }
+    child.stdin.end(input == null ? undefined : JSON.stringify(input));
   });
+
+/**
+ * @param {string} repoRoot
+ * @param {ReadonlyArray<string>} args
+ * @param {unknown} [input]
+ * @returns {Promise<string>}
+ */
+const ghApi = async (repoRoot, args, input) => {
+  const { code, stderr, stdout } = await runGhApi(repoRoot, args, input);
+  if (code === 0) {
+    return stdout.toString('utf8');
+  }
+
+  throw new Error(stderr.trim() || `gh api exited with code ${code}.`);
+};
 
 /**
  * @param {string} repoRoot
  * @param {ReadonlyArray<string>} args
  * @returns {Promise<Buffer | undefined>}
  */
-const ghApiBuffer = (repoRoot, args) =>
-  new Promise((resolve, reject) => {
-    const child = spawn('gh', ['api', ...args], {
-      cwd: repoRoot,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    /** @type {Array<Buffer>} */
-    const stdout = [];
-    /** @type {Array<Buffer>} */
-    const stderr = [];
+const ghApiBuffer = async (repoRoot, args) => {
+  const { code, stderr, stdout } = await runGhApi(repoRoot, args);
+  if (code === 0) {
+    return stdout;
+  }
 
-    child.stdout.on('data', (chunk) => stdout.push(chunk));
-    child.stderr.on('data', (chunk) => stderr.push(chunk));
-    child.on('error', reject);
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve(Buffer.concat(stdout));
-        return;
-      }
+  if (code === 1 && /not found|404/i.test(stderr)) {
+    return undefined;
+  }
 
-      const errorOutput = Buffer.concat(stderr).toString('utf8');
-      if (code === 1 && /not found|404/i.test(errorOutput)) {
-        resolve(undefined);
-        return;
-      }
-
-      reject(new Error(errorOutput.trim() || `gh api exited with code ${code}.`));
-    });
-  });
+  throw new Error(stderr.trim() || `gh api exited with code ${code}.`);
+};
 
 /** @param {string} repoRoot @param {PullRequestReference} pullRequest @returns {Promise<GitHubPullRequestMetadata>} */
 const readPullRequestMetadata = async (repoRoot, pullRequest) =>
@@ -1062,12 +1105,14 @@ const createPullRequestReviewPayload = (request) => {
 };
 
 module.exports = {
+  GH_NOT_FOUND_CODE,
   PENDING_REVIEW_COMMENT_ERROR,
   collectResolvedReviewCommentIds,
   createPatchFromPullRequestFile,
   createPullRequestHistoryFetchRefspecs,
   createPullRequestSection,
   createPullRequestSource,
+  getGhCommand,
   getPullRequestHeadImageSource,
   listPullRequestHistory,
   normalizeGitHubCommit,


### PR DESCRIPTION
Opening a PR in the packaged app fails with `Error invoking remote method 'codiff:getRepositoryState': Error: spawn gh ENOENT`.

Codiff takes a single instance lock, so whichever process starts the app first wins it and spawns `gh` for the rest of its lifetime. If that process came from the Dock, Spotlight or Finder, there's no shell in its ancestry and it gets the launchd default `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, which doesn't include `/opt/homebrew/bin`. A later `codiff <url>` from a terminal does carry the right `PATH`, but only into a short-lived second process that hands its arguments over `second-instance` and exits, so the primary keeps its original environment. `git` works throughout because `/usr/bin/git` happens to be on the default `PATH`.

Every other CLI Codiff shells out to already handles this. `glab`, `claude`, `codex`, `opencode`, `pi` and `cloudflared` all go through `findExecutableOnPath`, fall back to `~/.local/bin`, `/opt/homebrew/bin` and `/usr/local/bin`, take a `CODIFF_*_PATH` override, and throw a typed not-found error with install instructions. `gh` was the one that got missed, so GitLab works from the Dock and GitHub doesn't.

This PR:

- Adds `getGhCommand` to `electron/git-state/pull-request.cjs`, mirroring `getGlabCommand`, with a `CODIFF_GH_PATH` override and a `GH_NOT_FOUND` error that explains how to install `gh`
- Collapses `ghApi` and `ghApiBuffer` onto one `runGhApi` helper, so there's a single spawn site and the resolution can't be applied to one path and missed on the other. The two callers keep their own exit code handling, including `ghApiBuffer` treating a 404 as `undefined`
- Converts a spawn-time `ENOENT` into the same typed error, like `glabApi` does, since an executable with a missing interpreter passes the resolution check and then fails to spawn
- Adds tests for the override, the `~/.local/bin` fallback, the unspawnable binary, and one that submits a review with `gh` absent from `PATH` and asserts the payload still reaches it over stdin

Nothing caches the lookup, so if you hit the not-found message you can install `gh` and retry in the same window. The `CODIFF_GH_PATH` override is only for installs outside those three directories, and the message tells you to quit Codiff first in that case, because by then an instance is already running and only `launchOptions` and `repositoryPath` cross the lock handoff. The six existing `CODIFF_*_PATH` messages have the same gap and I left them alone here.

`bin/arguments.js` also calls `gh` but only runs in terminal-launched Node contexts where `PATH` is inherited, and it already catches the failure and reports something readable, so I left it alone too.

Created with Opus 5 xhigh, reviewed by Sol 5.6 xhigh, and addressed all feedback.
