### PR TITLE
fix(keymap): match Alt shortcuts on macOS through the active keyboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,14 @@ Shortcuts match on the character your layout produces. <kbd>Option</kbd> is the 
 replaces the character it would otherwise produce (<kbd>Option</kbd>+<kbd>z</kbd> types `Ω`), so
 `Alt` shortcuts fall back to the key your layout puts that character on. `Alt+z` follows the key
 that types <kbd>z</kbd> on QWERTZ, AZERTY, and Dvorak rather than the one US keyboards label
-<kbd>z</kbd>. On a layout that types no Latin at all, such as Cyrillic or Greek, letters and digits
-stay at their US positions so those shortcuts remain reachable. Shifted `Alt` shortcuts such as
-`Alt+Shift+?` also use US positions, because the layout only reports the character a key produces
-unmodified. This all applies only to a keypress that matches no shortcut by character, so it never
-overrides one that does.
+<kbd>z</kbd>. On a layout that types no Latin at all, such as Cyrillic or Greek, letters stay at
+their US positions so those shortcuts remain reachable.
+
+An `Alt` shortcut naming a character your layout reaches only through <kbd>Shift</kbd> does not
+fire, because layouts report their unmodified characters only. Name the character the key really
+types instead: on AZERTY, `Alt+&` rather than `Alt+1`. Shifted `Alt` shortcuts such as
+`Alt+Shift+?` use US key positions for the same reason. All of this applies only to a keypress that
+matches no shortcut by character, so it never overrides one that does.
 
 ## Walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -166,24 +166,7 @@ Set `settings.codeFontFamily` manually to an installed CSS font family name, for
 `"JetBrains Mono"` or `"SF Mono"`. Leave it empty to use Codiff's bundled mono stack.
 Use `Mod` for <kbd>Cmd</kbd> on macOS and <kbd>Ctrl</kbd> on other platforms. Shortcut strings can
 combine `Mod`, `Ctrl`, `Alt`, `Shift`, or `Meta` with a key, for example `Mod+Shift+p` or
-`Alt+Enter`. A shifted keystroke can be written either way: `Shift+?` names the character it
-types, `Shift+/` the key it sits on, and both mean the same shortcut. Reading a spelling as a key
-name relies on the keyboard layout the desktop app reads from the operating system; where no
-layout is available a spelling means the character as written, so `Shift+?` is the portable form.
-
-Shortcuts match on the character your layout produces. <kbd>Option</kbd> is the exception: macOS
-replaces the character it would otherwise produce (<kbd>Option</kbd>+<kbd>z</kbd> types `Ω`), so
-`Alt` shortcuts fall back to the key your layout puts that character on, in the combo's own Shift
-state: `Alt+z` follows the key that types <kbd>z</kbd> on QWERTZ, AZERTY, and Dvorak, and
-`Alt+Shift+?` the key whose Shift types <kbd>?</kbd>. Codiff reads the layout from the operating
-system and follows input source switches as they happen. On a layout that types no Latin at all,
-such as Cyrillic or Greek, letters stay at their US positions so those shortcuts remain reachable.
-
-An `Alt` shortcut naming a character your layout reaches only through <kbd>Shift</kbd> must spell
-the Shift out: on AZERTY, `Alt+1` does nothing and `Alt+Shift+1` fires on the keystroke that types
-`1`. Naming the key's unshifted character instead, `Alt+&`, binds the same key without Shift held.
-The fallback applies only to a keypress that matches no shortcut by character, so it never
-overrides one that does.
+`Alt+Enter`.
 
 ## Walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ Set `settings.codeFontFamily` manually to an installed CSS font family name, for
 Use `Mod` for <kbd>Cmd</kbd> on macOS and <kbd>Ctrl</kbd> on other platforms. Shortcut strings can
 combine `Mod`, `Ctrl`, `Alt`, `Shift`, or `Meta` with a key, for example `Mod+Shift+p` or
 `Alt+Enter`. A shifted keystroke can be written either way: `Shift+?` names the character it
-types, `Shift+/` the key it sits on, and both mean the same shortcut.
+types, `Shift+/` the key it sits on, and both mean the same shortcut. Reading a spelling as a key
+name relies on the keyboard layout the desktop app reads from the operating system; where no
+layout is available a spelling means the character as written, so `Shift+?` is the portable form.
 
 Shortcuts match on the character your layout produces. <kbd>Option</kbd> is the exception: macOS
 replaces the character it would otherwise produce (<kbd>Option</kbd>+<kbd>z</kbd> types `Ω`), so

--- a/README.md
+++ b/README.md
@@ -166,7 +166,14 @@ Set `settings.codeFontFamily` manually to an installed CSS font family name, for
 `"JetBrains Mono"` or `"SF Mono"`. Leave it empty to use Codiff's bundled mono stack.
 Use `Mod` for <kbd>Cmd</kbd> on macOS and <kbd>Ctrl</kbd> on other platforms. Shortcut strings can
 combine `Mod`, `Ctrl`, `Alt`, `Shift`, or `Meta` with a key, for example `Mod+Shift+p` or
-`Alt+Enter`.
+`Alt+Enter`. Name the character the key produces rather than the unshifted one, so a shortcut on
+<kbd>Shift</kbd>+<kbd>/</kbd> is written `Shift+?`.
+
+Shortcuts match on the character your layout produces. <kbd>Option</kbd> is the exception: macOS
+replaces the character it would otherwise produce (<kbd>Option</kbd>+<kbd>z</kbd> types `Ω`), so
+`Alt` shortcuts fall back to the US position of the key you named. On a layout that moves keys
+around, an `Alt` shortcut therefore follows the US position rather than the keycap. This applies
+only to a keypress that matches no shortcut by character, so it never overrides one that does.
 
 ## Walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -171,9 +171,13 @@ combine `Mod`, `Ctrl`, `Alt`, `Shift`, or `Meta` with a key, for example `Mod+Sh
 
 Shortcuts match on the character your layout produces. <kbd>Option</kbd> is the exception: macOS
 replaces the character it would otherwise produce (<kbd>Option</kbd>+<kbd>z</kbd> types `Ω`), so
-`Alt` shortcuts fall back to the US position of the key you named. On a layout that moves keys
-around, an `Alt` shortcut therefore follows the US position rather than the keycap. This applies
-only to a keypress that matches no shortcut by character, so it never overrides one that does.
+`Alt` shortcuts fall back to the key your layout puts that character on. `Alt+z` follows the key
+that types <kbd>z</kbd> on QWERTZ, AZERTY, and Dvorak rather than the one US keyboards label
+<kbd>z</kbd>. On a layout that types no Latin at all, such as Cyrillic or Greek, letters and digits
+stay at their US positions so those shortcuts remain reachable. Shifted `Alt` shortcuts such as
+`Alt+Shift+?` also use US positions, because the layout only reports the character a key produces
+unmodified. This all applies only to a keypress that matches no shortcut by character, so it never
+overrides one that does.
 
 ## Walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -166,21 +166,21 @@ Set `settings.codeFontFamily` manually to an installed CSS font family name, for
 `"JetBrains Mono"` or `"SF Mono"`. Leave it empty to use Codiff's bundled mono stack.
 Use `Mod` for <kbd>Cmd</kbd> on macOS and <kbd>Ctrl</kbd> on other platforms. Shortcut strings can
 combine `Mod`, `Ctrl`, `Alt`, `Shift`, or `Meta` with a key, for example `Mod+Shift+p` or
-`Alt+Enter`. Name the character the key produces rather than the unshifted one, so a shortcut on
-<kbd>Shift</kbd>+<kbd>/</kbd> is written `Shift+?`.
+`Alt+Enter`. A shifted keystroke can be written either way: `Shift+?` names the character it
+types, `Shift+/` the key it sits on, and both mean the same shortcut.
 
 Shortcuts match on the character your layout produces. <kbd>Option</kbd> is the exception: macOS
 replaces the character it would otherwise produce (<kbd>Option</kbd>+<kbd>z</kbd> types `Ω`), so
-`Alt` shortcuts fall back to the key your layout puts that character on. `Alt+z` follows the key
-that types <kbd>z</kbd> on QWERTZ, AZERTY, and Dvorak rather than the one US keyboards label
-<kbd>z</kbd>. On a layout that types no Latin at all, such as Cyrillic or Greek, letters stay at
-their US positions so those shortcuts remain reachable.
+`Alt` shortcuts fall back to the key your layout puts that character on, in the combo's own Shift
+state: `Alt+z` follows the key that types <kbd>z</kbd> on QWERTZ, AZERTY, and Dvorak, and
+`Alt+Shift+?` the key whose Shift types <kbd>?</kbd>. Codiff reads the layout from the operating
+system and follows input source switches as they happen. On a layout that types no Latin at all,
+such as Cyrillic or Greek, letters stay at their US positions so those shortcuts remain reachable.
 
-An `Alt` shortcut naming a character your layout reaches only through <kbd>Shift</kbd> does not
-fire, because layouts report their unmodified characters only. Name the character the key really
-types instead: on AZERTY, `Alt+&` rather than `Alt+1`. Shifted `Alt` shortcuts such as
-`Alt+Shift+?` use US key positions for the same reason. All of this applies only to a keypress that
-matches no shortcut by character, so it never overrides one that does.
+An `Alt` shortcut naming a character your layout reaches only through <kbd>Shift</kbd> must spell
+the Shift out: on AZERTY, `Alt+Shift+1` or equivalently `Alt+&`, rather than `Alt+1`. The fallback
+applies only to a keypress that matches no shortcut by character, so it never overrides one that
+does.
 
 ## Walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -178,9 +178,10 @@ system and follows input source switches as they happen. On a layout that types 
 such as Cyrillic or Greek, letters stay at their US positions so those shortcuts remain reachable.
 
 An `Alt` shortcut naming a character your layout reaches only through <kbd>Shift</kbd> must spell
-the Shift out: on AZERTY, `Alt+Shift+1` or equivalently `Alt+&`, rather than `Alt+1`. The fallback
-applies only to a keypress that matches no shortcut by character, so it never overrides one that
-does.
+the Shift out: on AZERTY, `Alt+1` does nothing and `Alt+Shift+1` fires on the keystroke that types
+`1`. Naming the key's unshifted character instead, `Alt+&`, binds the same key without Shift held.
+The fallback applies only to a keypress that matches no shortcut by character, so it never
+overrides one that does.
 
 ## Walkthroughs
 

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -166,6 +166,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
     email: 'reviewer@example.com',
     name: 'Reviewer',
   })),
+  getKeyboardLayout: vi.fn(async () => null),
   getLaunchOptions: vi.fn(async () => ({
     repositoryPathProvided: true,
     walkthrough: false,
@@ -226,6 +227,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
   onConfigChanged: vi.fn(() => () => {}),
   onCopyPendingCommentsRequest: vi.fn(() => () => {}),
   onFindInDiffs: vi.fn(() => () => {}),
+  onKeyboardLayoutChanged: vi.fn(() => () => {}),
   onMarkdownDocumentChanged: vi.fn(() => () => {}),
   onOpenReviewSource: vi.fn(() => () => {}),
   onPlanCloseRequested: vi.fn(() => () => {}),

--- a/core/__tests__/keyboard-layout.test.ts
+++ b/core/__tests__/keyboard-layout.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, expect, test, vi } from 'vite-plus/test';
+import {
+  codeForCharacter,
+  hasKeyboardLayout,
+  loadKeyboardLayout,
+  resetKeyboardLayout,
+  trackKeyboardLayout,
+} from '../config/keyboard-layout.ts';
+
+afterEach(() => {
+  resetKeyboardLayout();
+  vi.restoreAllMocks();
+});
+
+test('resolves a character to the key position that produces it', async () => {
+  // Arrange: QWERTZ swaps the characters on the US "z" and "y" positions.
+  createTestContext({ KeyY: 'z', KeyZ: 'y' });
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(codeForCharacter('z')).toBe('KeyY');
+});
+
+test('reports no layout before one has been read', () => {
+  // Arrange
+  createTestContext({ KeyZ: 'z' });
+
+  // Act
+  const layout = { code: codeForCharacter('z'), loaded: hasKeyboardLayout() };
+
+  // Assert
+  expect(layout).toEqual({ code: null, loaded: false });
+});
+
+test('reports no layout when the platform exposes no keyboard map', async () => {
+  // Arrange
+  Object.defineProperty(navigator, 'keyboard', { configurable: true, value: undefined });
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+test('reports no layout when the keyboard map comes back empty', async () => {
+  // Arrange: a window with no keyboard attached to it reports zero keys, which
+  // is an absent answer rather than a keyboard that produces nothing.
+  createTestContext({});
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+test('reports no layout when reading the keyboard map fails', async () => {
+  // Arrange
+  Object.defineProperty(navigator, 'keyboard', {
+    configurable: true,
+    value: {
+      getLayoutMap: () => Promise.reject(new Error('not allowed in this context')),
+    },
+  });
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+test('pins a letter the layout never produces to its US position', async () => {
+  // Arrange: a Cyrillic layout produces no Latin letters at all, so every
+  // letter shortcut would otherwise be unreachable.
+  createTestContext({ KeyA: 'ф', KeyZ: 'я' });
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(codeForCharacter('z')).toBe('KeyZ');
+});
+
+test('drops the character a pinned letter displaces', async () => {
+  // Arrange
+  createTestContext({ KeyA: 'ф', KeyZ: 'я' });
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert: one position produces one character, so pinning "z" to the US "z"
+  // key takes "я" off it rather than leaving both spellings claiming it.
+  expect(codeForCharacter('я')).toBe(null);
+});
+
+test('keeps a letter the layout produces somewhere else instead of pinning it', async () => {
+  // Arrange: AZERTY moves "a" to the US "q" position, so "a" is still typed.
+  createTestContext({ KeyA: 'q', KeyQ: 'a' });
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(codeForCharacter('a')).toBe('KeyQ');
+});
+
+test('pins a digit the layout only reaches through Shift', async () => {
+  // Arrange: AZERTY types "&" on the key labelled "1"; the digit needs Shift,
+  // which the keyboard map does not report.
+  createTestContext({ Digit1: '&', KeyA: 'q', KeyQ: 'a' });
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(codeForCharacter('1')).toBe('Digit1');
+});
+
+test('resolves to the first position when two keys produce one character', async () => {
+  // Arrange
+  createTestContext({ Backslash: '#', BracketRight: '#' });
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(codeForCharacter('#')).toBe('Backslash');
+});
+
+test('re-reads the layout when a keypress disagrees with it', async () => {
+  // Arrange: no layout change event exists, so a plain keypress reporting a
+  // character the cache does not have on that key is the signal.
+  const { setLayout } = createTestContext({ KeyZ: 'z' });
+  trackKeyboardLayout();
+  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
+  setLayout({ KeyY: 'z', KeyZ: 'y' });
+
+  // Act
+  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'y' }));
+
+  // Assert
+  await vi.waitFor(() => expect(codeForCharacter('z')).toBe('KeyY'));
+});
+
+test('does not re-read the layout for a keypress a modifier rewrote', async () => {
+  // Arrange
+  const { getReadCount, setLayout } = createTestContext({ KeyZ: 'z' });
+  trackKeyboardLayout();
+  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
+  setLayout({ KeyY: 'z', KeyZ: 'y' });
+
+  // Act: Option composes the character away, so it says nothing about the key.
+  window.dispatchEvent(new KeyboardEvent('keydown', { altKey: true, code: 'KeyZ', key: 'Ω' }));
+
+  // Assert
+  expect(getReadCount()).toBe(1);
+});
+
+test('re-reads the layout when the window regains focus', async () => {
+  // Arrange
+  const { setLayout } = createTestContext({ KeyZ: 'z' });
+  trackKeyboardLayout();
+  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
+  setLayout({ KeyY: 'z', KeyZ: 'y' });
+
+  // Act
+  window.dispatchEvent(new Event('focus'));
+
+  // Assert
+  await vi.waitFor(() => expect(codeForCharacter('z')).toBe('KeyY'));
+});
+
+test('stops watching for layout changes once it is reset', async () => {
+  // Arrange
+  const { getReadCount } = createTestContext({ KeyZ: 'z' });
+  trackKeyboardLayout();
+  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
+  resetKeyboardLayout();
+
+  // Act
+  window.dispatchEvent(new Event('focus'));
+
+  // Assert
+  expect(getReadCount()).toBe(1);
+});
+
+function createTestContext(initial: Record<string, string>) {
+  let layout = initial;
+  let readCount = 0;
+
+  Object.defineProperty(navigator, 'keyboard', {
+    configurable: true,
+    value: {
+      getLayoutMap: () => {
+        readCount++;
+        return Promise.resolve(new Map(Object.entries(layout)));
+      },
+    },
+  });
+
+  return {
+    getReadCount: () => readCount,
+    setLayout: (next: Record<string, string>) => {
+      layout = next;
+    },
+  };
+}

--- a/core/__tests__/keyboard-layout.test.ts
+++ b/core/__tests__/keyboard-layout.test.ts
@@ -192,6 +192,41 @@ test('stops watching for layout changes once it is reset', async () => {
   expect(getReadCount()).toBe(1);
 });
 
+test('discards a layout read that was still in flight when it was reset', async () => {
+  // Arrange: reads are asynchronous, so one can land after whoever started it
+  // has already given up on it.
+  const { reportLayout } = createSlowTestContext();
+  const pending = loadKeyboardLayout();
+  resetKeyboardLayout();
+
+  // Act
+  reportLayout({ KeyZ: 'z' });
+  await pending;
+
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+// A keyboard whose layout arrives only when the test says so.
+function createSlowTestContext() {
+  let resolveLayout!: (layout: Map<string, string>) => void;
+
+  Object.defineProperty(navigator, 'keyboard', {
+    configurable: true,
+    value: {
+      getLayoutMap: () =>
+        new Promise<Map<string, string>>((resolve) => {
+          resolveLayout = resolve;
+        }),
+    },
+  });
+
+  return {
+    reportLayout: (layout: Record<string, string>) =>
+      resolveLayout(new Map(Object.entries(layout))),
+  };
+}
+
 function createTestContext(initial: Record<string, string>) {
   let layout = initial;
   let readCount = 0;

--- a/core/__tests__/keyboard-layout.test.ts
+++ b/core/__tests__/keyboard-layout.test.ts
@@ -77,7 +77,7 @@ test('reports no layout when reading the keyboard map fails', async () => {
   expect(hasKeyboardLayout()).toBe(false);
 });
 
-test('pins a letter the layout never produces to its US position', async () => {
+test('pins letters to their US positions on a layout that types no Latin', async () => {
   // Arrange: a Cyrillic layout produces no Latin letters at all, so every
   // letter shortcut would otherwise be unreachable.
   createTestContext({ KeyA: 'ф', KeyZ: 'я' });
@@ -112,16 +112,37 @@ test('keeps a letter the layout produces somewhere else instead of pinning it', 
   expect(codeForCharacter('a')).toBe('KeyQ');
 });
 
-test('pins a digit the layout only reaches through Shift', async () => {
-  // Arrange: AZERTY types "&" on the key labelled "1"; the digit needs Shift,
-  // which the keyboard map does not report.
+test('leaves a digit the layout cannot type unmodified unresolved', async () => {
+  // Arrange: AZERTY types "&" on the key labelled "1" and reaches the digit
+  // only with Shift, which the keyboard map does not report. Putting "1" on
+  // that key anyway would be right on AZERTY and wrong on Programmer Dvorak,
+  // which moves the digits elsewhere, and it would take "&" off the key it
+  // really is on. Naming the character the key types works on both.
   createTestContext({ Digit1: '&', KeyA: 'q', KeyQ: 'a' });
 
   // Act
   await loadKeyboardLayout();
 
   // Assert
-  expect(codeForCharacter('1')).toBe('Digit1');
+  expect({ ampersand: codeForCharacter('&'), one: codeForCharacter('1') }).toEqual({
+    ampersand: 'Digit1',
+    one: null,
+  });
+});
+
+test('does not pin letters to US positions on a layout that types some Latin', async () => {
+  // Arrange: putting "a" on the US "a" key would take that key away from "b",
+  // which this layout really does type there.
+  createTestContext({ KeyA: 'b', KeyZ: 'ż' });
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect({ a: codeForCharacter('a'), b: codeForCharacter('b') }).toEqual({
+    a: null,
+    b: 'KeyA',
+  });
 });
 
 test('resolves to the first position when two keys produce one character', async () => {
@@ -162,6 +183,52 @@ test('does not re-read the layout for a keypress a modifier rewrote', async () =
 
   // Assert
   expect(getReadCount()).toBe(1);
+});
+
+test('keeps the layout it has when a re-read comes back empty', async () => {
+  // Arrange: losing a good layout to one bad answer would send every shortcut
+  // back to guessing at US positions, and nothing would ask again.
+  const { setLayout } = createTestContext({ KeyY: 'z', KeyZ: 'y' });
+  await loadKeyboardLayout();
+  setLayout({});
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(codeForCharacter('z')).toBe('KeyY');
+});
+
+test('keeps the layout it has when a re-read fails', async () => {
+  // Arrange
+  const { failReads } = createTestContext({ KeyY: 'z', KeyZ: 'y' });
+  await loadKeyboardLayout();
+  failReads();
+
+  // Act
+  await loadKeyboardLayout();
+
+  // Assert
+  expect(codeForCharacter('z')).toBe('KeyY');
+});
+
+test('does not re-read the layout once per keypress when it keeps disagreeing', async () => {
+  // Arrange: remapping software can make the reported character disagree with
+  // the layout permanently, and asking again on every keypress would never
+  // resolve it.
+  const { getReadCount } = createTestContext({ KeyZ: 'z' });
+  trackKeyboardLayout();
+  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
+
+  // Act: each press waits for the previous read to settle, so nothing is
+  // coalesced and every one of them is free to ask again.
+  for (let press = 0; press < 5; press++) {
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'q' }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  // Assert: the startup read, plus one for the first press.
+  expect(getReadCount()).toBe(2);
 });
 
 test('re-reads the layout when the window regains focus', async () => {
@@ -229,6 +296,7 @@ function createSlowTestContext() {
 
 function createTestContext(initial: Record<string, string>) {
   let layout = initial;
+  let failing = false;
   let readCount = 0;
 
   Object.defineProperty(navigator, 'keyboard', {
@@ -236,12 +304,17 @@ function createTestContext(initial: Record<string, string>) {
     value: {
       getLayoutMap: () => {
         readCount++;
-        return Promise.resolve(new Map(Object.entries(layout)));
+        return failing
+          ? Promise.reject(new Error('not allowed in this context'))
+          : Promise.resolve(new Map(Object.entries(layout)));
       },
     },
   });
 
   return {
+    failReads: () => {
+      failing = true;
+    },
     getReadCount: () => readCount,
     setLayout: (next: Record<string, string>) => {
       layout = next;

--- a/core/__tests__/keyboard-layout.test.ts
+++ b/core/__tests__/keyboard-layout.test.ts
@@ -4,396 +4,389 @@
 
 import { afterEach, expect, test, vi } from 'vite-plus/test';
 import {
+  applyKeyboardLayout,
   codeForCharacter,
   hasKeyboardLayout,
-  loadKeyboardLayout,
   resetKeyboardLayout,
+  shiftedCharacterForCode,
   trackKeyboardLayout,
 } from '../config/keyboard-layout.ts';
+import type { NativeKeyboardLayout } from '../config/keyboard-layout.ts';
 
 afterEach(() => {
   resetKeyboardLayout();
-  vi.restoreAllMocks();
-  vi.useRealTimers();
+  delete (window as { codiff?: unknown }).codiff;
 });
 
-test('resolves a character to the key position that produces it', async () => {
+test('resolves a character to the key position that produces it', () => {
   // Arrange: QWERTZ swaps the characters on the US "z" and "y" positions.
-  createTestContext({ KeyY: 'z', KeyZ: 'y' });
+  const layout = { KeyY: key('z', 'Z'), KeyZ: key('y', 'Y') };
 
   // Act
-  await loadKeyboardLayout();
+  applyKeyboardLayout(layout);
 
   // Assert
-  expect(codeForCharacter('z')).toBe('KeyY');
+  expect(codeForCharacter('z', false)).toBe('KeyY');
 });
 
-test('reports no layout before one has been read', () => {
+test('resolves a shifted character through the key that types it with Shift', () => {
+  // Arrange: on German layouts "?" is typed with Shift on the "ß" key, which
+  // sits at the US "-" position.
+  const layout = { KeyQ: key('q', 'Q'), Minus: key('ß', '?') };
+
+  // Act
+  applyKeyboardLayout(layout);
+
+  // Assert
+  expect({
+    plain: codeForCharacter('?', false),
+    shifted: codeForCharacter('?', true),
+  }).toEqual({ plain: null, shifted: 'Minus' });
+});
+
+test('matches a shifted letter by its lowercase spelling', () => {
+  // Arrange: combos spell letters in lowercase, but Shift types them in
+  // uppercase.
+  const layout = { KeyZ: key('z', 'Z') };
+
+  // Act
+  applyKeyboardLayout(layout);
+
+  // Assert
+  expect(codeForCharacter('z', true)).toBe('KeyZ');
+});
+
+test('names the character a key produces with Shift held', () => {
   // Arrange
-  createTestContext({ KeyZ: 'z' });
+  const layout = { KeyZ: key('z', 'Z'), Slash: key('/', '?') };
 
   // Act
-  const layout = { code: codeForCharacter('z'), loaded: hasKeyboardLayout() };
+  applyKeyboardLayout(layout);
 
   // Assert
-  expect(layout).toEqual({ code: null, loaded: false });
+  expect({
+    letter: shiftedCharacterForCode('KeyZ'),
+    slash: shiftedCharacterForCode('Slash'),
+    unknown: shiftedCharacterForCode('Digit1'),
+  }).toEqual({ letter: 'z', slash: '?', unknown: null });
 });
 
-test('reports no layout when the platform exposes no keyboard map', async () => {
-  // Arrange
-  Object.defineProperty(navigator, 'keyboard', { configurable: true, value: undefined });
-
-  // Act
-  await loadKeyboardLayout();
-
+test('reports no layout before one has been applied', () => {
   // Assert
-  expect(hasKeyboardLayout()).toBe(false);
+  expect({
+    code: codeForCharacter('z', false),
+    loaded: hasKeyboardLayout(),
+    shifted: shiftedCharacterForCode('KeyZ'),
+  }).toEqual({ code: null, loaded: false, shifted: null });
 });
 
-test('reports no layout when the keyboard map comes back empty', async () => {
-  // Arrange: a window with no keyboard attached to it reports zero keys, which
-  // is an absent answer rather than a keyboard that produces nothing.
-  createTestContext({});
-
-  // Act
-  await loadKeyboardLayout();
-
-  // Assert
-  expect(hasKeyboardLayout()).toBe(false);
-});
-
-test('reports no layout when reading the keyboard map fails', async () => {
-  // Arrange
-  Object.defineProperty(navigator, 'keyboard', {
-    configurable: true,
-    value: {
-      getLayoutMap: () => Promise.reject(new Error('not allowed in this context')),
+test('skips a position whose character is a dead key', () => {
+  // Arrange: a dead key arms a composition instead of typing its character, so
+  // no keypress ever reports it.
+  const layout = {
+    Backquote: {
+      value: '`',
+      valueIsDeadKey: true,
+      withShift: '~',
+      withShiftIsDeadKey: false,
     },
-  });
+    KeyQ: key('q', 'Q'),
+  };
 
   // Act
-  await loadKeyboardLayout();
+  applyKeyboardLayout(layout);
 
   // Assert
-  expect(hasKeyboardLayout()).toBe(false);
+  expect({
+    backquote: codeForCharacter('`', false),
+    tilde: codeForCharacter('~', true),
+  }).toEqual({ backquote: null, tilde: 'Backquote' });
 });
 
-test('pins letters to their US positions on a layout that types no Latin', async () => {
+test('ignores keys outside the writing system', () => {
+  // Arrange: the numpad types "1" too, but `Alt+1` means the digit on the
+  // number row, and Space is no way to spell a combo.
+  const layout = {
+    Digit1: key('1', '!'),
+    KeyQ: key('q', 'Q'),
+    Numpad1: key('1', '1'),
+    Space: key(' ', ' '),
+  };
+
+  // Act
+  applyKeyboardLayout(layout);
+
+  // Assert
+  expect(codeForCharacter('1', false)).toBe('Digit1');
+
+  // Act: with only the numpad producing the digit, it stays unresolved.
+  applyKeyboardLayout({ KeyQ: key('q', 'Q'), Numpad1: key('1', '1') });
+
+  // Assert
+  expect(codeForCharacter('1', false)).toBe(null);
+});
+
+test('resolves to the first position in a fixed order when two keys produce one character', () => {
+  // Arrange: the claim order is letters, digits, then punctuation in row
+  // order, so the answer does not depend on how the platform happens to order
+  // the map. BracketRight comes before Backslash in that order even though the
+  // fixture lists it second.
+  const layout = { Backslash: key('#', "'"), BracketRight: key('#', '"'), KeyQ: key('q', 'Q') };
+
+  // Act
+  applyKeyboardLayout(layout);
+
+  // Assert
+  expect(codeForCharacter('#', false)).toBe('BracketRight');
+});
+
+test('pins letters to their US positions on a layout that types no Latin', () => {
   // Arrange: a Cyrillic layout produces no Latin letters at all, so every
   // letter shortcut would otherwise be unreachable.
-  createTestContext({ KeyA: 'ф', KeyZ: 'я' });
+  const layout = { KeyA: key('ф', 'Ф'), KeyZ: key('я', 'Я') };
 
   // Act
-  await loadKeyboardLayout();
+  applyKeyboardLayout(layout);
 
-  // Assert
-  expect(codeForCharacter('z')).toBe('KeyZ');
+  // Assert: the pin covers both Shift states, so `Alt+Shift+z` keeps working
+  // too.
+  expect({
+    plain: codeForCharacter('z', false),
+    shifted: codeForCharacter('z', true),
+  }).toEqual({ plain: 'KeyZ', shifted: 'KeyZ' });
 });
 
-test('drops the character a pinned letter displaces', async () => {
+test('drops the character a pinned letter displaces', () => {
   // Arrange
-  createTestContext({ KeyA: 'ф', KeyZ: 'я' });
+  const layout = { KeyA: key('ф', 'Ф'), KeyZ: key('я', 'Я') };
 
   // Act
-  await loadKeyboardLayout();
+  applyKeyboardLayout(layout);
 
   // Assert: one position produces one character, so pinning "z" to the US "z"
   // key takes "я" off it rather than leaving both spellings claiming it.
-  expect(codeForCharacter('я')).toBe(null);
+  expect({
+    plain: codeForCharacter('я', false),
+    shifted: codeForCharacter('я', true),
+  }).toEqual({ plain: null, shifted: null });
 });
 
-test('keeps a letter the layout produces somewhere else instead of pinning it', async () => {
-  // Arrange: AZERTY moves "a" to the US "q" position, so "a" is still typed.
-  createTestContext({ KeyA: 'q', KeyQ: 'a' });
-
-  // Act
-  await loadKeyboardLayout();
-
-  // Assert
-  expect(codeForCharacter('a')).toBe('KeyQ');
-});
-
-test('leaves a digit the layout cannot type unmodified unresolved', async () => {
-  // Arrange: AZERTY types "&" on the key labelled "1" and reaches the digit
-  // only with Shift, which the keyboard map does not report. Putting "1" on
-  // that key anyway would be right on AZERTY and wrong on Programmer Dvorak,
-  // which moves the digits elsewhere, and it would take "&" off the key it
-  // really is on. Naming the character the key types works on both.
-  createTestContext({ Digit1: '&', KeyA: 'q', KeyQ: 'a' });
-
-  // Act
-  await loadKeyboardLayout();
-
-  // Assert
-  expect({ ampersand: codeForCharacter('&'), one: codeForCharacter('1') }).toEqual({
-    ampersand: 'Digit1',
-    one: null,
-  });
-});
-
-test('does not pin letters to US positions on a layout that types some Latin', async () => {
+test('does not pin letters to US positions on a layout that types some Latin', () => {
   // Arrange: putting "a" on the US "a" key would take that key away from "b",
   // which this layout really does type there.
-  createTestContext({ KeyA: 'b', KeyZ: 'ż' });
+  const layout = { KeyA: key('b', 'B'), KeyZ: key('ż', 'Ż') };
 
   // Act
-  await loadKeyboardLayout();
+  applyKeyboardLayout(layout);
 
   // Assert
-  expect({ a: codeForCharacter('a'), b: codeForCharacter('b') }).toEqual({
-    a: null,
-    b: 'KeyA',
-  });
+  expect({
+    a: codeForCharacter('a', false),
+    b: codeForCharacter('b', false),
+  }).toEqual({ a: null, b: 'KeyA' });
 });
 
-test('resolves to the first position when two keys produce one character', async () => {
+test('counts Latin reached only through Shift when deciding whether to pin', () => {
+  // Arrange: a layout that types "b" with Shift somewhere types Latin, so
+  // pinning would displace it.
+  const layout = { KeyA: key('ф', 'B') };
+
+  // Act
+  applyKeyboardLayout(layout);
+
+  // Assert
+  expect({
+    b: codeForCharacter('b', true),
+    z: codeForCharacter('z', false),
+  }).toEqual({ b: 'KeyA', z: null });
+});
+
+test('resolves a digit the layout types only with Shift through its shifted spelling', () => {
+  // Arrange: AZERTY types "&" on the key labelled "1" and reaches the digit
+  // only with Shift. Putting "1" on that key unshifted would fire `Alt+1` on a
+  // press that types "&".
+  const layout = { Digit1: key('&', '1'), KeyQ: key('a', 'A') };
+
+  // Act
+  applyKeyboardLayout(layout);
+
+  // Assert
+  expect({
+    ampersand: codeForCharacter('&', false),
+    one: codeForCharacter('1', false),
+    shiftedOne: codeForCharacter('1', true),
+  }).toEqual({ ampersand: 'Digit1', one: null, shiftedOne: 'Digit1' });
+});
+
+test('reads the layout from the desktop shell when tracking starts', async () => {
   // Arrange
-  createTestContext({ Backslash: '#', BracketRight: '#' });
+  createTestContext({ initialLayout: { KeyY: key('z', 'Z'), KeyZ: key('y', 'Y') } });
 
   // Act
-  await loadKeyboardLayout();
+  trackKeyboardLayout();
 
   // Assert
-  expect(codeForCharacter('#')).toBe('Backslash');
-});
-
-test('re-reads the layout when a keypress disagrees with it', async () => {
-  // Arrange: no layout change event exists, so a plain keypress reporting a
-  // character the cache does not have on that key is the signal.
-  const { setLayout } = createTestContext({ KeyZ: 'z' });
-  trackKeyboardLayout();
   await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
-  setLayout({ KeyY: 'z', KeyZ: 'y' });
-
-  // Act
-  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'y' }));
-
-  // Assert
-  await vi.waitFor(() => expect(codeForCharacter('z')).toBe('KeyY'));
+  expect(codeForCharacter('z', false)).toBe('KeyY');
 });
 
-test('does not re-read the layout for a keypress a modifier rewrote', async () => {
-  // Arrange
-  const { getReadCount, setLayout } = createTestContext({ KeyZ: 'z' });
+test('stays without a layout when no desktop shell is present', () => {
+  // Arrange: the web build and the test environment have no `window.codiff`,
+  // and the matcher stays on its US tables there.
+
+  // Act
   trackKeyboardLayout();
-  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
-  setLayout({ KeyY: 'z', KeyZ: 'y' });
-
-  // Act: Option composes the character away, so it says nothing about the key.
-  window.dispatchEvent(new KeyboardEvent('keydown', { altKey: true, code: 'KeyZ', key: 'Ω' }));
-
-  // Assert
-  expect(getReadCount()).toBe(1);
-});
-
-test('keeps the layout it has when a re-read comes back empty', async () => {
-  // Arrange: losing a good layout to one bad answer would send every shortcut
-  // back to guessing at US positions, and nothing would ask again.
-  const { setLayout } = createTestContext({ KeyY: 'z', KeyZ: 'y' });
-  await loadKeyboardLayout();
-  setLayout({});
-
-  // Act
-  await loadKeyboardLayout();
-
-  // Assert
-  expect(codeForCharacter('z')).toBe('KeyY');
-});
-
-test('keeps the layout it has when a re-read fails', async () => {
-  // Arrange
-  const { failReads } = createTestContext({ KeyY: 'z', KeyZ: 'y' });
-  await loadKeyboardLayout();
-  failReads();
-
-  // Act
-  await loadKeyboardLayout();
-
-  // Assert
-  expect(codeForCharacter('z')).toBe('KeyY');
-});
-
-test('does not re-read the layout once per keypress when it keeps disagreeing', async () => {
-  // Arrange: remapping software can make the reported character disagree with
-  // the layout permanently, and asking again on every keypress would never
-  // resolve it.
-  const { getReadCount } = createTestContext({ KeyZ: 'z' });
-  trackKeyboardLayout();
-  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
-
-  // Act: each press waits for the previous read to settle, so nothing is
-  // coalesced and every one of them is free to ask again.
-  for (let press = 0; press < 5; press++) {
-    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'q' }));
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-
-  // Assert: the startup read, plus one for the first press.
-  expect(getReadCount()).toBe(2);
-});
-
-test('asks again on the next keypress when it has no layout at all', async () => {
-  // Arrange: a window with no keyboard attached to it yet reports nothing, and
-  // waiting for it to lose and regain focus is a long way back from that.
-  const { setLayout } = createTestContext({});
-  trackKeyboardLayout();
-  await loadKeyboardLayout();
-  setLayout({ KeyY: 'z', KeyZ: 'y' });
-
-  // Act
-  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'y' }));
-
-  // Assert
-  await vi.waitFor(() => expect(codeForCharacter('z')).toBe('KeyY'));
-});
-
-test('asks again once the quiet period after a disagreement has passed', async () => {
-  // Arrange: the quiet period stops a permanent disagreement asking on every
-  // keystroke, and must not stop a later real change from being noticed.
-  vi.useFakeTimers({ toFake: ['performance'] });
-  const { getReadCount, setLayout } = createTestContext({ KeyZ: 'z' });
-  trackKeyboardLayout();
-  await loadKeyboardLayout();
-  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'q' }));
-  await loadKeyboardLayout();
-  setLayout({ KeyY: 'z', KeyZ: 'y' });
-
-  // Act
-  vi.advanceTimersByTime(2000);
-  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'y' }));
-  await new Promise((resolve) => setTimeout(resolve, 0));
-
-  // Assert
-  expect({ code: codeForCharacter('z'), reads: getReadCount() }).toEqual({
-    code: 'KeyY',
-    reads: 3,
-  });
-});
-
-test('does not start a second read while one is already in flight', async () => {
-  // Arrange: a read abandoned by a reset must not hand the in-flight slot back
-  // while the read that replaced it is still running.
-  const { getReadCount, reportLayout } = createSlowTestContext();
-  const abandoned = loadKeyboardLayout();
-  resetKeyboardLayout();
-  loadKeyboardLayout();
-
-  // Act
-  reportLayout({ KeyZ: 'z' });
-  await abandoned;
-  loadKeyboardLayout();
-
-  // Assert
-  expect(getReadCount()).toBe(2);
-});
-
-test('does not re-read the layout for a key the layout never mentions', async () => {
-  // Arrange: the keyboard map covers the letter, digit and punctuation keys
-  // only, so the space bar reporting a space is not a disagreement.
-  const { getReadCount } = createTestContext({ KeyZ: 'z' });
-  trackKeyboardLayout();
-  await loadKeyboardLayout();
-
-  // Act
-  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ' }));
-  await new Promise((resolve) => setTimeout(resolve, 0));
-
-  // Assert
-  expect(getReadCount()).toBe(1);
-});
-
-test('re-reads the layout when the window regains focus', async () => {
-  // Arrange
-  const { setLayout } = createTestContext({ KeyZ: 'z' });
-  trackKeyboardLayout();
-  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
-  setLayout({ KeyY: 'z', KeyZ: 'y' });
-
-  // Act
-  window.dispatchEvent(new Event('focus'));
-
-  // Assert
-  await vi.waitFor(() => expect(codeForCharacter('z')).toBe('KeyY'));
-});
-
-test('stops watching for layout changes once it is reset', async () => {
-  // Arrange
-  const { getReadCount } = createTestContext({ KeyZ: 'z' });
-  trackKeyboardLayout();
-  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
-  resetKeyboardLayout();
-
-  // Act
-  window.dispatchEvent(new Event('focus'));
-
-  // Assert
-  expect(getReadCount()).toBe(1);
-});
-
-test('discards a layout read that was still in flight when it was reset', async () => {
-  // Arrange: reads are asynchronous, so one can land after whoever started it
-  // has already given up on it.
-  const { reportLayout } = createSlowTestContext();
-  const pending = loadKeyboardLayout();
-  resetKeyboardLayout();
-
-  // Act
-  reportLayout({ KeyZ: 'z' });
-  await pending;
 
   // Assert
   expect(hasKeyboardLayout()).toBe(false);
 });
 
-// A keyboard whose layout arrives only when the test says so, one read at a
-// time and in the order they were started.
-function createSlowTestContext() {
-  const waiting: Array<(layout: Map<string, string>) => void> = [];
-  let readCount = 0;
+test('keeps no layout when the shell cannot read one', async () => {
+  // Arrange
+  createTestContext({ failReads: true });
 
-  Object.defineProperty(navigator, 'keyboard', {
-    configurable: true,
-    value: {
-      getLayoutMap: () => {
-        readCount++;
-        return new Promise<Map<string, string>>((resolve) => {
-          waiting.push(resolve);
-        });
-      },
-    },
-  });
+  // Act
+  trackKeyboardLayout();
+  await flush();
 
-  return {
-    getReadCount: () => readCount,
-    reportLayout: (layout: Record<string, string>) =>
-      waiting.shift()?.(new Map(Object.entries(layout))),
-  };
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+test('keeps no layout when the shell reports none', async () => {
+  // Arrange: a platform where native-keymap fails answers with null rather
+  // than a broken map.
+  createTestContext({ initialLayout: null });
+
+  // Act
+  trackKeyboardLayout();
+  await flush();
+
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+test('applies a layout change pushed by the shell', async () => {
+  // Arrange: switching input source fires a real event in the main process,
+  // which pushes the fresh layout here.
+  const { pushLayout } = createTestContext({ initialLayout: { KeyZ: key('z', 'Z') } });
+  trackKeyboardLayout();
+  await vi.waitFor(() => expect(hasKeyboardLayout()).toBe(true));
+
+  // Act
+  pushLayout({ KeyY: key('z', 'Z'), KeyZ: key('y', 'Y') });
+
+  // Assert
+  expect(codeForCharacter('z', false)).toBe('KeyY');
+});
+
+test('prefers a pushed layout over a slower startup read', async () => {
+  // Arrange: a push that arrives while the startup read is on the wire is
+  // newer than whatever that read answers with.
+  const { pushLayout, resolveRead } = createTestContext({ deferReads: true });
+  trackKeyboardLayout();
+
+  // Act
+  pushLayout({ KeyY: key('z', 'Z') });
+  resolveRead({ KeyZ: key('z', 'Z') });
+  await flush();
+
+  // Assert
+  expect(codeForCharacter('z', false)).toBe('KeyY');
+});
+
+test('discards a startup read that was still in flight when it was reset', async () => {
+  // Arrange
+  const { resolveRead } = createTestContext({ deferReads: true });
+  trackKeyboardLayout();
+  resetKeyboardLayout();
+
+  // Act
+  resolveRead({ KeyZ: key('z', 'Z') });
+  await flush();
+
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+test('stops applying layout pushes once it is reset', () => {
+  // Arrange
+  const { pushLayout } = createTestContext({ initialLayout: null });
+  trackKeyboardLayout();
+  resetKeyboardLayout();
+
+  // Act
+  pushLayout({ KeyZ: key('z', 'Z') });
+
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+test('subscribes to layout pushes once no matter how often tracking starts', () => {
+  // Arrange
+  const { getSubscriptionCount } = createTestContext({ initialLayout: null });
+
+  // Act
+  trackKeyboardLayout();
+  trackKeyboardLayout();
+
+  // Assert
+  expect(getSubscriptionCount()).toBe(1);
+});
+
+function key(value: string, withShift: string) {
+  return { value, valueIsDeadKey: false, withShift, withShiftIsDeadKey: false };
 }
 
-function createTestContext(initial: Record<string, string>) {
-  let layout = initial;
-  let failing = false;
-  let readCount = 0;
-
-  Object.defineProperty(navigator, 'keyboard', {
-    configurable: true,
-    value: {
-      getLayoutMap: () => {
-        readCount++;
-        return failing
-          ? Promise.reject(new Error('not allowed in this context'))
-          : Promise.resolve(new Map(Object.entries(layout)));
-      },
-    },
+function flush() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
   });
+}
+
+// A desktop shell whose layout answers arrive only when the test says so.
+function createTestContext({
+  deferReads = false,
+  failReads = false,
+  initialLayout = null,
+}: {
+  deferReads?: boolean;
+  failReads?: boolean;
+  initialLayout?: NativeKeyboardLayout | null;
+} = {}) {
+  const pushCallbacks: Array<(layout: NativeKeyboardLayout) => void> = [];
+  const pendingReads: Array<(layout: NativeKeyboardLayout | null) => void> = [];
+
+  (window as { codiff?: unknown }).codiff = {
+    getKeyboardLayout: () => {
+      if (failReads) {
+        return Promise.reject(new Error('ipc failure'));
+      }
+      if (deferReads) {
+        return new Promise<NativeKeyboardLayout | null>((resolve) => {
+          pendingReads.push(resolve);
+        });
+      }
+      return Promise.resolve(initialLayout);
+    },
+    onKeyboardLayoutChanged: (callback: (layout: NativeKeyboardLayout) => void) => {
+      pushCallbacks.push(callback);
+      return () => {
+        const index = pushCallbacks.indexOf(callback);
+        if (index !== -1) {
+          pushCallbacks.splice(index, 1);
+        }
+      };
+    },
+  };
 
   return {
-    failReads: () => {
-      failing = true;
+    getSubscriptionCount: () => pushCallbacks.length,
+    pushLayout: (layout: NativeKeyboardLayout) => {
+      for (const callback of pushCallbacks) {
+        callback(layout);
+      }
     },
-    getReadCount: () => readCount,
-    setLayout: (next: Record<string, string>) => {
-      layout = next;
-    },
+    resolveRead: (layout: NativeKeyboardLayout | null) => pendingReads.shift()?.(layout),
   };
 }

--- a/core/__tests__/keyboard-layout.test.ts
+++ b/core/__tests__/keyboard-layout.test.ts
@@ -218,6 +218,45 @@ test('resolves a digit the layout types only with Shift through its shifted spel
   }).toEqual({ ampersand: 'Digit1', one: null, shiftedOne: 'Digit1' });
 });
 
+test('keeps the layout it has when an empty one arrives', () => {
+  // Arrange: a failed native read reports nothing rather than a keyboard that
+  // types nothing, so it must not erase a good layout or pin letters onto a
+  // keyboard that was never read.
+  applyKeyboardLayout({ KeyY: key('z', 'Z'), KeyZ: key('y', 'Y') });
+
+  // Act
+  applyKeyboardLayout({});
+
+  // Assert
+  expect(codeForCharacter('z', false)).toBe('KeyY');
+});
+
+test('stays without a layout when the first one to arrive is empty', () => {
+  // Act
+  applyKeyboardLayout({});
+
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+test('ignores a key whose mapping is malformed', () => {
+  // Arrange: layout data crosses the IPC boundary, so a shape the native
+  // module never promised must not take the matcher down.
+  const layout = {
+    KeyQ: key('q', 'Q'),
+    KeyZ: { value: 7, withShift: null } as unknown as ReturnType<typeof key>,
+  };
+
+  // Act
+  applyKeyboardLayout(layout);
+
+  // Assert
+  expect({ q: codeForCharacter('q', false), z: codeForCharacter('z', false) }).toEqual({
+    q: 'KeyQ',
+    z: null,
+  });
+});
+
 test('reads the layout from the desktop shell when tracking starts', async () => {
   // Arrange
   createTestContext({ initialLayout: { KeyY: key('z', 'Z'), KeyZ: key('y', 'Y') } });

--- a/core/__tests__/keyboard-layout.test.ts
+++ b/core/__tests__/keyboard-layout.test.ts
@@ -257,6 +257,28 @@ test('ignores a key whose mapping is malformed', () => {
   });
 });
 
+test('survives a layout that is not an object at all', () => {
+  // Act
+  applyKeyboardLayout(null as unknown as NativeKeyboardLayout);
+
+  // Assert
+  expect(hasKeyboardLayout()).toBe(false);
+});
+
+test('ignores a key whose mapping is missing entirely', () => {
+  // Act
+  applyKeyboardLayout({
+    KeyA: null,
+    Slash: key('/', '?'),
+  } as unknown as NativeKeyboardLayout);
+
+  // Assert
+  expect({ loaded: hasKeyboardLayout(), slash: codeForCharacter('/', false) }).toEqual({
+    loaded: true,
+    slash: 'Slash',
+  });
+});
+
 test('reads the layout from the desktop shell when tracking starts', async () => {
   // Arrange
   createTestContext({ initialLayout: { KeyY: key('z', 'Z'), KeyZ: key('y', 'Y') } });

--- a/core/__tests__/keyboard-layout.test.ts
+++ b/core/__tests__/keyboard-layout.test.ts
@@ -231,6 +231,36 @@ test('does not re-read the layout once per keypress when it keeps disagreeing', 
   expect(getReadCount()).toBe(2);
 });
 
+test('asks again on the next keypress when it has no layout at all', async () => {
+  // Arrange: a window with no keyboard attached to it yet reports nothing, and
+  // waiting for it to lose and regain focus is a long way back from that.
+  const { setLayout } = createTestContext({});
+  trackKeyboardLayout();
+  await loadKeyboardLayout();
+  setLayout({ KeyY: 'z', KeyZ: 'y' });
+
+  // Act
+  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'y' }));
+
+  // Assert
+  await vi.waitFor(() => expect(codeForCharacter('z')).toBe('KeyY'));
+});
+
+test('does not re-read the layout for a key the layout never mentions', async () => {
+  // Arrange: the keyboard map covers the letter, digit and punctuation keys
+  // only, so the space bar reporting a space is not a disagreement.
+  const { getReadCount } = createTestContext({ KeyZ: 'z' });
+  trackKeyboardLayout();
+  await loadKeyboardLayout();
+
+  // Act
+  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', key: ' ' }));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // Assert
+  expect(getReadCount()).toBe(1);
+});
+
 test('re-reads the layout when the window regains focus', async () => {
   // Arrange
   const { setLayout } = createTestContext({ KeyZ: 'z' });

--- a/core/__tests__/keyboard-layout.test.ts
+++ b/core/__tests__/keyboard-layout.test.ts
@@ -14,6 +14,7 @@ import {
 afterEach(() => {
   resetKeyboardLayout();
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 test('resolves a character to the key position that produces it', async () => {
@@ -246,6 +247,46 @@ test('asks again on the next keypress when it has no layout at all', async () =>
   await vi.waitFor(() => expect(codeForCharacter('z')).toBe('KeyY'));
 });
 
+test('asks again once the quiet period after a disagreement has passed', async () => {
+  // Arrange: the quiet period stops a permanent disagreement asking on every
+  // keystroke, and must not stop a later real change from being noticed.
+  vi.useFakeTimers({ toFake: ['performance'] });
+  const { getReadCount, setLayout } = createTestContext({ KeyZ: 'z' });
+  trackKeyboardLayout();
+  await loadKeyboardLayout();
+  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'q' }));
+  await loadKeyboardLayout();
+  setLayout({ KeyY: 'z', KeyZ: 'y' });
+
+  // Act
+  vi.advanceTimersByTime(2000);
+  window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyZ', key: 'y' }));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // Assert
+  expect({ code: codeForCharacter('z'), reads: getReadCount() }).toEqual({
+    code: 'KeyY',
+    reads: 3,
+  });
+});
+
+test('does not start a second read while one is already in flight', async () => {
+  // Arrange: a read abandoned by a reset must not hand the in-flight slot back
+  // while the read that replaced it is still running.
+  const { getReadCount, reportLayout } = createSlowTestContext();
+  const abandoned = loadKeyboardLayout();
+  resetKeyboardLayout();
+  loadKeyboardLayout();
+
+  // Act
+  reportLayout({ KeyZ: 'z' });
+  await abandoned;
+  loadKeyboardLayout();
+
+  // Assert
+  expect(getReadCount()).toBe(2);
+});
+
 test('does not re-read the layout for a key the layout never mentions', async () => {
   // Arrange: the keyboard map covers the letter, digit and punctuation keys
   // only, so the space bar reporting a space is not a disagreement.
@@ -304,23 +345,28 @@ test('discards a layout read that was still in flight when it was reset', async 
   expect(hasKeyboardLayout()).toBe(false);
 });
 
-// A keyboard whose layout arrives only when the test says so.
+// A keyboard whose layout arrives only when the test says so, one read at a
+// time and in the order they were started.
 function createSlowTestContext() {
-  let resolveLayout!: (layout: Map<string, string>) => void;
+  const waiting: Array<(layout: Map<string, string>) => void> = [];
+  let readCount = 0;
 
   Object.defineProperty(navigator, 'keyboard', {
     configurable: true,
     value: {
-      getLayoutMap: () =>
-        new Promise<Map<string, string>>((resolve) => {
-          resolveLayout = resolve;
-        }),
+      getLayoutMap: () => {
+        readCount++;
+        return new Promise<Map<string, string>>((resolve) => {
+          waiting.push(resolve);
+        });
+      },
     },
   });
 
   return {
+    getReadCount: () => readCount,
     reportLayout: (layout: Record<string, string>) =>
-      resolveLayout(new Map(Object.entries(layout))),
+      waiting.shift()?.(new Map(Object.entries(layout))),
   };
 }
 

--- a/core/__tests__/keymap.test.ts
+++ b/core/__tests__/keymap.test.ts
@@ -3,10 +3,12 @@
  */
 
 import { afterEach, expect, test, vi } from 'vite-plus/test';
+import { loadKeyboardLayout, resetKeyboardLayout } from '../config/keyboard-layout.ts';
 import { matchesShortcut } from '../config/keymap.ts';
 import type { CodiffKeymap } from '../config/types.ts';
 
 afterEach(() => {
+  resetKeyboardLayout();
   vi.restoreAllMocks();
 });
 
@@ -284,6 +286,125 @@ test('does not fall back to the physical key for shortcuts without Alt', () => {
   expect(matched).toBe(false);
 });
 
+test('resolves an Alt shortcut to the key that produces its character on this layout', async () => {
+  // Arrange: QWERTZ types "z" on the key US keyboards label "y".
+  const { keydown, keymap } = createTestContext();
+  await withKeyboardLayout({ KeyY: 'z', KeyZ: 'y' });
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'KeyY', key: 'Ω' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('does not resolve an Alt shortcut to the US position on a layout that moved it', async () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext();
+  await withKeyboardLayout({ KeyY: 'z', KeyZ: 'y' });
+
+  // Act: this key types "y" on QWERTZ, so it must not toggle word wrap.
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'KeyZ', key: 'Ω' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(false);
+});
+
+test('resolves an Alt shortcut to a punctuation key when the layout puts a letter there', async () => {
+  // Arrange: Dvorak types "z" on the key US keyboards label "/".
+  const { keydown, keymap } = createTestContext();
+  await withKeyboardLayout({ KeyZ: ';', Slash: 'z' });
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'Slash', key: '÷' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('keeps shifted Alt shortcuts on US key positions', async () => {
+  // Arrange: the keyboard map reports unmodified characters only, so a shifted
+  // spelling has no layout answer. Resolving "z" through the layout and "?"
+  // through the US table would otherwise put both on Dvorak's Slash key.
+  const { keydown, keymap } = createTestContext({
+    commandBar: 'Alt+Shift+z',
+    toggleWordWrap: 'Alt+Shift+?',
+  });
+  await withKeyboardLayout({ KeyZ: ';', Slash: 'z' });
+  const event = keydown({ altKey: true, code: 'Slash', key: '¿', shiftKey: true });
+
+  // Act
+  const matched = {
+    commandBar: matchesShortcut(event, keymap, 'commandBar'),
+    toggleWordWrap: matchesShortcut(event, keymap, 'toggleWordWrap'),
+  };
+
+  // Assert
+  expect(matched).toEqual({ commandBar: false, toggleWordWrap: true });
+});
+
+test('resolves a letter shortcut to its US position on a layout that types no Latin', async () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext();
+  await withKeyboardLayout({ KeyA: 'ф', KeyZ: 'я' });
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'KeyZ', key: 'Ω' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('does not fire an Alt shortcut whose character the layout cannot type', async () => {
+  // Arrange: German types "-" where US keyboards have "/", and reaches "/"
+  // only through Shift. Falling back to the US position would fire this on the
+  // key that types "-", which already answers to `Alt+-`.
+  const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+/' });
+  await withKeyboardLayout({ Minus: 'ß', Slash: '-' });
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'Slash', key: '÷' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(false);
+});
+
+test('falls back to the US position while no layout has been read', () => {
+  // Arrange: the layout arrives asynchronously, so every keypress before it
+  // lands resolves the way it did before layouts were consulted at all.
+  const { keydown, keymap } = createTestContext();
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'KeyZ', key: 'Ω' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
 function createTestContext({
   platform = 'MacIntel',
   ...overrides
@@ -309,6 +430,15 @@ function createTestContext({
   } satisfies CodiffKeymap;
 
   return { keydown, keymap };
+}
+
+async function withKeyboardLayout(layout: Record<string, string>) {
+  Object.defineProperty(navigator, 'keyboard', {
+    configurable: true,
+    value: { getLayoutMap: () => Promise.resolve(new Map(Object.entries(layout))) },
+  });
+
+  await loadKeyboardLayout();
 }
 
 function keydown({

--- a/core/__tests__/keymap.test.ts
+++ b/core/__tests__/keymap.test.ts
@@ -209,10 +209,10 @@ test('lets a binding on the composed character itself suppress the position fall
 });
 
 test('resolves a swallowed character to the US key position when nothing else claims it', () => {
-  // Arrange: this pins the documented semantics. The fallback is defined in
-  // terms of US key positions, so on a layout that moves keys it can fire an
-  // action the label does not suggest. It only ever does so for a keypress no
-  // binding matched by character, so it cannot take one from another shortcut.
+  // Arrange: with no layout read yet, the fallback is defined in terms of US
+  // key positions, so on a layout that moves keys it can fire an action the
+  // label does not suggest. It only ever does so for a keypress no binding
+  // matched by character, so it cannot take one from another shortcut.
   const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+2' });
 
   // Act
@@ -405,6 +405,56 @@ test('falls back to the US position while no layout has been read', () => {
   expect(matched).toBe(true);
 });
 
+test('never lets two shortcut spellings claim the same key', async () => {
+  // Arrange: one key must answer to at most one spelling, or a single keypress
+  // fires two actions and which one wins is down to the order the app happens
+  // to check them in. Resolution has three sources, and this walks every
+  // spelling through all of them on layouts that move keys in different ways.
+  const collisions: Array<string> = [];
+
+  for (const [name, layout] of Object.entries(keyboardLayouts)) {
+    resetKeyboardLayout();
+    if (layout !== null) {
+      await withKeyboardLayout(layout);
+    }
+
+    // Act
+    for (const shiftKey of [false, true]) {
+      const claimedBy = new Map<string, string>();
+      for (const spelling of comboSpellings) {
+        const code = resolvePhysicalKey(spelling, shiftKey);
+        const previous = code === null ? undefined : claimedBy.get(code);
+        if (code !== null && previous !== undefined) {
+          collisions.push(`${name}: "${previous}" and "${spelling}" both claim ${code}`);
+        } else if (code !== null) {
+          claimedBy.set(code, spelling);
+        }
+      }
+    }
+  }
+
+  // Assert
+  expect(collisions).toEqual([]);
+});
+
+// The key a combo resolves to, found by pressing every key in turn. The event
+// reports a character no spelling names, so only the key position can match it.
+function resolvePhysicalKey(spelling: string, shiftKey: boolean): string | null {
+  const { keydown, keymap } = createTestContext({
+    toggleWordWrap: `Alt+${shiftKey ? 'Shift+' : ''}${spelling}`,
+  });
+
+  return (
+    candidateCodes.find((code) =>
+      matchesShortcut(
+        keydown({ altKey: true, code, key: unmatchableCharacter, shiftKey }),
+        keymap,
+        'toggleWordWrap',
+      ),
+    ) ?? null
+  );
+}
+
 function createTestContext({
   platform = 'MacIntel',
   ...overrides
@@ -439,6 +489,75 @@ async function withKeyboardLayout(layout: Record<string, string>) {
   });
 
   await loadKeyboardLayout();
+}
+
+// A character from the Unicode private use area: no keyboard produces it and no
+// shortcut can name it.
+const unmatchableCharacter = '\uE000';
+
+const candidateCodes = [
+  ...'abcdefghijklmnopqrstuvwxyz'.split('').map((letter) => `Key${letter.toUpperCase()}`),
+  ...'0123456789'.split('').map((digit) => `Digit${digit}`),
+  'Backquote',
+  'Minus',
+  'Equal',
+  'BracketLeft',
+  'BracketRight',
+  'Backslash',
+  'Semicolon',
+  'Quote',
+  'Comma',
+  'Period',
+  'Slash',
+  'IntlBackslash',
+];
+
+// Every character a combo can name, so a spelling added to the punctuation
+// tables later is covered without touching this list. `+` separates the parts
+// of a combo and space is trimmed away, so neither can be named, and combos are
+// lowercased when parsed, so `Alt+A` is another way to write `Alt+a` rather
+// than a second spelling that could collide with it.
+const comboSpellings = Array.from({ length: 0x7e - 0x21 + 1 }, (_, index) =>
+  String.fromCharCode(0x21 + index),
+)
+  .filter((character) => character !== '+' && !/^[A-Z]$/.test(character))
+  .concat(['é', 'ü', 'ß', 'я', 'ω']);
+
+// Approximations of real layouts, accurate in the ways that matter here: which
+// keys move, which characters need Shift, and which layouts produce no Latin.
+// Each row runs left to right across `keyRows`.
+const keyRows = [
+  ['Backquote', ...'1234567890'.split('').map((digit) => `Digit${digit}`), 'Minus', 'Equal'],
+  [
+    ...'qwertyuiop'.split('').map((l) => `Key${l.toUpperCase()}`),
+    'BracketLeft',
+    'BracketRight',
+    'Backslash',
+  ],
+  [...'asdfghjkl'.split('').map((l) => `Key${l.toUpperCase()}`), 'Semicolon', 'Quote'],
+  [...'zxcvbnm'.split('').map((l) => `Key${l.toUpperCase()}`), 'Comma', 'Period', 'Slash'],
+];
+
+const keyboardLayouts: Record<string, Record<string, string> | null> = {
+  azerty: layoutFromRows(['@&é"\'(§è!çà)-', 'azertyuiop^$`', 'qsdfghjklmù', 'wxcvbn,;:!']),
+  dvorak: layoutFromRows(['`1234567890[]', "',.pyfgcrl/=\\", 'aoeuidhtns-', ';qjkxbmwvz']),
+  german: layoutFromRows(['^1234567890ß´', 'qwertzuiopü+#', 'asdfghjklöä', 'yxcvbnm,.-']),
+  none: null,
+  russian: layoutFromRows([']1234567890-=', 'йцукенгшщзхъё', 'фывапролджэ', 'ячсмитьбю.']),
+  us: layoutFromRows(['`1234567890-=', 'qwertyuiop[]\\', "asdfghjkl;'", 'zxcvbnm,./']),
+};
+
+function layoutFromRows(rows: ReadonlyArray<string>): Record<string, string> {
+  const layout: Record<string, string> = {};
+
+  rows.forEach((row, index) => {
+    const codes = keyRows[index];
+    [...row].forEach((character, position) => {
+      layout[codes[position]] = character;
+    });
+  });
+
+  return layout;
 }
 
 function keydown({

--- a/core/__tests__/keymap.test.ts
+++ b/core/__tests__/keymap.test.ts
@@ -4,6 +4,7 @@
 
 import { afterEach, expect, test, vi } from 'vite-plus/test';
 import { applyKeyboardLayout, resetKeyboardLayout } from '../config/keyboard-layout.ts';
+import type { NativeKeyboardLayout } from '../config/keyboard-layout.ts';
 import { matchesShortcut } from '../config/keymap.ts';
 import type { CodiffKeymap } from '../config/types.ts';
 
@@ -155,6 +156,167 @@ test('matches an Alt shortcut bound to shifted punctuation', () => {
   expect(matched).toBe(true);
 });
 
+test('resolves a shifted Alt shortcut through the key that types its character', () => {
+  // Arrange: German types "?" with Shift on the "ß" key, which sits at the US
+  // "-" position.
+  const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+Shift+?' });
+  applyKeyboardLayout(germanLayout);
+
+  // Act
+  const matched = {
+    minus: matchesShortcut(
+      keydown({ altKey: true, code: 'Minus', key: '¿', shiftKey: true }),
+      keymap,
+      'toggleWordWrap',
+    ),
+    slash: matchesShortcut(
+      keydown({ altKey: true, code: 'Slash', key: '¿', shiftKey: true }),
+      keymap,
+      'toggleWordWrap',
+    ),
+  };
+
+  // Assert: the US position stays quiet.
+  expect(matched).toEqual({ minus: true, slash: false });
+});
+
+test('resolves shifted letter and punctuation spellings to their own keys', () => {
+  // Arrange: Dvorak types "z" on the key US keyboards label "/" and "?" on the
+  // key they label "[". Resolving both through the layout keeps each spelling
+  // on the key that really types it.
+  const { keydown, keymap } = createTestContext({
+    commandBar: 'Alt+Shift+z',
+    toggleWordWrap: 'Alt+Shift+?',
+  });
+  applyKeyboardLayout(dvorakLayout);
+  const onBracket = keydown({ altKey: true, code: 'BracketLeft', key: '¿', shiftKey: true });
+  const onSlash = keydown({ altKey: true, code: 'Slash', key: '¿', shiftKey: true });
+
+  // Act
+  const matched = {
+    bracketQuestion: matchesShortcut(onBracket, keymap, 'toggleWordWrap'),
+    bracketZ: matchesShortcut(onBracket, keymap, 'commandBar'),
+    slashQuestion: matchesShortcut(onSlash, keymap, 'toggleWordWrap'),
+    slashZ: matchesShortcut(onSlash, keymap, 'commandBar'),
+  };
+
+  // Assert
+  expect(matched).toEqual({
+    bracketQuestion: true,
+    bracketZ: false,
+    slashQuestion: false,
+    slashZ: true,
+  });
+});
+
+test('accepts the unshifted spelling of a shifted keystroke', () => {
+  // Arrange: `Shift+/` and `Shift+?` are the same keystroke on a US keyboard,
+  // so both spellings describe it and both fire.
+  const { keydown, keymap } = createTestContext({
+    commandBar: 'Alt+Shift+/',
+    toggleWordWrap: 'Alt+Shift+?',
+  });
+  applyKeyboardLayout(usLayout);
+  const event = keydown({ altKey: true, code: 'Slash', key: '¿', shiftKey: true });
+
+  // Act
+  const matched = {
+    commandBar: matchesShortcut(event, keymap, 'commandBar'),
+    toggleWordWrap: matchesShortcut(event, keymap, 'toggleWordWrap'),
+  };
+
+  // Assert
+  expect(matched).toEqual({ commandBar: true, toggleWordWrap: true });
+});
+
+test('matches a shifted spelling written by the key it sits on', () => {
+  // Arrange: `Mod+Shift+/` names the keystroke that types "?", with and
+  // without a layout to consult.
+  const { keydown, keymap } = createTestContext({ diffSearch: 'Mod+Shift+/' });
+  const event = keydown({ key: '?', metaKey: true, shiftKey: true });
+
+  // Act
+  const noLayout = matchesShortcut(event, keymap, 'diffSearch');
+  applyKeyboardLayout(usLayout);
+  const withLayout = matchesShortcut(event, keymap, 'diffSearch');
+
+  // Assert
+  expect({ noLayout, withLayout }).toEqual({ noLayout: true, withLayout: true });
+});
+
+test('follows the layout when a spelling is written by its key', () => {
+  // Arrange: German Shift+7 types "/", so `Mod+Shift+7` names that keystroke
+  // rather than the "&" a US keyboard would put there.
+  const { keydown, keymap } = createTestContext({ diffSearch: 'Mod+Shift+7' });
+  applyKeyboardLayout(germanLayout);
+
+  // Act
+  const matched = {
+    ampersand: matchesShortcut(
+      keydown({ key: '&', metaKey: true, shiftKey: true }),
+      keymap,
+      'diffSearch',
+    ),
+    slash: matchesShortcut(
+      keydown({ key: '/', metaKey: true, shiftKey: true }),
+      keymap,
+      'diffSearch',
+    ),
+  };
+
+  // Assert
+  expect(matched).toEqual({ ampersand: false, slash: true });
+});
+
+test('resolves a digit the layout reaches only through Shift to its real key', () => {
+  // Arrange: AZERTY keeps "1" on the US "1" key but behind Shift, while
+  // Programmer Dvorak moves it elsewhere entirely.
+  const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+Shift+1' });
+  applyKeyboardLayout(azertyLayout);
+
+  // Act
+  const azerty = matchesShortcut(
+    keydown({ altKey: true, code: 'Digit1', key: '¿', shiftKey: true }),
+    keymap,
+    'toggleWordWrap',
+  );
+  applyKeyboardLayout(programmerDvorakLayout);
+  const programmerDvorak = {
+    movedKey: matchesShortcut(
+      keydown({ altKey: true, code: 'Digit5', key: '¿', shiftKey: true }),
+      keymap,
+      'toggleWordWrap',
+    ),
+    usKey: matchesShortcut(
+      keydown({ altKey: true, code: 'Digit1', key: '¿', shiftKey: true }),
+      keymap,
+      'toggleWordWrap',
+    ),
+  };
+
+  // Assert
+  expect({ azerty, ...programmerDvorak }).toEqual({
+    azerty: true,
+    movedKey: true,
+    usKey: false,
+  });
+});
+
+test('gives the combo delimiter character a spelling through Shift+=', () => {
+  // Arrange: `+` separates the parts of a combo, so the keystroke that types
+  // it can only be named by the key it sits on.
+  const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+Shift+=' });
+  const event = keydown({ altKey: true, code: 'Equal', key: '±', shiftKey: true });
+
+  // Act
+  const noLayout = matchesShortcut(event, keymap, 'toggleWordWrap');
+  applyKeyboardLayout(usLayout);
+  const withLayout = matchesShortcut(event, keymap, 'toggleWordWrap');
+
+  // Assert
+  expect({ noLayout, withLayout }).toEqual({ noLayout: true, withLayout: true });
+});
+
 test('does not let shifted and unshifted punctuation on one key collide', () => {
   // Arrange: "?" and "/" share the US Slash key, so only the spelling whose
   // Shift state the combo declares may claim that position.
@@ -171,8 +333,9 @@ test('does not let shifted and unshifted punctuation on one key collide', () => 
   expect(matched).toEqual({ commandBar: false, toggleWordWrap: true });
 });
 
-test('does not let a shifted digit collide with the digit sharing its key', () => {
-  // Arrange
+test('treats a shifted digit and the character it types as one chord', () => {
+  // Arrange: on a US keyboard Shift+1 and "!" are the same keystroke, so both
+  // spellings describe it and both fire.
   const { keydown, keymap } = createTestContext({
     commandBar: 'Alt+Shift+1',
     toggleWordWrap: 'Alt+Shift+!',
@@ -186,7 +349,7 @@ test('does not let a shifted digit collide with the digit sharing its key', () =
   };
 
   // Assert
-  expect(matched).toEqual({ commandBar: false, toggleWordWrap: true });
+  expect(matched).toEqual({ commandBar: true, toggleWordWrap: true });
 });
 
 test('lets a binding on the composed character itself suppress the position fallback', () => {
@@ -334,27 +497,6 @@ test('resolves an Alt shortcut to a punctuation key when the layout puts a lette
   expect(matched).toBe(true);
 });
 
-test('keeps shifted Alt shortcuts on US key positions', () => {
-  // Arrange: the keyboard map reports unmodified characters only, so a shifted
-  // spelling has no layout answer. Resolving "z" through the layout and "?"
-  // through the US table would otherwise put both on Dvorak's Slash key.
-  const { keydown, keymap } = createTestContext({
-    commandBar: 'Alt+Shift+z',
-    toggleWordWrap: 'Alt+Shift+?',
-  });
-  withKeyboardLayout({ KeyZ: ';', Slash: 'z' });
-  const event = keydown({ altKey: true, code: 'Slash', key: '¿', shiftKey: true });
-
-  // Act
-  const matched = {
-    commandBar: matchesShortcut(event, keymap, 'commandBar'),
-    toggleWordWrap: matchesShortcut(event, keymap, 'toggleWordWrap'),
-  };
-
-  // Assert
-  expect(matched).toEqual({ commandBar: false, toggleWordWrap: true });
-});
-
 test('resolves a letter shortcut to its US position on a layout that types no Latin', () => {
   // Arrange
   const { keydown, keymap } = createTestContext();
@@ -405,17 +547,18 @@ test('falls back to the US position while no layout has been read', () => {
   expect(matched).toBe(true);
 });
 
-test('never lets two shortcut combos claim the same key', () => {
-  // Arrange: one key must answer to at most one spelling, or a single keypress
-  // fires two actions and which one wins is down to the order the app happens
-  // to check them in. Resolution has three sources, and this walks every
-  // spelling through all of them on layouts that move keys in different ways.
+test('never lets two shortcut combos claim the same keystroke unless they spell it both ways', () => {
+  // Arrange: one keystroke must answer to at most one combo, or a single
+  // keypress fires two actions and which one wins is down to the order the app
+  // happens to check them in. The only exception is deliberate: with Shift
+  // held, a key's own character and the character Shift makes it type are two
+  // spellings of the same keystroke, like `Shift+/` and `Shift+?`.
   const collisions: Array<string> = [];
 
   for (const [name, layout] of Object.entries(keyboardLayouts)) {
     resetKeyboardLayout();
     if (layout !== null) {
-      withKeyboardLayout(layout);
+      applyKeyboardLayout(layout);
     }
 
     // Act
@@ -424,9 +567,13 @@ test('never lets two shortcut combos claim the same key', () => {
       for (const spelling of comboSpellings) {
         const code = resolvePhysicalKey(spelling, shiftKey);
         const previous = code === null ? undefined : claimedBy.get(code);
-        if (code !== null && previous !== undefined) {
+        if (
+          code !== null &&
+          previous !== undefined &&
+          !describesOneKeystroke(previous, spelling, code, shiftKey, layout)
+        ) {
           collisions.push(`${name}: "${previous}" and "${spelling}" both claim ${code}`);
-        } else if (code !== null) {
+        } else if (code !== null && previous === undefined) {
           claimedBy.set(code, spelling);
         }
       }
@@ -436,6 +583,81 @@ test('never lets two shortcut combos claim the same key', () => {
   // Assert
   expect(collisions).toEqual([]);
 });
+
+test('resolves every combo to a key that really types its character', () => {
+  // Arrange: a combo landing on a key that types something else is the bug all
+  // of this replaces, so every resolved position is checked against what the
+  // layout says that keystroke produces. Layouts that pin Latin letters are
+  // covered by their own tests, since pinning moves letters on purpose.
+  const wrongKeys: Array<string> = [];
+
+  for (const [name, layout] of Object.entries(keyboardLayouts)) {
+    if (layout !== null && name !== 'russian') {
+      resetKeyboardLayout();
+      applyKeyboardLayout(layout);
+
+      // Act
+      for (const shiftKey of [false, true]) {
+        for (const spelling of comboSpellings) {
+          const code = resolvePhysicalKey(spelling, shiftKey);
+          if (code !== null) {
+            const mapping = layout[code];
+            const typed = mapping
+              ? shiftKey
+                ? [mapping.withShift.toLowerCase(), mapping.value.toLowerCase()]
+                : [mapping.value.toLowerCase()]
+              : [];
+            if (!typed.includes(spelling)) {
+              collect(wrongKeys, name, spelling, shiftKey, code, typed);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Assert
+  expect(wrongKeys).toEqual([]);
+});
+
+function collect(
+  wrongKeys: Array<string>,
+  name: string,
+  spelling: string,
+  shiftKey: boolean,
+  code: string,
+  typed: ReadonlyArray<string>,
+) {
+  wrongKeys.push(
+    `${name}: "${spelling}"${shiftKey ? ' with Shift' : ''} landed on ${code}, which types "${typed.join('", "')}"`,
+  );
+}
+
+// Two spellings may share a keystroke only when the layout says they describe
+// the same one: the key's own character named alongside the character Shift
+// makes it type. Without a layout the US pairs answer.
+function describesOneKeystroke(
+  a: string,
+  b: string,
+  code: string,
+  shiftKey: boolean,
+  layout: NativeKeyboardLayout | null,
+): boolean {
+  if (!shiftKey) {
+    return false;
+  }
+  if (layout === null) {
+    return usShiftPairs[a] === b || usShiftPairs[b] === a;
+  }
+
+  const mapping = layout[code];
+  if (!mapping) {
+    return false;
+  }
+
+  const spellings = [mapping.value.toLowerCase(), mapping.withShift.toLowerCase()];
+  return spellings.includes(a) && spellings.includes(b);
+}
 
 // The key a combo resolves to, found by pressing every key in turn. The event
 // reports a character no spelling names, so only the key position can match it.
@@ -522,9 +744,36 @@ const comboSpellings = Array.from({ length: 0x7e - 0x21 + 1 }, (_, index) =>
   .filter((character) => character !== '+' && !/^[A-Z]$/.test(character))
   .concat(['é', 'ü', 'ß', 'я', 'ω']);
 
+// The US pairing of a key's plain character with the one Shift makes it type,
+// as an independent check on what the tables in `keymap.ts` encode.
+const usShiftPairs: Record<string, string> = {
+  '-': '_',
+  ',': '<',
+  ';': ':',
+  '.': '>',
+  "'": '"',
+  '[': '{',
+  ']': '}',
+  '/': '?',
+  '\\': '|',
+  '`': '~',
+  '=': '+',
+  '0': ')',
+  '1': '!',
+  '2': '@',
+  '3': '#',
+  '4': '$',
+  '5': '%',
+  '6': '^',
+  '7': '&',
+  '8': '*',
+  '9': '(',
+};
+
 // Approximations of real layouts, accurate in the ways that matter here: which
 // keys move, which characters need Shift, and which layouts produce no Latin.
-// Each row runs left to right across `keyRows`.
+// Each row pairs the plain characters with the ones Shift produces, running
+// left to right across `keyRows`.
 const keyRows = [
   ['Backquote', ...'1234567890'.split('').map((digit) => `Digit${digit}`), 'Minus', 'Equal'],
   [
@@ -537,33 +786,84 @@ const keyRows = [
   [...'zxcvbnm'.split('').map((l) => `Key${l.toUpperCase()}`), 'Comma', 'Period', 'Slash'],
 ];
 
-const keyboardLayouts: Record<string, Record<string, string> | null> = {
-  azerty: layoutFromRows(['@&é"\'(§è!çà)-', 'azertyuiop^$`', 'qsdfghjklmù', 'wxcvbn,;:!']),
-  dvorak: layoutFromRows(['`1234567890[]', "',.pyfgcrl/=\\", 'aoeuidhtns-', ';qjkxbmwvz']),
-  german: layoutFromRows(['^1234567890ß´', 'qwertzuiopü+#', 'asdfghjklöä', 'yxcvbnm,.-']),
+const usLayout = layoutFromRows([
+  ['`1234567890-=', '~!@#$%^&*()_+'],
+  ['qwertyuiop[]\\', 'QWERTYUIOP{}|'],
+  ["asdfghjkl;'", 'ASDFGHJKL:"'],
+  ['zxcvbnm,./', 'ZXCVBNM<>?'],
+]);
+
+const germanLayout = layoutFromRows([
+  ['^1234567890ß´', '°!"§$%&/()=?`'],
+  ['qwertzuiopü+#', "QWERTZUIOPÜ*'"],
+  ['asdfghjklöä', 'ASDFGHJKLÖÄ'],
+  ['yxcvbnm,.-', 'YXCVBNM;:_'],
+]);
+
+const azertyLayout = layoutFromRows([
+  ['@&é"\'(§è!çà)-', '#1234567890°_'],
+  ['azertyuiop^$`', 'AZERTYUIOP¨*£'],
+  ['qsdfghjklmù', 'QSDFGHJKLM%'],
+  ['wxcvbn,;:!', 'WXCVBN?./§'],
+]);
+
+const dvorakLayout = layoutFromRows([
+  ['`1234567890[]', '~!@#$%^&*(){}'],
+  ["',.pyfgcrl/=\\", '"<>PYFGCRL?+|'],
+  ['aoeuidhtns-', 'AOEUIDHTNS_'],
+  [';qjkxbmwvz', ':QJKXBMWVZ'],
+]);
+
+// Puts symbols on the number row and reaches the digits through Shift in an
+// order of its own, so assuming the US number row would resolve them to the
+// wrong keys.
+const programmerDvorakLayout = layoutFromRows([
+  ['$&[{}(=*)+]!#', '~%7531902468`'],
+  [';,.pyfgcrl/@\\', ':<>PYFGCRL?^|'],
+  ['aoeuidhtns-', 'AOEUIDHTNS_'],
+  ["'qjkxbmwvz", '"QJKXBMWVZ'],
+]);
+
+// Types most of the alphabet but not all of it, which is where filling in the
+// missing letters one at a time would take a key from one that is there.
+const partialLatinLayout = layoutFromRows([
+  ['`1234567890-=', '~!@#$%^&*()_+'],
+  ['ąwertyuiop[]\\', 'ĄWERTYUIOP{}|'],
+  ["asdfghjkl;'", 'ASDFGHJKL:"'],
+  ['zxcvbnm,./', 'ZXCVBNM<>?'],
+]);
+
+const russianLayout = layoutFromRows([
+  [']1234567890-=', '[!"№;%:?*()_+'],
+  ['йцукенгшщзхъё', 'ЙЦУКЕНГШЩЗХЪЁ'],
+  ['фывапролджэ', 'ФЫВАПРОЛДЖЭ'],
+  ['ячсмитьбю.', 'ЯЧСМИТЬБЮ,'],
+]);
+
+const keyboardLayouts: Record<string, NativeKeyboardLayout | null> = {
+  azerty: azertyLayout,
+  dvorak: dvorakLayout,
+  german: germanLayout,
   none: null,
-  // Types most of the alphabet but not all of it, which is where filling in the
-  // missing letters one at a time would take a key from one that is there.
-  partialLatin: layoutFromRows(['`1234567890-=', 'ąwertyuiop[]\\', "asdfghjkl;'", 'zxcvbnm,./']),
-  // Puts symbols on the number row and reaches the digits through Shift, so
-  // assuming the US number row would resolve them to the wrong keys.
-  programmerDvorak: layoutFromRows([
-    '$&[{}(=*)+]!#',
-    ';,.pyfgcrl/@\\',
-    'aoeuidhtns-',
-    "'qjkxbmwvz",
-  ]),
-  russian: layoutFromRows([']1234567890-=', 'йцукенгшщзхъё', 'фывапролджэ', 'ячсмитьбю.']),
-  us: layoutFromRows(['`1234567890-=', 'qwertyuiop[]\\', "asdfghjkl;'", 'zxcvbnm,./']),
+  partialLatin: partialLatinLayout,
+  programmerDvorak: programmerDvorakLayout,
+  russian: russianLayout,
+  us: usLayout,
 };
 
-function layoutFromRows(rows: ReadonlyArray<string>): Record<string, string> {
-  const layout: Record<string, string> = {};
+function layoutFromRows(
+  rows: ReadonlyArray<readonly [string, string]>,
+): Record<string, { value: string; withShift: string }> {
+  const layout: Record<string, { value: string; withShift: string }> = {};
 
-  rows.forEach((row, index) => {
+  rows.forEach(([plain, shifted], index) => {
     const codes = keyRows[index];
-    [...row].forEach((character, position) => {
-      layout[codes[position]] = character;
+    const shiftedCharacters = [...shifted];
+    [...plain].forEach((character, position) => {
+      layout[codes[position]] = {
+        value: character,
+        withShift: shiftedCharacters[position] ?? '',
+      };
     });
   });
 

--- a/core/__tests__/keymap.test.ts
+++ b/core/__tests__/keymap.test.ts
@@ -1,0 +1,330 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, expect, test, vi } from 'vite-plus/test';
+import { matchesShortcut } from '../config/keymap.ts';
+import type { CodiffKeymap } from '../config/types.ts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('matches an Alt shortcut on macOS where Option composes the letter away', () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext({ platform: 'MacIntel' });
+
+  // Act: macOS turns Option+Z into "Ω" but still reports the physical key.
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'KeyZ', key: 'Ω' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('matches an Alt shortcut bound to a digit', () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+1' });
+
+  // Act: Option+1 composes to "¡" on a US layout.
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'Digit1', key: '¡' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('does not match an Alt shortcut when a different physical key is pressed', () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext();
+
+  // Act: Option+X, which composes to "≈" and must not trigger Alt+z.
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'KeyX', key: '≈' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(false);
+});
+
+test('does not match an Alt shortcut bound to a named key against a press with no code', () => {
+  // Arrange: `Enter` has no physical-key fallback, so an event that reports no
+  // code must not be treated as an empty-for-empty match.
+  const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+Enter' });
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: '', key: 'œ' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(false);
+});
+
+test('does not let one keypress match two different Alt shortcuts', () => {
+  // Arrange: on QWERTZ the key at the US "z" position is labelled "y", and
+  // Windows does not compose the character away.
+  const { keydown, keymap } = createTestContext({
+    commandBar: 'Alt+z',
+    platform: 'Win32',
+    toggleSidebar: 'Alt+y',
+  });
+  const event = keydown({ altKey: true, code: 'KeyZ', key: 'y' });
+
+  // Act
+  const matched = {
+    commandBar: matchesShortcut(event, keymap, 'commandBar'),
+    toggleSidebar: matchesShortcut(event, keymap, 'toggleSidebar'),
+  };
+
+  // Assert: the character the user typed wins; the US key position does not.
+  expect(matched).toEqual({ commandBar: false, toggleSidebar: true });
+});
+
+test('lets a layout character win over the US key position it sits on', () => {
+  // Arrange: AZERTY produces "é" natively at the US "2" position, so the
+  // character is real input rather than something Option composed away.
+  const { keydown, keymap } = createTestContext({ commandBar: 'Alt+2', toggleSidebar: 'Alt+é' });
+  const event = keydown({ altKey: true, code: 'Digit2', key: 'é' });
+
+  // Act
+  const matched = {
+    commandBar: matchesShortcut(event, keymap, 'commandBar'),
+    toggleSidebar: matchesShortcut(event, keymap, 'toggleSidebar'),
+  };
+
+  // Assert
+  expect(matched).toEqual({ commandBar: false, toggleSidebar: true });
+});
+
+test('does not fall back to the US key position on platforms that never compose', () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext({ platform: 'Win32' });
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'KeyZ', key: 'Ω' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(false);
+});
+
+test('fails closed when the event reports no usable key', () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext();
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'KeyZ', key: 'Unidentified' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(false);
+});
+
+test('matches an Alt shortcut bound to shifted punctuation', () => {
+  // Arrange: the shipped `Shift+?` default shows combos name the resulting
+  // character, not the unshifted one.
+  const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+Shift+?' });
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'Slash', key: '¿', shiftKey: true }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('does not let shifted and unshifted punctuation on one key collide', () => {
+  // Arrange: "?" and "/" share the US Slash key, so only the spelling whose
+  // Shift state the combo declares may claim that position.
+  const { keydown, keymap } = createTestContext({ commandBar: 'Alt+?', toggleWordWrap: 'Alt+/' });
+  const event = keydown({ altKey: true, code: 'Slash', key: '÷' });
+
+  // Act
+  const matched = {
+    commandBar: matchesShortcut(event, keymap, 'commandBar'),
+    toggleWordWrap: matchesShortcut(event, keymap, 'toggleWordWrap'),
+  };
+
+  // Assert
+  expect(matched).toEqual({ commandBar: false, toggleWordWrap: true });
+});
+
+test('does not let a shifted digit collide with the digit sharing its key', () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext({
+    commandBar: 'Alt+Shift+1',
+    toggleWordWrap: 'Alt+Shift+!',
+  });
+  const event = keydown({ altKey: true, code: 'Digit1', key: '⁄', shiftKey: true });
+
+  // Act
+  const matched = {
+    commandBar: matchesShortcut(event, keymap, 'commandBar'),
+    toggleWordWrap: matchesShortcut(event, keymap, 'toggleWordWrap'),
+  };
+
+  // Assert
+  expect(matched).toEqual({ commandBar: false, toggleWordWrap: true });
+});
+
+test('lets a binding on the composed character itself suppress the position fallback', () => {
+  // Arrange: binding the composed character is exotic, but if someone does it
+  // that binding owns the keypress and the position fallback stays out of it.
+  const { keydown, keymap } = createTestContext({
+    closeSearch: 'Alt+ω',
+    toggleWordWrap: 'Alt+z',
+  });
+  const event = keydown({ altKey: true, code: 'KeyZ', key: 'ω' });
+
+  // Act
+  const matched = {
+    closeSearch: matchesShortcut(event, keymap, 'closeSearch'),
+    toggleWordWrap: matchesShortcut(event, keymap, 'toggleWordWrap'),
+  };
+
+  // Assert
+  expect(matched).toEqual({ closeSearch: true, toggleWordWrap: false });
+});
+
+test('resolves a swallowed character to the US key position when nothing else claims it', () => {
+  // Arrange: this pins the documented semantics. The fallback is defined in
+  // terms of US key positions, so on a layout that moves keys it can fire an
+  // action the label does not suggest. It only ever does so for a keypress no
+  // binding matched by character, so it cannot take one from another shortcut.
+  const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+2' });
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'Digit2', key: '™' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('matches an Alt shortcut on the typed character when the physical key differs', () => {
+  // Arrange: a layout where the character "z" sits on the US "y" position.
+  const { keydown, keymap } = createTestContext({ platform: 'Win32' });
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'KeyY', key: 'z' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('matches an Alt shortcut bound to punctuation that Option composes away', () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+/' });
+
+  // Act: Option+/ composes to "÷" on a US layout.
+  const matched = matchesShortcut(
+    keydown({ altKey: true, code: 'Slash', key: '÷' }),
+    keymap,
+    'toggleWordWrap',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('matches a non-Alt shortcut on the character the layout produces', () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext();
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ code: 'KeyF', key: 'f', metaKey: true }),
+    keymap,
+    'diffSearch',
+  );
+
+  // Assert
+  expect(matched).toBe(true);
+});
+
+test('does not fall back to the physical key for shortcuts without Alt', () => {
+  // Arrange: on a remapped layout the character, not the key position, wins.
+  const { keydown, keymap } = createTestContext();
+
+  // Act
+  const matched = matchesShortcut(
+    keydown({ code: 'KeyF', key: 'ç', metaKey: true }),
+    keymap,
+    'diffSearch',
+  );
+
+  // Assert
+  expect(matched).toBe(false);
+});
+
+function createTestContext({
+  platform = 'MacIntel',
+  ...overrides
+}: { platform?: string } & Partial<CodiffKeymap> = {}) {
+  vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue(platform);
+
+  const keymap = {
+    closeSearch: 'Escape',
+    commandBar: 'Mod+Shift+p',
+    diffSearch: 'Mod+f',
+    discardComment: 'Escape',
+    fileFilter: 'Mod+p',
+    nextHunk: ['Ctrl+ArrowDown', 'j'],
+    nextSearchMatch: 'Enter',
+    openFile: 'Mod+k',
+    prevHunk: ['Ctrl+ArrowUp', 'k'],
+    prevSearchMatch: 'Shift+Enter',
+    shortcutsHelp: 'Shift+?',
+    submitComment: 'Mod+Enter',
+    toggleSidebar: 'Mod+Shift+b',
+    toggleWordWrap: 'Alt+z',
+    ...overrides,
+  } satisfies CodiffKeymap;
+
+  return { keydown, keymap };
+}
+
+function keydown({
+  altKey = false,
+  code = '',
+  ctrlKey = false,
+  key,
+  metaKey = false,
+  shiftKey = false,
+}: {
+  altKey?: boolean;
+  code?: string;
+  ctrlKey?: boolean;
+  key: string;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+}) {
+  return new KeyboardEvent('keydown', { altKey, code, ctrlKey, key, metaKey, shiftKey });
+}

--- a/core/__tests__/keymap.test.ts
+++ b/core/__tests__/keymap.test.ts
@@ -302,6 +302,97 @@ test('resolves a digit the layout reaches only through Shift to its real key', (
   });
 });
 
+test('keeps a shifted spelling on the key that really types it when it appears in both columns', () => {
+  // Arrange: Linux Russian types "/" with Shift on the US "\" key and plain on
+  // the key next to the left Shift, which types "|" when shifted. "/" written
+  // with Shift must mean the keystroke that types "/", not get reinterpreted
+  // as the "/" key and land on the keystroke that types "|".
+  const { keydown, keymap } = createTestContext({ diffSearch: 'Mod+Shift+/' });
+  applyKeyboardLayout(bothColumnOverlapLayout);
+
+  // Act
+  const matched = {
+    pipe: matchesShortcut(
+      keydown({ key: '|', metaKey: true, shiftKey: true }),
+      keymap,
+      'diffSearch',
+    ),
+    slash: matchesShortcut(
+      keydown({ key: '/', metaKey: true, shiftKey: true }),
+      keymap,
+      'diffSearch',
+    ),
+  };
+
+  // Assert
+  expect(matched).toEqual({ pipe: false, slash: true });
+});
+
+test('resolves both-column spellings to their own keys', () => {
+  // Arrange
+  const { keydown, keymap } = createTestContext({
+    commandBar: 'Alt+Shift+/',
+    toggleWordWrap: 'Alt+Shift+|',
+  });
+  applyKeyboardLayout(bothColumnOverlapLayout);
+  const onBackslash = keydown({ altKey: true, code: 'Backslash', key: '¿', shiftKey: true });
+  const onIntlBackslash = keydown({
+    altKey: true,
+    code: 'IntlBackslash',
+    key: '¿',
+    shiftKey: true,
+  });
+
+  // Act
+  const matched = {
+    backslashPipe: matchesShortcut(onBackslash, keymap, 'toggleWordWrap'),
+    backslashSlash: matchesShortcut(onBackslash, keymap, 'commandBar'),
+    intlPipe: matchesShortcut(onIntlBackslash, keymap, 'toggleWordWrap'),
+    intlSlash: matchesShortcut(onIntlBackslash, keymap, 'commandBar'),
+  };
+
+  // Assert
+  expect(matched).toEqual({
+    backslashPipe: false,
+    backslashSlash: true,
+    intlPipe: true,
+    intlSlash: false,
+  });
+});
+
+test('lands a key spelling on the key it names when its shifted character lives elsewhere too', () => {
+  // Arrange: two keys type "?" with Shift. `Alt+Shift+/` names the "/" key, so
+  // it must stay on that key rather than follow "?" to whichever key claimed
+  // the character first.
+  const { keydown, keymap } = createTestContext({
+    commandBar: 'Alt+Shift+/',
+    toggleWordWrap: 'Alt+Shift+?',
+  });
+  applyKeyboardLayout({
+    KeyQ: { value: 'q', withShift: 'Q' },
+    Semicolon: { value: ';', withShift: '?' },
+    Slash: { value: '/', withShift: '?' },
+  });
+  const onSemicolon = keydown({ altKey: true, code: 'Semicolon', key: '¿', shiftKey: true });
+  const onSlash = keydown({ altKey: true, code: 'Slash', key: '¿', shiftKey: true });
+
+  // Act
+  const matched = {
+    semicolonQuestion: matchesShortcut(onSemicolon, keymap, 'toggleWordWrap'),
+    semicolonSlash: matchesShortcut(onSemicolon, keymap, 'commandBar'),
+    slashQuestion: matchesShortcut(onSlash, keymap, 'toggleWordWrap'),
+    slashSlash: matchesShortcut(onSlash, keymap, 'commandBar'),
+  };
+
+  // Assert
+  expect(matched).toEqual({
+    semicolonQuestion: true,
+    semicolonSlash: false,
+    slashQuestion: false,
+    slashSlash: true,
+  });
+});
+
 test('gives the combo delimiter character a spelling through Shift+=', () => {
   // Arrange: `+` separates the parts of a combo, so the keystroke that types
   // it can only be named by the key it sits on.
@@ -592,7 +683,7 @@ test('resolves every combo to a key that really types its character', () => {
   const wrongKeys: Array<string> = [];
 
   for (const [name, layout] of Object.entries(keyboardLayouts)) {
-    if (layout !== null && name !== 'russian') {
+    if (layout !== null && !pinnedLayouts.has(name)) {
       resetKeyboardLayout();
       applyKeyboardLayout(layout);
 
@@ -655,8 +746,18 @@ function describesOneKeystroke(
     return false;
   }
 
-  const spellings = [mapping.value.toLowerCase(), mapping.withShift.toLowerCase()];
-  return spellings.includes(a) && spellings.includes(b);
+  const value = mapping.value.toLowerCase();
+  const withShift = mapping.withShift.toLowerCase();
+  if (![a, b].includes(value) || ![a, b].includes(withShift)) {
+    return false;
+  }
+
+  // Naming the key is only a spelling of this keystroke when no key types the
+  // named character with Shift; if one does, the combo belongs on that key
+  // instead and this collision is a real bug, not a dual spelling.
+  return !Object.values(layout).some(
+    (other) => other.withShift.toLowerCase() === value && !other.withShiftIsDeadKey,
+  );
 }
 
 // The key a combo resolves to, found by pressing every key in turn. The event
@@ -840,10 +941,32 @@ const russianLayout = layoutFromRows([
   ['ячсмитьбю.', 'ЯЧСМИТЬБЮ,'],
 ]);
 
+// Linux Russian puts "/" in both columns: typed with Shift on the US "\" key
+// and plain on the key next to the left Shift, whose own Shift types "|". This
+// is VS Code's linux_ru fixture shape, and it is where reinterpreting an
+// actually shifted character as a key name lands a combo on the wrong key.
+const linuxRussianLayout: NativeKeyboardLayout = {
+  ...russianLayout,
+  Backslash: { value: '\\', withShift: '/' },
+  IntlBackslash: { value: '/', withShift: '|' },
+};
+
+// The minimal both-column overlap, with a Latin letter so no pinning applies.
+const bothColumnOverlapLayout: NativeKeyboardLayout = {
+  Backslash: { value: '\\', withShift: '/' },
+  IntlBackslash: { value: '/', withShift: '|' },
+  KeyQ: { value: 'q', withShift: 'Q' },
+};
+
+// Layouts whose Latin letters are pinned to US positions on purpose, which the
+// fidelity walk would misread as combos landing on the wrong keys.
+const pinnedLayouts = new Set(['linuxRussian', 'russian']);
+
 const keyboardLayouts: Record<string, NativeKeyboardLayout | null> = {
   azerty: azertyLayout,
   dvorak: dvorakLayout,
   german: germanLayout,
+  linuxRussian: linuxRussianLayout,
   none: null,
   partialLatin: partialLatinLayout,
   programmerDvorak: programmerDvorakLayout,

--- a/core/__tests__/keymap.test.ts
+++ b/core/__tests__/keymap.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { afterEach, expect, test, vi } from 'vite-plus/test';
-import { loadKeyboardLayout, resetKeyboardLayout } from '../config/keyboard-layout.ts';
+import { applyKeyboardLayout, resetKeyboardLayout } from '../config/keyboard-layout.ts';
 import { matchesShortcut } from '../config/keymap.ts';
 import type { CodiffKeymap } from '../config/types.ts';
 
@@ -286,10 +286,10 @@ test('does not fall back to the physical key for shortcuts without Alt', () => {
   expect(matched).toBe(false);
 });
 
-test('resolves an Alt shortcut to the key that produces its character on this layout', async () => {
+test('resolves an Alt shortcut to the key that produces its character on this layout', () => {
   // Arrange: QWERTZ types "z" on the key US keyboards label "y".
   const { keydown, keymap } = createTestContext();
-  await withKeyboardLayout({ KeyY: 'z', KeyZ: 'y' });
+  withKeyboardLayout({ KeyY: 'z', KeyZ: 'y' });
 
   // Act
   const matched = matchesShortcut(
@@ -302,10 +302,10 @@ test('resolves an Alt shortcut to the key that produces its character on this la
   expect(matched).toBe(true);
 });
 
-test('does not resolve an Alt shortcut to the US position on a layout that moved it', async () => {
+test('does not resolve an Alt shortcut to the US position on a layout that moved it', () => {
   // Arrange
   const { keydown, keymap } = createTestContext();
-  await withKeyboardLayout({ KeyY: 'z', KeyZ: 'y' });
+  withKeyboardLayout({ KeyY: 'z', KeyZ: 'y' });
 
   // Act: this key types "y" on QWERTZ, so it must not toggle word wrap.
   const matched = matchesShortcut(
@@ -318,10 +318,10 @@ test('does not resolve an Alt shortcut to the US position on a layout that moved
   expect(matched).toBe(false);
 });
 
-test('resolves an Alt shortcut to a punctuation key when the layout puts a letter there', async () => {
+test('resolves an Alt shortcut to a punctuation key when the layout puts a letter there', () => {
   // Arrange: Dvorak types "z" on the key US keyboards label "/".
   const { keydown, keymap } = createTestContext();
-  await withKeyboardLayout({ KeyZ: ';', Slash: 'z' });
+  withKeyboardLayout({ KeyZ: ';', Slash: 'z' });
 
   // Act
   const matched = matchesShortcut(
@@ -334,7 +334,7 @@ test('resolves an Alt shortcut to a punctuation key when the layout puts a lette
   expect(matched).toBe(true);
 });
 
-test('keeps shifted Alt shortcuts on US key positions', async () => {
+test('keeps shifted Alt shortcuts on US key positions', () => {
   // Arrange: the keyboard map reports unmodified characters only, so a shifted
   // spelling has no layout answer. Resolving "z" through the layout and "?"
   // through the US table would otherwise put both on Dvorak's Slash key.
@@ -342,7 +342,7 @@ test('keeps shifted Alt shortcuts on US key positions', async () => {
     commandBar: 'Alt+Shift+z',
     toggleWordWrap: 'Alt+Shift+?',
   });
-  await withKeyboardLayout({ KeyZ: ';', Slash: 'z' });
+  withKeyboardLayout({ KeyZ: ';', Slash: 'z' });
   const event = keydown({ altKey: true, code: 'Slash', key: '¿', shiftKey: true });
 
   // Act
@@ -355,10 +355,10 @@ test('keeps shifted Alt shortcuts on US key positions', async () => {
   expect(matched).toEqual({ commandBar: false, toggleWordWrap: true });
 });
 
-test('resolves a letter shortcut to its US position on a layout that types no Latin', async () => {
+test('resolves a letter shortcut to its US position on a layout that types no Latin', () => {
   // Arrange
   const { keydown, keymap } = createTestContext();
-  await withKeyboardLayout({ KeyA: 'ф', KeyZ: 'я' });
+  withKeyboardLayout({ KeyA: 'ф', KeyZ: 'я' });
 
   // Act
   const matched = matchesShortcut(
@@ -371,12 +371,12 @@ test('resolves a letter shortcut to its US position on a layout that types no La
   expect(matched).toBe(true);
 });
 
-test('does not fire an Alt shortcut whose character the layout cannot type', async () => {
+test('does not fire an Alt shortcut whose character the layout cannot type', () => {
   // Arrange: German types "-" where US keyboards have "/", and reaches "/"
   // only through Shift. Falling back to the US position would fire this on the
   // key that types "-", which already answers to `Alt+-`.
   const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+/' });
-  await withKeyboardLayout({ Minus: 'ß', Slash: '-' });
+  withKeyboardLayout({ Minus: 'ß', Slash: '-' });
 
   // Act
   const matched = matchesShortcut(
@@ -405,7 +405,7 @@ test('falls back to the US position while no layout has been read', () => {
   expect(matched).toBe(true);
 });
 
-test('never lets two shortcut combos claim the same key', async () => {
+test('never lets two shortcut combos claim the same key', () => {
   // Arrange: one key must answer to at most one spelling, or a single keypress
   // fires two actions and which one wins is down to the order the app happens
   // to check them in. Resolution has three sources, and this walks every
@@ -415,7 +415,7 @@ test('never lets two shortcut combos claim the same key', async () => {
   for (const [name, layout] of Object.entries(keyboardLayouts)) {
     resetKeyboardLayout();
     if (layout !== null) {
-      await withKeyboardLayout(layout);
+      withKeyboardLayout(layout);
     }
 
     // Act
@@ -482,13 +482,12 @@ function createTestContext({
   return { keydown, keymap };
 }
 
-async function withKeyboardLayout(layout: Record<string, string>) {
-  Object.defineProperty(navigator, 'keyboard', {
-    configurable: true,
-    value: { getLayoutMap: () => Promise.resolve(new Map(Object.entries(layout))) },
-  });
-
-  await loadKeyboardLayout();
+function withKeyboardLayout(layout: Record<string, string>) {
+  applyKeyboardLayout(
+    Object.fromEntries(
+      Object.entries(layout).map(([code, value]) => [code, { value, withShift: '' }]),
+    ),
+  );
 }
 
 // A character from the Unicode private use area: no keyboard produces it and no

--- a/core/__tests__/keymap.test.ts
+++ b/core/__tests__/keymap.test.ts
@@ -230,10 +230,11 @@ test('accepts the unshifted spelling of a shifted keystroke', () => {
 });
 
 test('matches a shifted spelling written by the key it sits on', () => {
-  // Arrange: `Mod+Shift+/` names the keystroke that types "?", with and
-  // without a layout to consult.
+  // Arrange: `Mod+Shift+/` names the "/" key with Shift held, whose keystroke
+  // types "?". Reading a spelling as a key name takes a layout; before one
+  // arrives the spelling keeps meaning the character as written.
   const { keydown, keymap } = createTestContext({ diffSearch: 'Mod+Shift+/' });
-  const event = keydown({ key: '?', metaKey: true, shiftKey: true });
+  const event = keydown({ code: 'Slash', key: '?', metaKey: true, shiftKey: true });
 
   // Act
   const noLayout = matchesShortcut(event, keymap, 'diffSearch');
@@ -241,7 +242,7 @@ test('matches a shifted spelling written by the key it sits on', () => {
   const withLayout = matchesShortcut(event, keymap, 'diffSearch');
 
   // Assert
-  expect({ noLayout, withLayout }).toEqual({ noLayout: true, withLayout: true });
+  expect({ noLayout, withLayout }).toEqual({ noLayout: false, withLayout: true });
 });
 
 test('follows the layout when a spelling is written by its key', () => {
@@ -253,12 +254,12 @@ test('follows the layout when a spelling is written by its key', () => {
   // Act
   const matched = {
     ampersand: matchesShortcut(
-      keydown({ key: '&', metaKey: true, shiftKey: true }),
+      keydown({ code: 'Digit6', key: '&', metaKey: true, shiftKey: true }),
       keymap,
       'diffSearch',
     ),
     slash: matchesShortcut(
-      keydown({ key: '/', metaKey: true, shiftKey: true }),
+      keydown({ code: 'Digit7', key: '/', metaKey: true, shiftKey: true }),
       keymap,
       'diffSearch',
     ),
@@ -300,6 +301,65 @@ test('resolves a digit the layout reaches only through Shift to its real key', (
     movedKey: true,
     usKey: false,
   });
+});
+
+test('does not let a key spelling match its character on a different key', () => {
+  // Arrange: two keys type "?" with Shift. `Mod+Shift+/` names the "/" key,
+  // so the "?" typed on the other key must not fire it, or one keypress would
+  // fire two different actions.
+  const { keydown, keymap } = createTestContext({
+    commandBar: 'Mod+Shift+/',
+    toggleSidebar: 'Mod+Shift+?',
+  });
+  applyKeyboardLayout({
+    KeyQ: { value: 'q', withShift: 'Q' },
+    Semicolon: { value: ';', withShift: '?' },
+    Slash: { value: '/', withShift: '?' },
+  });
+  const onSemicolon = keydown({ code: 'Semicolon', key: '?', metaKey: true, shiftKey: true });
+  const onSlash = keydown({ code: 'Slash', key: '?', metaKey: true, shiftKey: true });
+
+  // Act
+  const matched = {
+    semicolonQuestion: matchesShortcut(onSemicolon, keymap, 'toggleSidebar'),
+    semicolonSlash: matchesShortcut(onSemicolon, keymap, 'commandBar'),
+    slashQuestion: matchesShortcut(onSlash, keymap, 'toggleSidebar'),
+    slashSlash: matchesShortcut(onSlash, keymap, 'commandBar'),
+  };
+
+  // Assert: the character spelling matches wherever "?" is typed; the key
+  // spelling only on the key it names.
+  expect(matched).toEqual({
+    semicolonQuestion: true,
+    semicolonSlash: false,
+    slashQuestion: true,
+    slashSlash: true,
+  });
+});
+
+test('keeps character semantics for shifted spellings when no layout has arrived', () => {
+  // Arrange: without a layout there is no saying which key a spelling names,
+  // so `Mod+Shift+/` keeps meaning the keystroke that types "/", exactly as it
+  // did before layouts were consulted at all. On a German keyboard that is
+  // Shift+7, and the keystroke typing "?" is someone else's.
+  const { keydown, keymap } = createTestContext({ diffSearch: 'Mod+Shift+/' });
+
+  // Act
+  const matched = {
+    question: matchesShortcut(
+      keydown({ code: 'Slash', key: '?', metaKey: true, shiftKey: true }),
+      keymap,
+      'diffSearch',
+    ),
+    slash: matchesShortcut(
+      keydown({ code: 'Digit7', key: '/', metaKey: true, shiftKey: true }),
+      keymap,
+      'diffSearch',
+    ),
+  };
+
+  // Assert
+  expect(matched).toEqual({ question: false, slash: true });
 });
 
 test('keeps a shifted spelling on the key that really types it when it appears in both columns', () => {
@@ -395,7 +455,8 @@ test('lands a key spelling on the key it names when its shifted character lives 
 
 test('gives the combo delimiter character a spelling through Shift+=', () => {
   // Arrange: `+` separates the parts of a combo, so the keystroke that types
-  // it can only be named by the key it sits on.
+  // it can only be named by the key it sits on, and reading a spelling as a
+  // key name takes a layout.
   const { keydown, keymap } = createTestContext({ toggleWordWrap: 'Alt+Shift+=' });
   const event = keydown({ altKey: true, code: 'Equal', key: '±', shiftKey: true });
 
@@ -405,7 +466,7 @@ test('gives the combo delimiter character a spelling through Shift+=', () => {
   const withLayout = matchesShortcut(event, keymap, 'toggleWordWrap');
 
   // Assert
-  expect({ noLayout, withLayout }).toEqual({ noLayout: true, withLayout: true });
+  expect({ noLayout, withLayout }).toEqual({ noLayout: false, withLayout: true });
 });
 
 test('does not let shifted and unshifted punctuation on one key collide', () => {
@@ -425,8 +486,9 @@ test('does not let shifted and unshifted punctuation on one key collide', () => 
 });
 
 test('treats a shifted digit and the character it types as one chord', () => {
-  // Arrange: on a US keyboard Shift+1 and "!" are the same keystroke, so both
-  // spellings describe it and both fire.
+  // Arrange: on a US layout Shift+1 and "!" are the same keystroke, so once
+  // the layout says so both spellings describe it and both fire. Before a
+  // layout arrives only the character spelling resolves.
   const { keydown, keymap } = createTestContext({
     commandBar: 'Alt+Shift+1',
     toggleWordWrap: 'Alt+Shift+!',
@@ -434,13 +496,21 @@ test('treats a shifted digit and the character it types as one chord', () => {
   const event = keydown({ altKey: true, code: 'Digit1', key: '⁄', shiftKey: true });
 
   // Act
-  const matched = {
-    commandBar: matchesShortcut(event, keymap, 'commandBar'),
-    toggleWordWrap: matchesShortcut(event, keymap, 'toggleWordWrap'),
+  const noLayout = {
+    digit: matchesShortcut(event, keymap, 'commandBar'),
+    exclamation: matchesShortcut(event, keymap, 'toggleWordWrap'),
+  };
+  applyKeyboardLayout(usLayout);
+  const withLayout = {
+    digit: matchesShortcut(event, keymap, 'commandBar'),
+    exclamation: matchesShortcut(event, keymap, 'toggleWordWrap'),
   };
 
   // Assert
-  expect(matched).toEqual({ commandBar: true, toggleWordWrap: true });
+  expect({ noLayout, withLayout }).toEqual({
+    noLayout: { digit: false, exclamation: true },
+    withLayout: { digit: true, exclamation: true },
+  });
 });
 
 test('lets a binding on the composed character itself suppress the position fallback', () => {
@@ -711,6 +781,63 @@ test('resolves every combo to a key that really types its character', () => {
   expect(wrongKeys).toEqual([]);
 });
 
+test('never lets one keystroke type its way into two different shortcut combos', () => {
+  // Arrange: the walks above press keys whose character nothing names, which
+  // is the Alt fallback path. This one types the character each keystroke
+  // really produces, the path every other shortcut matches on, where a key
+  // spelling loose from its key would collide with the character typed
+  // elsewhere. Without a layout the matcher still faces a real keyboard; a US
+  // one stands in.
+  const collisions: Array<string> = [];
+
+  for (const [name, layout] of Object.entries(keyboardLayouts)) {
+    resetKeyboardLayout();
+    if (layout !== null) {
+      applyKeyboardLayout(layout);
+    }
+    const keys = layout ?? usLayout;
+
+    // Act
+    for (const [code, mapping] of Object.entries(keys)) {
+      for (const shiftKey of [false, true]) {
+        const character = shiftKey ? mapping.withShift : mapping.value;
+        if (character.length === 1) {
+          const matched = comboSpellings.filter((spelling) =>
+            matchesTypedSpelling(spelling, { code, key: character, shiftKey }),
+          );
+          for (let first = 0; first < matched.length; first++) {
+            for (let second = first + 1; second < matched.length; second++) {
+              if (!describesOneKeystroke(matched[first], matched[second], code, shiftKey, layout)) {
+                collisions.push(
+                  `${name}: typing "${character}" on ${code} matches "${matched[first]}" and "${matched[second]}"`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Assert
+  expect(collisions).toEqual([]);
+});
+
+function matchesTypedSpelling(
+  spelling: string,
+  press: { code: string; key: string; shiftKey: boolean },
+): boolean {
+  const { keydown, keymap } = createTestContext({
+    toggleWordWrap: `Mod+${press.shiftKey ? 'Shift+' : ''}${spelling}`,
+  });
+
+  return matchesShortcut(
+    keydown({ code: press.code, key: press.key, metaKey: true, shiftKey: press.shiftKey }),
+    keymap,
+    'toggleWordWrap',
+  );
+}
+
 function collect(
   wrongKeys: Array<string>,
   name: string,
@@ -958,12 +1085,21 @@ const bothColumnOverlapLayout: NativeKeyboardLayout = {
   KeyQ: { value: 'q', withShift: 'Q' },
 };
 
+// Two keys typing one character with Shift, which is where a key spelling
+// loose from its key would follow the character to the wrong keystroke.
+const duplicateShiftedLayout: NativeKeyboardLayout = {
+  KeyQ: { value: 'q', withShift: 'Q' },
+  Semicolon: { value: ';', withShift: '?' },
+  Slash: { value: '/', withShift: '?' },
+};
+
 // Layouts whose Latin letters are pinned to US positions on purpose, which the
 // fidelity walk would misread as combos landing on the wrong keys.
 const pinnedLayouts = new Set(['linuxRussian', 'russian']);
 
 const keyboardLayouts: Record<string, NativeKeyboardLayout | null> = {
   azerty: azertyLayout,
+  duplicateShifted: duplicateShiftedLayout,
   dvorak: dvorakLayout,
   german: germanLayout,
   linuxRussian: linuxRussianLayout,

--- a/core/__tests__/keymap.test.ts
+++ b/core/__tests__/keymap.test.ts
@@ -405,7 +405,7 @@ test('falls back to the US position while no layout has been read', () => {
   expect(matched).toBe(true);
 });
 
-test('never lets two shortcut spellings claim the same key', async () => {
+test('never lets two shortcut combos claim the same key', async () => {
   // Arrange: one key must answer to at most one spelling, or a single keypress
   // fires two actions and which one wins is down to the order the app happens
   // to check them in. Resolution has three sources, and this walks every
@@ -543,6 +543,17 @@ const keyboardLayouts: Record<string, Record<string, string> | null> = {
   dvorak: layoutFromRows(['`1234567890[]', "',.pyfgcrl/=\\", 'aoeuidhtns-', ';qjkxbmwvz']),
   german: layoutFromRows(['^1234567890ß´', 'qwertzuiopü+#', 'asdfghjklöä', 'yxcvbnm,.-']),
   none: null,
+  // Types most of the alphabet but not all of it, which is where filling in the
+  // missing letters one at a time would take a key from one that is there.
+  partialLatin: layoutFromRows(['`1234567890-=', 'ąwertyuiop[]\\', "asdfghjkl;'", 'zxcvbnm,./']),
+  // Puts symbols on the number row and reaches the digits through Shift, so
+  // assuming the US number row would resolve them to the wrong keys.
+  programmerDvorak: layoutFromRows([
+    '$&[{}(=*)+]!#',
+    ';,.pyfgcrl/@\\',
+    'aoeuidhtns-',
+    "'qjkxbmwvz",
+  ]),
   russian: layoutFromRows([']1234567890-=', 'йцукенгшщзхъё', 'фывапролджэ', 'ячсмитьбю.']),
   us: layoutFromRows(['`1234567890-=', 'qwertyuiop[]\\', "asdfghjkl;'", 'zxcvbnm,./']),
 };

--- a/core/config/keyboard-layout.ts
+++ b/core/config/keyboard-layout.ts
@@ -1,0 +1,166 @@
+// Where each character sits on the keyboard the user is actually typing on.
+//
+// `Alt` shortcuts need this. macOS composes the character away when Option is
+// held (Option+Z types "Ω"), so the key position is the only thing left to
+// match a combo against, and which key produces "z" depends on the layout: on
+// QWERTZ it is the key US keyboards label "y", on Dvorak the one they label
+// "/". `navigator.keyboard.getLayoutMap()` answers that, but only
+// asynchronously and only for unmodified characters, so it is read here and
+// cached for the synchronous matcher in `keymap.ts`.
+
+type KeyboardLayoutSource = {
+  getLayoutMap?: () => Promise<ReadonlyMap<string, string>>;
+};
+
+const letters = 'abcdefghijklmnopqrstuvwxyz';
+const digits = '0123456789';
+
+// Keyed by character, so a combo naming "z" can find its key.
+let characterToCode: ReadonlyMap<string, string> | null = null;
+// The layout exactly as reported, used to notice that it changed.
+let codeToCharacter: ReadonlyMap<string, string> | null = null;
+let reading: Promise<void> | null = null;
+let watching = false;
+
+export const codeForCharacter = (character: string): string | null =>
+  characterToCode?.get(character) ?? null;
+
+export const hasKeyboardLayout = (): boolean => characterToCode !== null;
+
+// Starts the app tracking the layout. Callers do not wait for it: until the
+// first read lands `hasKeyboardLayout()` is false and `keymap.ts` resolves
+// combos against its US tables, which is where every platform without this API
+// stays permanently.
+export const trackKeyboardLayout = (): void => {
+  if (!watching) {
+    watching = true;
+    window.addEventListener('focus', handleFocus);
+    window.addEventListener('keydown', handleKeyDown, { capture: true, passive: true });
+  }
+
+  void loadKeyboardLayout();
+};
+
+export const loadKeyboardLayout = (): Promise<void> => {
+  reading ??= readLayout().finally(() => {
+    reading = null;
+  });
+
+  return reading;
+};
+
+export const resetKeyboardLayout = (): void => {
+  characterToCode = null;
+  codeToCharacter = null;
+  reading = null;
+
+  if (watching) {
+    watching = false;
+    window.removeEventListener('focus', handleFocus);
+    window.removeEventListener('keydown', handleKeyDown, { capture: true });
+  }
+};
+
+const readLayout = async (): Promise<void> => {
+  const keyboard = (navigator as Navigator & { keyboard?: KeyboardLayoutSource }).keyboard;
+  if (!keyboard?.getLayoutMap) {
+    clearLayout();
+    return;
+  }
+
+  try {
+    const layout = await keyboard.getLayoutMap();
+    // A window with no keyboard attached to it reports zero keys. That is a
+    // missing answer, not a keyboard that produces nothing, so keep waiting for
+    // a real one instead of caching it.
+    if (layout.size === 0) {
+      clearLayout();
+      return;
+    }
+
+    codeToCharacter = new Map(layout);
+    characterToCode = byCharacter(withLatinFallbacks(layout));
+  } catch {
+    // Platforms without the API and non-secure contexts reject. The US tables
+    // cover both.
+    clearLayout();
+  }
+};
+
+const clearLayout = (): void => {
+  characterToCode = null;
+  codeToCharacter = null;
+};
+
+// Latin letters and digits every layout can reach, at the position US
+// keyboards put them.
+//
+// A Cyrillic, Greek, Arabic or Hebrew layout produces no Latin letters, which
+// would leave every letter shortcut with no key to match and silently dead.
+// Digits are a milder version of the same problem: AZERTY types them only with
+// Shift held, and the keyboard map reports unmodified characters only.
+//
+// Each missing character replaces whatever the layout put on that key rather
+// than being added alongside it, so one position still produces one character
+// and two combo spellings can never claim the same key. VS Code does the same
+// thing with the richer per-key data `native-keymap` gives it.
+const withLatinFallbacks = (layout: ReadonlyMap<string, string>): Map<string, string> => {
+  const produced = new Set(layout.values());
+  const result = new Map(layout);
+
+  for (const letter of letters) {
+    if (!produced.has(letter)) {
+      result.set(`Key${letter.toUpperCase()}`, letter);
+    }
+  }
+  for (const digit of digits) {
+    if (!produced.has(digit)) {
+      result.set(`Digit${digit}`, digit);
+    }
+  }
+
+  return result;
+};
+
+// A layout may put one character on two keys. The first one wins so that a
+// character always names a single key and the answer does not drift between
+// reads.
+const byCharacter = (layout: ReadonlyMap<string, string>): ReadonlyMap<string, string> => {
+  const result = new Map<string, string>();
+
+  for (const [code, character] of layout) {
+    if (!result.has(character)) {
+      result.set(character, code);
+    }
+  }
+
+  return result;
+};
+
+const handleFocus = (): void => {
+  void loadKeyboardLayout();
+};
+
+// Chromium reports no layout change event, and `navigator.keyboard` is not even
+// an `EventTarget`, so switching input source has to be inferred. A keypress
+// that reports a character the cached layout does not put on that key is proof
+// the layout moved. Modifiers, dead keys and Caps Lock all report something
+// other than the key's plain character, so only an unmodified press counts.
+const handleKeyDown = (event: KeyboardEvent): void => {
+  if (
+    codeToCharacter === null ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey ||
+    event.key.length !== 1 ||
+    event.getModifierState('CapsLock')
+  ) {
+    return;
+  }
+
+  const character = codeToCharacter.get(event.code);
+  if (character !== undefined && character !== event.key) {
+    void loadKeyboardLayout();
+  }
+};

--- a/core/config/keyboard-layout.ts
+++ b/core/config/keyboard-layout.ts
@@ -48,9 +48,17 @@ export const trackKeyboardLayout = (): void => {
 };
 
 export const loadKeyboardLayout = (): Promise<void> => {
-  reading ??= readLayout().finally(() => {
-    reading = null;
-  });
+  if (reading === null) {
+    // Only the read that still holds the slot may give it up. A read abandoned
+    // by a reset finishes eventually, and clearing the slot then would let a
+    // third read start alongside the one that replaced it.
+    const pending: Promise<void> = readLayout().finally(() => {
+      if (reading === pending) {
+        reading = null;
+      }
+    });
+    reading = pending;
+  }
 
   return reading;
 };

--- a/core/config/keyboard-layout.ts
+++ b/core/config/keyboard-layout.ts
@@ -13,7 +13,9 @@ type KeyboardLayoutSource = {
 };
 
 const letters = 'abcdefghijklmnopqrstuvwxyz';
-const digits = '0123456789';
+// How long a keypress that disagrees with the layout waits before another one
+// may ask for a fresh read.
+const rereadInterval = 2000;
 
 // Keyed by character, so a combo naming "z" can find its key.
 let characterToCode: ReadonlyMap<string, string> | null = null;
@@ -24,6 +26,7 @@ let watching = false;
 // Bumped by every reset, so a read that was already in flight cannot land
 // afterwards and put the layout back.
 let generation = 0;
+let lastRereadAt = Number.NEGATIVE_INFINITY;
 
 export const codeForCharacter = (character: string): string | null =>
   characterToCode?.get(character) ?? null;
@@ -56,6 +59,7 @@ export const resetKeyboardLayout = (): void => {
   characterToCode = null;
   codeToCharacter = null;
   reading = null;
+  lastRereadAt = Number.NEGATIVE_INFINITY;
   generation++;
 
   if (watching) {
@@ -69,64 +73,54 @@ const readLayout = async (): Promise<void> => {
   const startedAt = generation;
   const keyboard = (navigator as Navigator & { keyboard?: KeyboardLayoutSource }).keyboard;
   if (!keyboard?.getLayoutMap) {
-    clearLayout();
     return;
   }
 
   try {
     const layout = await keyboard.getLayoutMap();
-    if (startedAt !== generation) {
-      return;
-    }
-    // A window with no keyboard attached to it reports zero keys. That is a
-    // missing answer, not a keyboard that produces nothing, so keep waiting for
-    // a real one instead of caching it.
-    if (layout.size === 0) {
-      clearLayout();
+    // A window with no keyboard attached to it reports zero keys, and a
+    // non-secure context rejects outright. Both are missing answers rather than
+    // news about the keyboard, so whatever is already known survives them; at
+    // startup that is nothing, which is the same as failing outright.
+    if (startedAt !== generation || layout.size === 0) {
       return;
     }
 
     codeToCharacter = new Map(layout);
-    characterToCode = byCharacter(withLatinFallbacks(layout));
+    characterToCode = byCharacter(withLatinLetters(layout));
   } catch {
-    // Platforms without the API and non-secure contexts reject. The US tables
-    // cover both.
-    if (startedAt === generation) {
-      clearLayout();
-    }
+    // Platforms without the API reject too. The US tables cover them.
   }
 };
 
-const clearLayout = (): void => {
-  characterToCode = null;
-  codeToCharacter = null;
-};
-
-// Latin letters and digits every layout can reach, at the position US
-// keyboards put them.
+// Latin letters at the positions US keyboards put them, for a layout that types
+// none of its own.
 //
-// A Cyrillic, Greek, Arabic or Hebrew layout produces no Latin letters, which
-// would leave every letter shortcut with no key to match and silently dead.
-// Digits are a milder version of the same problem: AZERTY types them only with
-// Shift held, and the keyboard map reports unmodified characters only.
+// Cyrillic, Greek, Arabic and Hebrew layouts produce no Latin at all, so every
+// letter shortcut would have no key to match and would silently stop working,
+// including the `Alt+z` Codiff ships. Each letter replaces whatever the layout
+// put on that key rather than being added alongside it, so one position still
+// produces one character and two combo spellings can never claim the same key.
 //
-// Each missing character replaces whatever the layout put on that key rather
-// than being added alongside it, so one position still produces one character
-// and two combo spellings can never claim the same key. VS Code does the same
-// thing with the richer per-key data `native-keymap` gives it.
-const withLatinFallbacks = (layout: ReadonlyMap<string, string>): Map<string, string> => {
+// It is all or nothing on purpose. Filling in individual letters would take a
+// key away from a character the layout really does type there, so a layout that
+// types most of the alphabet is left exactly as it reported itself. Digits get
+// no such treatment at all: AZERTY reaches them only with Shift, which the
+// keyboard map does not report, and while assuming the US number row would be
+// right there, it would be wrong on Programmer Dvorak, which moves the digits.
+// Naming the character the key actually types works on both.
+//
+// VS Code fills in missing letters the same way, per letter rather than all at
+// once, because `native-keymap` gives it the shifted values to disambiguate.
+const withLatinLetters = (layout: ReadonlyMap<string, string>): ReadonlyMap<string, string> => {
   const produced = new Set(layout.values());
-  const result = new Map(layout);
-
-  for (const letter of letters) {
-    if (!produced.has(letter)) {
-      result.set(`Key${letter.toUpperCase()}`, letter);
-    }
+  if ([...letters].some((letter) => produced.has(letter))) {
+    return layout;
   }
-  for (const digit of digits) {
-    if (!produced.has(digit)) {
-      result.set(`Digit${digit}`, digit);
-    }
+
+  const result = new Map(layout);
+  for (const letter of letters) {
+    result.set(`Key${letter.toUpperCase()}`, letter);
   }
 
   return result;
@@ -153,9 +147,13 @@ const handleFocus = (): void => {
 
 // Chromium reports no layout change event, and `navigator.keyboard` is not even
 // an `EventTarget`, so switching input source has to be inferred. A keypress
-// that reports a character the cached layout does not put on that key is proof
-// the layout moved. Modifiers, dead keys and Caps Lock all report something
-// other than the key's plain character, so only an unmodified press counts.
+// that reports a character the cached layout does not put on that key says the
+// layout moved. Modifiers, dead keys and Caps Lock all report something other
+// than the key's plain character, so only an unmodified press counts.
+//
+// Some disagreements never resolve, because remapping software can rewrite what
+// a key reports without the layout knowing. Those must not turn every keystroke
+// into another read, so a disagreement only asks once every `rereadInterval`.
 const handleKeyDown = (event: KeyboardEvent): void => {
   if (
     codeToCharacter === null ||
@@ -164,13 +162,15 @@ const handleKeyDown = (event: KeyboardEvent): void => {
     event.metaKey ||
     event.shiftKey ||
     event.key.length !== 1 ||
-    event.getModifierState('CapsLock')
+    event.getModifierState('CapsLock') ||
+    performance.now() - lastRereadAt < rereadInterval
   ) {
     return;
   }
 
   const character = codeToCharacter.get(event.code);
   if (character !== undefined && character !== event.key) {
+    lastRereadAt = performance.now();
     void loadKeyboardLayout();
   }
 };

--- a/core/config/keyboard-layout.ts
+++ b/core/config/keyboard-layout.ts
@@ -105,6 +105,14 @@ export const trackKeyboardLayout = (): void => {
 };
 
 export const applyKeyboardLayout = (layout: NativeKeyboardLayout): void => {
+  // A layout with nothing usable on it is a missing answer, not a keyboard
+  // that types nothing: the shell validates its reads, but this data crosses
+  // the IPC boundary, and applying an empty answer would erase a good layout
+  // or pin letters onto a keyboard that was never read.
+  if (!hasUsableKey(layout)) {
+    return;
+  }
+
   const withLetters = withLatinLetters(layout);
   const nextUnshifted = new Map<string, string>();
   const nextShifted = new Map<string, string>();
@@ -173,6 +181,16 @@ const withLatinLetters = (layout: NativeKeyboardLayout): NativeKeyboardLayout =>
   return result;
 };
 
+const hasUsableKey = (layout: NativeKeyboardLayout): boolean =>
+  writingSystemCodes.some((code) => {
+    const mapping = layout[code];
+    return (
+      mapping !== undefined &&
+      (usableCharacter(mapping.value, mapping.valueIsDeadKey) !== null ||
+        usableCharacter(mapping.withShift, mapping.withShiftIsDeadKey) !== null)
+    );
+  });
+
 const isLatinLetter = (value: string, isDeadKey: boolean | undefined): boolean => {
   const character = usableCharacter(value, isDeadKey);
   return character !== null && letters.includes(character);
@@ -182,9 +200,10 @@ const isLatinLetter = (value: string, isDeadKey: boolean | undefined): boolean =
 // composition rather than typing, named keys like Enter report empty strings,
 // and matching is case-insensitive so a Shift column's "Z" answers to the
 // spelling "z". A character whose lowercase form is longer than itself, like
-// "İ", keeps its own spelling.
+// "İ", keeps its own spelling. The typeof check guards the IPC boundary: a
+// mapping this module never promised must not take the matcher down.
 const usableCharacter = (value: string, isDeadKey: boolean | undefined): string | null => {
-  if (isDeadKey || value.length !== 1) {
+  if (isDeadKey || typeof value !== 'string' || value.length !== 1) {
     return null;
   }
 

--- a/core/config/keyboard-layout.ts
+++ b/core/config/keyboard-layout.ts
@@ -4,194 +4,190 @@
 // held (Option+Z types "Ω"), so the key position is the only thing left to
 // match a combo against, and which key produces "z" depends on the layout: on
 // QWERTZ it is the key US keyboards label "y", on Dvorak the one they label
-// "/". `navigator.keyboard.getLayoutMap()` answers that, but only
-// asynchronously and only for unmodified characters, so it is read here and
-// cached for the synchronous matcher in `keymap.ts`.
+// "/". The Electron main process reads the layout with `native-keymap`, which
+// reports what every key types plain and with Shift held and announces layout
+// switches, and hands it to this cache over IPC for the synchronous matcher in
+// `keymap.ts`. Outside the desktop shell (the web build, tests) no layout ever
+// arrives and the matcher stays on its US tables.
 
-type KeyboardLayoutSource = {
-  getLayoutMap?: () => Promise<ReadonlyMap<string, string>>;
+export type NativeKeyboardKeyMapping = {
+  value: string;
+  valueIsDeadKey?: boolean;
+  withShift: string;
+  withShiftIsDeadKey?: boolean;
+};
+
+export type NativeKeyboardLayout = Readonly<Record<string, NativeKeyboardKeyMapping>>;
+
+type KeyboardLayoutShell = {
+  getKeyboardLayout: () => Promise<NativeKeyboardLayout | null>;
+  onKeyboardLayoutChanged: (callback: (layout: NativeKeyboardLayout) => void) => () => void;
 };
 
 const letters = 'abcdefghijklmnopqrstuvwxyz';
-// How long a keypress that disagrees with the layout waits before another one
-// may ask for a fresh read.
-const rereadInterval = 2000;
 
-// Keyed by character, so a combo naming "z" can find its key.
-let characterToCode: ReadonlyMap<string, string> | null = null;
-// The layout exactly as reported, used to notice that it changed.
-let codeToCharacter: ReadonlyMap<string, string> | null = null;
-let reading: Promise<void> | null = null;
-let watching = false;
-// Bumped by every reset, so a read that was already in flight cannot land
+// The keys a layout redraws, in the order a character appearing twice is
+// claimed: letters, then digits, then punctuation in row order. Everything
+// else (Numpad, Space, Enter, function keys) never answers for a character a
+// combo can name.
+const writingSystemCodes = [
+  ...[...letters].map((letter) => `Key${letter.toUpperCase()}`),
+  ...'1234567890'.split('').map((digit) => `Digit${digit}`),
+  'Backquote',
+  'Minus',
+  'Equal',
+  'BracketLeft',
+  'BracketRight',
+  'Backslash',
+  'Semicolon',
+  'Quote',
+  'Comma',
+  'Period',
+  'Slash',
+  'IntlBackslash',
+  'IntlRo',
+  'IntlYen',
+];
+
+// Keyed by character, so a combo naming "z" can find its key. One map per
+// Shift state, because Shift moves punctuation and digits around.
+let unshifted: ReadonlyMap<string, string> | null = null;
+let shifted: ReadonlyMap<string, string> | null = null;
+// Keyed by position, so a spelling like `Shift+/` can find the character that
+// press really types.
+let shiftedByCode: ReadonlyMap<string, string> | null = null;
+let unsubscribe: (() => void) | null = null;
+let sawPushedLayout = false;
+// Bumped by every reset, so a startup read still in flight cannot land
 // afterwards and put the layout back.
 let generation = 0;
-let lastRereadAt = Number.NEGATIVE_INFINITY;
 
-export const codeForCharacter = (character: string): string | null =>
-  characterToCode?.get(character) ?? null;
+export const codeForCharacter = (character: string, shiftKey: boolean): string | null =>
+  (shiftKey ? shifted : unshifted)?.get(character) ?? null;
 
-export const hasKeyboardLayout = (): boolean => characterToCode !== null;
+export const shiftedCharacterForCode = (code: string): string | null =>
+  shiftedByCode?.get(code) ?? null;
 
-// Starts the app tracking the layout. Callers do not wait for it: until the
-// first read lands `hasKeyboardLayout()` is false and `keymap.ts` resolves
-// combos against its US tables, which is where every platform without this API
-// stays permanently.
+export const hasKeyboardLayout = (): boolean => unshifted !== null;
+
+// Starts the renderer tracking the layout the desktop shell reports. Callers
+// do not wait for it: until the first answer lands `hasKeyboardLayout()` is
+// false and `keymap.ts` resolves combos against its US tables, which is where
+// every environment without a shell stays permanently.
 export const trackKeyboardLayout = (): void => {
-  if (!watching) {
-    watching = true;
-    window.addEventListener('focus', handleFocus);
-    window.addEventListener('keydown', handleKeyDown, { capture: true, passive: true });
-  }
-
-  void loadKeyboardLayout();
-};
-
-export const loadKeyboardLayout = (): Promise<void> => {
-  if (reading === null) {
-    // Only the read that still holds the slot may give it up. A read abandoned
-    // by a reset finishes eventually, and clearing the slot then would let a
-    // third read start alongside the one that replaced it.
-    const pending: Promise<void> = readLayout().finally(() => {
-      if (reading === pending) {
-        reading = null;
-      }
-    });
-    reading = pending;
-  }
-
-  return reading;
-};
-
-export const resetKeyboardLayout = (): void => {
-  characterToCode = null;
-  codeToCharacter = null;
-  reading = null;
-  lastRereadAt = Number.NEGATIVE_INFINITY;
-  generation++;
-
-  if (watching) {
-    watching = false;
-    window.removeEventListener('focus', handleFocus);
-    window.removeEventListener('keydown', handleKeyDown, { capture: true });
-  }
-};
-
-const readLayout = async (): Promise<void> => {
-  const startedAt = generation;
-  const keyboard = (navigator as Navigator & { keyboard?: KeyboardLayoutSource }).keyboard;
-  if (!keyboard?.getLayoutMap) {
+  // The web build and the test environment have no desktop shell at all, so
+  // the property is optional here no matter what the global type promises.
+  const shell = (window as unknown as { codiff?: KeyboardLayoutShell }).codiff;
+  if (!shell) {
     return;
   }
 
-  try {
-    const layout = await keyboard.getLayoutMap();
-    // A window with no keyboard attached to it reports zero keys, and a
-    // non-secure context rejects outright. Both are missing answers rather than
-    // news about the keyboard, so whatever is already known survives them; at
-    // startup that is nothing, which is the same as failing outright.
-    if (startedAt !== generation || layout.size === 0) {
-      return;
-    }
-
-    codeToCharacter = new Map(layout);
-    characterToCode = byCharacter(withLatinLetters(layout));
-  } catch {
-    // Platforms without the API reject too. The US tables cover them.
+  if (unsubscribe === null) {
+    unsubscribe = shell.onKeyboardLayoutChanged((layout) => {
+      sawPushedLayout = true;
+      applyKeyboardLayout(layout);
+    });
   }
+
+  const startedAt = generation;
+  shell.getKeyboardLayout().then(
+    (layout) => {
+      // A layout pushed while this read was on the wire is newer than what the
+      // read answers with, and a reset means nobody wants the answer at all.
+      if (layout && !sawPushedLayout && startedAt === generation) {
+        applyKeyboardLayout(layout);
+      }
+    },
+    () => {
+      // A shell that cannot answer leaves the US tables in charge.
+    },
+  );
 };
 
-// Latin letters at the positions US keyboards put them, for a layout that types
-// none of its own.
+export const applyKeyboardLayout = (layout: NativeKeyboardLayout): void => {
+  const withLetters = withLatinLetters(layout);
+  const nextUnshifted = new Map<string, string>();
+  const nextShifted = new Map<string, string>();
+  const nextShiftedByCode = new Map<string, string>();
+
+  for (const code of writingSystemCodes) {
+    const mapping = withLetters[code];
+    if (mapping) {
+      const value = usableCharacter(mapping.value, mapping.valueIsDeadKey);
+      const withShift = usableCharacter(mapping.withShift, mapping.withShiftIsDeadKey);
+      if (value !== null && !nextUnshifted.has(value)) {
+        nextUnshifted.set(value, code);
+      }
+      if (withShift !== null) {
+        if (!nextShifted.has(withShift)) {
+          nextShifted.set(withShift, code);
+        }
+        nextShiftedByCode.set(code, withShift);
+      }
+    }
+  }
+
+  unshifted = nextUnshifted;
+  shifted = nextShifted;
+  shiftedByCode = nextShiftedByCode;
+};
+
+export const resetKeyboardLayout = (): void => {
+  unshifted = null;
+  shifted = null;
+  shiftedByCode = null;
+  sawPushedLayout = false;
+  generation++;
+  unsubscribe?.();
+  unsubscribe = null;
+};
+
+// Latin letters at the positions US keyboards put them, for a layout that
+// types none of its own.
 //
 // Cyrillic, Greek, Arabic and Hebrew layouts produce no Latin at all, so every
 // letter shortcut would have no key to match and would silently stop working,
 // including the `Alt+z` Codiff ships. Each letter replaces whatever the layout
-// put on that key rather than being added alongside it, so one position still
-// produces one character and two combo spellings can never claim the same key.
+// put on that key, in both Shift states, so one position still produces one
+// character and two combo spellings can never claim the same key.
 //
 // It is all or nothing on purpose. Filling in one missing letter at a time
 // would take a key away from a character the layout really does type there, so
-// a layout that types most of the alphabet is left exactly as it reported
-// itself. VS Code does fill letters in one at a time, but `native-keymap` gives
-// it the shifted values it needs to tell those cases apart.
-//
-// Digits get no such treatment at all. AZERTY reaches them only with Shift, so
-// the keyboard map does not report them, and assuming the US number row would
-// be right there but wrong on Programmer Dvorak, which moves the digits and
-// puts brackets in their place. Naming the character the key really types works
-// on both.
-const withLatinLetters = (layout: ReadonlyMap<string, string>): ReadonlyMap<string, string> => {
-  const produced = new Set(layout.values());
-  if ([...letters].some((letter) => produced.has(letter))) {
+// a layout that types any Latin anywhere, plain or shifted, is left exactly as
+// it reported itself.
+const withLatinLetters = (layout: NativeKeyboardLayout): NativeKeyboardLayout => {
+  const typesLatin = Object.values(layout).some(
+    (mapping) =>
+      isLatinLetter(mapping.value, mapping.valueIsDeadKey) ||
+      isLatinLetter(mapping.withShift, mapping.withShiftIsDeadKey),
+  );
+  if (typesLatin) {
     return layout;
   }
 
-  const result = new Map(layout);
+  const result: Record<string, NativeKeyboardKeyMapping> = { ...layout };
   for (const letter of letters) {
-    result.set(`Key${letter.toUpperCase()}`, letter);
+    result[`Key${letter.toUpperCase()}`] = { value: letter, withShift: letter.toUpperCase() };
   }
 
   return result;
 };
 
-// A layout may put one character on two keys. The first one wins so that a
-// character always names a single key and the answer does not drift between
-// reads.
-const byCharacter = (layout: ReadonlyMap<string, string>): ReadonlyMap<string, string> => {
-  const result = new Map<string, string>();
-
-  for (const [code, character] of layout) {
-    if (!result.has(character)) {
-      result.set(character, code);
-    }
-  }
-
-  return result;
+const isLatinLetter = (value: string, isDeadKey: boolean | undefined): boolean => {
+  const character = usableCharacter(value, isDeadKey);
+  return character !== null && letters.includes(character);
 };
 
-const handleFocus = (): void => {
-  void loadKeyboardLayout();
-};
-
-// Chromium reports no layout change event, and `navigator.keyboard` is not even
-// an `EventTarget`, so switching input source has to be inferred. A keypress
-// that reports a character the cached layout does not put on that key says the
-// layout moved. Modifiers, dead keys and Caps Lock all report something other
-// than the key's plain character, so only an unmodified press counts.
-//
-// Some disagreements never resolve, because remapping software can rewrite what
-// a key reports without the layout knowing. Those must not turn every keystroke
-// into another read, so a disagreement only asks once every `rereadInterval`.
-const handleKeyDown = (event: KeyboardEvent): void => {
-  if (
-    event.altKey ||
-    event.ctrlKey ||
-    event.metaKey ||
-    event.shiftKey ||
-    event.key.length !== 1 ||
-    event.getModifierState('CapsLock') ||
-    performance.now() - lastRereadAt < rereadInterval ||
-    !isNewsAboutTheLayout(event)
-  ) {
-    return;
+// A key answers for the single printable character it types. Dead keys arm a
+// composition rather than typing, named keys like Enter report empty strings,
+// and matching is case-insensitive so a Shift column's "Z" answers to the
+// spelling "z". A character whose lowercase form is longer than itself, like
+// "İ", keeps its own spelling.
+const usableCharacter = (value: string, isDeadKey: boolean | undefined): string | null => {
+  if (isDeadKey || value.length !== 1) {
+    return null;
   }
 
-  lastRereadAt = performance.now();
-  void loadKeyboardLayout();
-};
-
-// No layout at all means the read came back empty, which a window with no
-// keyboard attached to it does, so any keypress is reason enough to ask again.
-// Once there is one, only a key reporting a character the layout does not have
-// there says anything new; a key the layout never mentioned, such as the space
-// bar, says nothing either way.
-const isNewsAboutTheLayout = (event: KeyboardEvent): boolean => {
-  if (codeToCharacter === null) {
-    return true;
-  }
-
-  const character = codeToCharacter.get(event.code);
-
-  return character !== undefined && character !== event.key;
+  const lower = value.toLowerCase();
+  return lower.length === 1 ? lower : value;
 };

--- a/core/config/keyboard-layout.ts
+++ b/core/config/keyboard-layout.ts
@@ -109,7 +109,7 @@ export const applyKeyboardLayout = (layout: NativeKeyboardLayout): void => {
   // that types nothing: the shell validates its reads, but this data crosses
   // the IPC boundary, and applying an empty answer would erase a good layout
   // or pin letters onto a keyboard that was never read.
-  if (!hasUsableKey(layout)) {
+  if (layout === null || typeof layout !== 'object' || !hasUsableKey(layout)) {
     return;
   }
 
@@ -120,7 +120,7 @@ export const applyKeyboardLayout = (layout: NativeKeyboardLayout): void => {
 
   for (const code of writingSystemCodes) {
     const mapping = withLetters[code];
-    if (mapping) {
+    if (isKeyMapping(mapping)) {
       const value = usableCharacter(mapping.value, mapping.valueIsDeadKey);
       const withShift = usableCharacter(mapping.withShift, mapping.withShiftIsDeadKey);
       if (value !== null && !nextUnshifted.has(value)) {
@@ -166,8 +166,9 @@ export const resetKeyboardLayout = (): void => {
 const withLatinLetters = (layout: NativeKeyboardLayout): NativeKeyboardLayout => {
   const typesLatin = Object.values(layout).some(
     (mapping) =>
-      isLatinLetter(mapping.value, mapping.valueIsDeadKey) ||
-      isLatinLetter(mapping.withShift, mapping.withShiftIsDeadKey),
+      isKeyMapping(mapping) &&
+      (isLatinLetter(mapping.value, mapping.valueIsDeadKey) ||
+        isLatinLetter(mapping.withShift, mapping.withShiftIsDeadKey)),
   );
   if (typesLatin) {
     return layout;
@@ -185,11 +186,15 @@ const hasUsableKey = (layout: NativeKeyboardLayout): boolean =>
   writingSystemCodes.some((code) => {
     const mapping = layout[code];
     return (
-      mapping !== undefined &&
+      isKeyMapping(mapping) &&
       (usableCharacter(mapping.value, mapping.valueIsDeadKey) !== null ||
         usableCharacter(mapping.withShift, mapping.withShiftIsDeadKey) !== null)
     );
   });
+
+// Hostile IPC data may hold anything where a mapping belongs.
+const isKeyMapping = (mapping: unknown): mapping is NativeKeyboardKeyMapping =>
+  mapping !== null && typeof mapping === 'object';
 
 const isLatinLetter = (value: string, isDeadKey: boolean | undefined): boolean => {
   const character = usableCharacter(value, isDeadKey);

--- a/core/config/keyboard-layout.ts
+++ b/core/config/keyboard-layout.ts
@@ -156,21 +156,33 @@ const handleFocus = (): void => {
 // into another read, so a disagreement only asks once every `rereadInterval`.
 const handleKeyDown = (event: KeyboardEvent): void => {
   if (
-    codeToCharacter === null ||
     event.altKey ||
     event.ctrlKey ||
     event.metaKey ||
     event.shiftKey ||
     event.key.length !== 1 ||
     event.getModifierState('CapsLock') ||
-    performance.now() - lastRereadAt < rereadInterval
+    performance.now() - lastRereadAt < rereadInterval ||
+    !isNewsAboutTheLayout(event)
   ) {
     return;
   }
 
-  const character = codeToCharacter.get(event.code);
-  if (character !== undefined && character !== event.key) {
-    lastRereadAt = performance.now();
-    void loadKeyboardLayout();
+  lastRereadAt = performance.now();
+  void loadKeyboardLayout();
+};
+
+// No layout at all means the read came back empty, which a window with no
+// keyboard attached to it does, so any keypress is reason enough to ask again.
+// Once there is one, only a key reporting a character the layout does not have
+// there says anything new; a key the layout never mentioned, such as the space
+// bar, says nothing either way.
+const isNewsAboutTheLayout = (event: KeyboardEvent): boolean => {
+  if (codeToCharacter === null) {
+    return true;
   }
+
+  const character = codeToCharacter.get(event.code);
+
+  return character !== undefined && character !== event.key;
 };

--- a/core/config/keyboard-layout.ts
+++ b/core/config/keyboard-layout.ts
@@ -110,16 +110,17 @@ const readLayout = async (): Promise<void> => {
 // put on that key rather than being added alongside it, so one position still
 // produces one character and two combo spellings can never claim the same key.
 //
-// It is all or nothing on purpose. Filling in individual letters would take a
-// key away from a character the layout really does type there, so a layout that
-// types most of the alphabet is left exactly as it reported itself. Digits get
-// no such treatment at all: AZERTY reaches them only with Shift, which the
-// keyboard map does not report, and while assuming the US number row would be
-// right there, it would be wrong on Programmer Dvorak, which moves the digits.
-// Naming the character the key actually types works on both.
+// It is all or nothing on purpose. Filling in one missing letter at a time
+// would take a key away from a character the layout really does type there, so
+// a layout that types most of the alphabet is left exactly as it reported
+// itself. VS Code does fill letters in one at a time, but `native-keymap` gives
+// it the shifted values it needs to tell those cases apart.
 //
-// VS Code fills in missing letters the same way, per letter rather than all at
-// once, because `native-keymap` gives it the shifted values to disambiguate.
+// Digits get no such treatment at all. AZERTY reaches them only with Shift, so
+// the keyboard map does not report them, and assuming the US number row would
+// be right there but wrong on Programmer Dvorak, which moves the digits and
+// puts brackets in their place. Naming the character the key really types works
+// on both.
 const withLatinLetters = (layout: ReadonlyMap<string, string>): ReadonlyMap<string, string> => {
   const produced = new Set(layout.values());
   if ([...letters].some((letter) => produced.has(letter))) {

--- a/core/config/keyboard-layout.ts
+++ b/core/config/keyboard-layout.ts
@@ -21,6 +21,9 @@ let characterToCode: ReadonlyMap<string, string> | null = null;
 let codeToCharacter: ReadonlyMap<string, string> | null = null;
 let reading: Promise<void> | null = null;
 let watching = false;
+// Bumped by every reset, so a read that was already in flight cannot land
+// afterwards and put the layout back.
+let generation = 0;
 
 export const codeForCharacter = (character: string): string | null =>
   characterToCode?.get(character) ?? null;
@@ -53,6 +56,7 @@ export const resetKeyboardLayout = (): void => {
   characterToCode = null;
   codeToCharacter = null;
   reading = null;
+  generation++;
 
   if (watching) {
     watching = false;
@@ -62,6 +66,7 @@ export const resetKeyboardLayout = (): void => {
 };
 
 const readLayout = async (): Promise<void> => {
+  const startedAt = generation;
   const keyboard = (navigator as Navigator & { keyboard?: KeyboardLayoutSource }).keyboard;
   if (!keyboard?.getLayoutMap) {
     clearLayout();
@@ -70,6 +75,9 @@ const readLayout = async (): Promise<void> => {
 
   try {
     const layout = await keyboard.getLayoutMap();
+    if (startedAt !== generation) {
+      return;
+    }
     // A window with no keyboard attached to it reports zero keys. That is a
     // missing answer, not a keyboard that produces nothing, so keep waiting for
     // a real one instead of caching it.
@@ -83,7 +91,9 @@ const readLayout = async (): Promise<void> => {
   } catch {
     // Platforms without the API and non-secure contexts reject. The US tables
     // cover both.
-    clearLayout();
+    if (startedAt === generation) {
+      clearLayout();
+    }
   }
 };
 

--- a/core/config/keymap.ts
+++ b/core/config/keymap.ts
@@ -106,31 +106,51 @@ const physicalCode = (key: string, shiftKey: boolean): string | null => {
   return (shiftKey ? shiftedPunctuationCodes : unshiftedPunctuationCodes)[key] ?? null;
 };
 
-// The one character this combo's keystroke types, whichever of its spellings
-// the combo used. `Shift+/` names the "/" key with Shift held, and that
-// keystroke types "?", so it is `Shift+?` written by the key instead of the
-// character; both must parse identically or they would claim the "/" key
-// twice. The layout answers when it can, so on German `Shift+7` means the "/"
-// that keystroke really types; the US pairing answers when no layout has
-// arrived.
-const canonicalKey = (key: string, shiftKey: boolean): string => {
-  if (!shiftKey || key.length !== 1) {
-    return key;
+type ResolvedComboKey = { code: string | null; key: string };
+
+// The character and key a shifted combo means, whichever of its two spellings
+// it used. `Shift+?` names the character a keystroke types; `Shift+/` names
+// the "/" key with Shift held, whose keystroke types "?", so both must parse
+// identically or they would claim the "/" key twice.
+//
+// A character some key types with Shift held is always the character
+// spelling, and stays on that key even when another key types it unshifted:
+// Linux Russian types "/" plain on one key and with Shift on another, and
+// `Shift+/` must mean the keystroke that types "/". Only a character no
+// Shift ever produces is read as a key name, and it keeps the key it named
+// rather than following its shifted character to whichever key claimed that
+// character first. Without a layout the US pairing and tables answer.
+const resolveComboKey = (spelled: string, shiftKey: boolean): ResolvedComboKey => {
+  if (!shiftKey || spelled.length !== 1) {
+    return { code: physicalCode(spelled, shiftKey), key: spelled };
   }
 
   if (hasKeyboardLayout()) {
-    const code = codeForCharacter(key, false);
-    return (code === null ? null : shiftedCharacterForCode(code)) ?? key;
+    const shiftedCode = codeForCharacter(spelled, true);
+    if (shiftedCode !== null) {
+      return { code: shiftedCode, key: spelled };
+    }
+
+    const unshiftedCode = codeForCharacter(spelled, false);
+    const shiftedCharacter = unshiftedCode === null ? null : shiftedCharacterForCode(unshiftedCode);
+    if (unshiftedCode !== null && shiftedCharacter !== null) {
+      return { code: unshiftedCode, key: shiftedCharacter };
+    }
+
+    // The layout cannot type it with Shift at all; the character may still
+    // arrive composed, so typed matching keeps the spelling as written.
+    return { code: null, key: spelled };
   }
 
-  return usShiftedSpellings[key] ?? key;
+  const key = usShiftedSpellings[spelled] ?? spelled;
+  return { code: physicalCode(key, true), key };
 };
 
 const parseKeyCombo = (combo: KeyCombo): ParsedKeyCombo => {
   const parts = combo.split('+').map((part) => part.trim().toLowerCase());
   const mac = isMac();
   const shiftKey = parts.includes('shift');
-  const key = canonicalKey(
+  const { code, key } = resolveComboKey(
     parts.find(
       (part) =>
         part !== 'mod' && part !== 'ctrl' && part !== 'alt' && part !== 'shift' && part !== 'meta',
@@ -140,7 +160,7 @@ const parseKeyCombo = (combo: KeyCombo): ParsedKeyCombo => {
 
   return {
     altKey: parts.includes('alt'),
-    code: physicalCode(key, shiftKey),
+    code,
     ctrlKey: mac ? parts.includes('ctrl') : parts.includes('mod') || parts.includes('ctrl'),
     key,
     metaKey: mac ? parts.includes('mod') || parts.includes('meta') : parts.includes('meta'),

--- a/core/config/keymap.ts
+++ b/core/config/keymap.ts
@@ -1,4 +1,4 @@
-import { codeForCharacter, hasKeyboardLayout } from './keyboard-layout.ts';
+import { codeForCharacter, hasKeyboardLayout, shiftedCharacterForCode } from './keyboard-layout.ts';
 import type { CodiffKeymap, KeyCombo, KeyComboBinding } from './types.ts';
 
 type ParsedKeyCombo = {
@@ -42,6 +42,7 @@ const shiftedPunctuationCodes: Record<string, string> = {
   '#': 'Digit3',
   '%': 'Digit5',
   '^': 'Digit6',
+  '+': 'Equal',
   '<': 'Comma',
   '>': 'Period',
   '|': 'Backslash',
@@ -49,31 +50,52 @@ const shiftedPunctuationCodes: Record<string, string> = {
   $: 'Digit4',
 };
 
+// What Shift makes each unshifted US character type, so a combo written by the
+// key, like VS Code's `Shift+/`, means the same keystroke as one written by
+// the character it produces, `Shift+?`. Letters need no entry: their two
+// spellings already collapse when combos are lowercased.
+const usShiftedSpellings: Record<string, string> = {
+  '-': '_',
+  ',': '<',
+  ';': ':',
+  '.': '>',
+  "'": '"',
+  '[': '{',
+  ']': '}',
+  '/': '?',
+  '\\': '|',
+  '`': '~',
+  '=': '+',
+  '0': ')',
+  '1': '!',
+  '2': '@',
+  '3': '#',
+  '4': '$',
+  '5': '%',
+  '6': '^',
+  '7': '&',
+  '8': '*',
+  '9': '(',
+};
+
 // `KeyboardEvent.code` for the letter, digit or punctuation key a combo names,
 // or null for a named key like `Enter` that no modifier rewrites.
 //
-// The user's own layout answers first, so `Alt+z` follows the key that really
-// types "z" rather than wherever US keyboards put it. A shifted spelling has to
-// keep using the tables below, because the layout reports unmodified characters
-// only; mixing the two sources within one Shift state would let a spelling the
-// layout placed and a spelling a table placed land on the same key.
-//
-// Combos name the resulting character, so `Shift+?` and `/` describe the same
-// key; keying the tables on the combo's own Shift state keeps at most one
-// spelling able to claim each position and stops the two from colliding.
-// Shifted `Equal` has no spelling at all, since `+` is the combo delimiter.
+// The user's own layout answers first, in the combo's own Shift state, so
+// `Alt+z` follows the key that really types "z" and `Alt+Shift+?` the key
+// whose Shift produces "?", wherever the layout put them. Keeping each Shift
+// state inside one source means two combos can land on one key only by naming
+// the same keystroke, which canonicalization has already collapsed.
 const physicalCode = (key: string, shiftKey: boolean): string | null => {
-  if (!shiftKey) {
-    const layoutCode = codeForCharacter(key, false);
-    if (layoutCode !== null) {
-      return layoutCode;
-    }
-    // With the real layout in hand, a character it cannot type has no key to
-    // match. Guessing the US position would fire the shortcut on whichever key
-    // the layout put there instead, which is the bug this replaces.
-    if (hasKeyboardLayout()) {
-      return null;
-    }
+  const layoutCode = codeForCharacter(key, shiftKey);
+  if (layoutCode !== null) {
+    return layoutCode;
+  }
+  // With the real layout in hand, a character it cannot type has no key to
+  // match. Guessing the US position would fire the shortcut on whichever key
+  // the layout put there instead, which is the bug this replaces.
+  if (hasKeyboardLayout()) {
+    return null;
   }
   if (/^[a-z]$/.test(key)) {
     return `Key${key.toUpperCase()}`;
@@ -84,15 +106,37 @@ const physicalCode = (key: string, shiftKey: boolean): string | null => {
   return (shiftKey ? shiftedPunctuationCodes : unshiftedPunctuationCodes)[key] ?? null;
 };
 
+// The one character this combo's keystroke types, whichever of its spellings
+// the combo used. `Shift+/` names the "/" key with Shift held, and that
+// keystroke types "?", so it is `Shift+?` written by the key instead of the
+// character; both must parse identically or they would claim the "/" key
+// twice. The layout answers when it can, so on German `Shift+7` means the "/"
+// that keystroke really types; the US pairing answers when no layout has
+// arrived.
+const canonicalKey = (key: string, shiftKey: boolean): string => {
+  if (!shiftKey || key.length !== 1) {
+    return key;
+  }
+
+  if (hasKeyboardLayout()) {
+    const code = codeForCharacter(key, false);
+    return (code === null ? null : shiftedCharacterForCode(code)) ?? key;
+  }
+
+  return usShiftedSpellings[key] ?? key;
+};
+
 const parseKeyCombo = (combo: KeyCombo): ParsedKeyCombo => {
   const parts = combo.split('+').map((part) => part.trim().toLowerCase());
   const mac = isMac();
   const shiftKey = parts.includes('shift');
-  const key =
+  const key = canonicalKey(
     parts.find(
       (part) =>
         part !== 'mod' && part !== 'ctrl' && part !== 'alt' && part !== 'shift' && part !== 'meta',
-    ) ?? '';
+    ) ?? '',
+    shiftKey,
+  );
 
   return {
     altKey: parts.includes('alt'),
@@ -100,7 +144,7 @@ const parseKeyCombo = (combo: KeyCombo): ParsedKeyCombo => {
     ctrlKey: mac ? parts.includes('ctrl') : parts.includes('mod') || parts.includes('ctrl'),
     key,
     metaKey: mac ? parts.includes('mod') || parts.includes('meta') : parts.includes('meta'),
-    shiftKey: parts.includes('shift'),
+    shiftKey,
   };
 };
 
@@ -159,10 +203,11 @@ const matchesBinding = (
 // matcher can see, so instead of guessing it only ever turns a keypress nothing
 // wanted into one that fires, never takes one from a shortcut that matched.
 //
-// `physicalCode` resolves the position through the user's real layout, so the
-// key it lands on is the one the keycap advertises. Shifted spellings and the
-// window before the layout loads still resolve to US positions, which on a
-// layout that moves keys can fire an action the keycap does not suggest.
+// `physicalCode` resolves the position through the user's real layout, in the
+// combo's own Shift state, so the key it lands on is the one the keycap
+// advertises. Only the window before the layout arrives resolves against US
+// positions, which on a layout that moves keys can fire an action the keycap
+// does not suggest.
 const canFallBackToPhysicalKey = (event: ShortcutEvent, keymap: CodiffKeymap): boolean =>
   event.altKey &&
   isMac() &&

--- a/core/config/keymap.ts
+++ b/core/config/keymap.ts
@@ -7,6 +7,11 @@ type ParsedKeyCombo = {
   ctrlKey: boolean;
   key: string;
   metaKey: boolean;
+  // True for a combo that named its key rather than its character, like
+  // `Shift+/` for the keystroke typing "?". Typed matching then requires the
+  // named key too: the same character typed on a different key is a different
+  // keystroke.
+  requiresCode: boolean;
   shiftKey: boolean;
 };
 
@@ -50,34 +55,6 @@ const shiftedPunctuationCodes: Record<string, string> = {
   $: 'Digit4',
 };
 
-// What Shift makes each unshifted US character type, so a combo written by the
-// key, like VS Code's `Shift+/`, means the same keystroke as one written by
-// the character it produces, `Shift+?`. Letters need no entry: their two
-// spellings already collapse when combos are lowercased.
-const usShiftedSpellings: Record<string, string> = {
-  '-': '_',
-  ',': '<',
-  ';': ':',
-  '.': '>',
-  "'": '"',
-  '[': '{',
-  ']': '}',
-  '/': '?',
-  '\\': '|',
-  '`': '~',
-  '=': '+',
-  '0': ')',
-  '1': '!',
-  '2': '@',
-  '3': '#',
-  '4': '$',
-  '5': '%',
-  '6': '^',
-  '7': '&',
-  '8': '*',
-  '9': '(',
-};
-
 // `KeyboardEvent.code` for the letter, digit or punctuation key a combo names,
 // or null for a named key like `Enter` that no modifier rewrites.
 //
@@ -106,51 +83,50 @@ const physicalCode = (key: string, shiftKey: boolean): string | null => {
   return (shiftKey ? shiftedPunctuationCodes : unshiftedPunctuationCodes)[key] ?? null;
 };
 
-type ResolvedComboKey = { code: string | null; key: string };
+type ResolvedComboKey = { code: string | null; key: string; requiresCode: boolean };
 
 // The character and key a shifted combo means, whichever of its two spellings
 // it used. `Shift+?` names the character a keystroke types; `Shift+/` names
-// the "/" key with Shift held, whose keystroke types "?", so both must parse
-// identically or they would claim the "/" key twice.
+// the "/" key with Shift held, whose keystroke types "?", so both must mean
+// the same keystroke or they would claim the "/" key twice.
 //
 // A character some key types with Shift held is always the character
 // spelling, and stays on that key even when another key types it unshifted:
 // Linux Russian types "/" plain on one key and with Shift on another, and
 // `Shift+/` must mean the keystroke that types "/". Only a character no
-// Shift ever produces is read as a key name, and it keeps the key it named
-// rather than following its shifted character to whichever key claimed that
-// character first. Without a layout the US pairing and tables answer.
+// Shift ever produces is read as a key name, and it stays bound to the key it
+// named, in matching too, rather than following its shifted character to
+// whichever key types that character elsewhere.
+//
+// Reading a spelling as a key name takes a layout. Before one arrives, and
+// wherever none ever does, a combo keeps meaning the character as written,
+// exactly as it did before layouts were consulted at all.
 const resolveComboKey = (spelled: string, shiftKey: boolean): ResolvedComboKey => {
-  if (!shiftKey || spelled.length !== 1) {
-    return { code: physicalCode(spelled, shiftKey), key: spelled };
+  if (!shiftKey || spelled.length !== 1 || !hasKeyboardLayout()) {
+    return { code: physicalCode(spelled, shiftKey), key: spelled, requiresCode: false };
   }
 
-  if (hasKeyboardLayout()) {
-    const shiftedCode = codeForCharacter(spelled, true);
-    if (shiftedCode !== null) {
-      return { code: shiftedCode, key: spelled };
-    }
-
-    const unshiftedCode = codeForCharacter(spelled, false);
-    const shiftedCharacter = unshiftedCode === null ? null : shiftedCharacterForCode(unshiftedCode);
-    if (unshiftedCode !== null && shiftedCharacter !== null) {
-      return { code: unshiftedCode, key: shiftedCharacter };
-    }
-
-    // The layout cannot type it with Shift at all; the character may still
-    // arrive composed, so typed matching keeps the spelling as written.
-    return { code: null, key: spelled };
+  const shiftedCode = codeForCharacter(spelled, true);
+  if (shiftedCode !== null) {
+    return { code: shiftedCode, key: spelled, requiresCode: false };
   }
 
-  const key = usShiftedSpellings[spelled] ?? spelled;
-  return { code: physicalCode(key, true), key };
+  const unshiftedCode = codeForCharacter(spelled, false);
+  const shiftedCharacter = unshiftedCode === null ? null : shiftedCharacterForCode(unshiftedCode);
+  if (unshiftedCode !== null && shiftedCharacter !== null) {
+    return { code: unshiftedCode, key: shiftedCharacter, requiresCode: true };
+  }
+
+  // The layout cannot type it with Shift at all; the character may still
+  // arrive composed, so typed matching keeps the spelling as written.
+  return { code: null, key: spelled, requiresCode: false };
 };
 
 const parseKeyCombo = (combo: KeyCombo): ParsedKeyCombo => {
   const parts = combo.split('+').map((part) => part.trim().toLowerCase());
   const mac = isMac();
   const shiftKey = parts.includes('shift');
-  const { code, key } = resolveComboKey(
+  const { code, key, requiresCode } = resolveComboKey(
     parts.find(
       (part) =>
         part !== 'mod' && part !== 'ctrl' && part !== 'alt' && part !== 'shift' && part !== 'meta',
@@ -164,6 +140,7 @@ const parseKeyCombo = (combo: KeyCombo): ParsedKeyCombo => {
     ctrlKey: mac ? parts.includes('ctrl') : parts.includes('mod') || parts.includes('ctrl'),
     key,
     metaKey: mac ? parts.includes('mod') || parts.includes('meta') : parts.includes('meta'),
+    requiresCode,
     shiftKey,
   };
 };
@@ -185,8 +162,11 @@ type ShortcutEvent = Pick<
 const isDeadOrNonAsciiKey = (key: string): boolean =>
   key === 'Dead' || (key.length === 1 && key.charCodeAt(0) > 0x7e);
 
+// A key-spelled combo additionally requires the key it named: two keys may
+// type the same character with Shift, and `Shift+/` means only one of them.
 const matchesTypedKey = (event: ShortcutEvent, parsed: ParsedKeyCombo): boolean =>
-  event.key.toLowerCase() === parsed.key;
+  event.key.toLowerCase() === parsed.key &&
+  (!parsed.requiresCode || (parsed.code !== null && event.code === parsed.code));
 
 const matchesPhysicalKey = (event: ShortcutEvent, parsed: ParsedKeyCombo): boolean =>
   parsed.altKey && parsed.code !== null && event.code === parsed.code;

--- a/core/config/keymap.ts
+++ b/core/config/keymap.ts
@@ -149,17 +149,20 @@ const matchesBinding = (
   matchesKey: (event: ShortcutEvent, parsed: ParsedKeyCombo) => boolean,
 ): boolean => getBindingCombos(binding).some((combo) => matchesCombo(event, combo, matchesKey));
 
-// The US key position is a last resort, read only for an Alt press on macOS
-// whose character Option swallowed, and only when the character the event does
-// report matches no binding at all. So a character a layout produces natively
-// (AZERTY "é" on the US "2" key) can never be overruled by the key beneath it.
+// The key position is a last resort, read only for an Alt press on macOS whose
+// character Option swallowed, and only when the character the event does report
+// matches no binding at all. So a character a layout produces natively (AZERTY
+// "é" on the US "2" key) can never be overruled by the key beneath it.
 //
-// The fallback is deliberately defined in terms of US key positions: telling a
-// composed character apart from one a layout produces natively needs layout
-// knowledge this matcher does not have. On a layout that moves keys it can
-// therefore resolve to a position the keycap does not advertise, but only for a
-// keypress that already matched nothing, never by taking one from a shortcut
-// that did match.
+// That last condition is what makes the whole fallback safe. Telling a composed
+// character apart from one a layout produces natively needs more than this
+// matcher can see, so instead of guessing it only ever turns a keypress nothing
+// wanted into one that fires, never takes one from a shortcut that matched.
+//
+// `physicalCode` resolves the position through the user's real layout, so the
+// key it lands on is the one the keycap advertises. Shifted spellings and the
+// window before the layout loads still resolve to US positions, which on a
+// layout that moves keys can fire an action the keycap does not suggest.
 const canFallBackToPhysicalKey = (event: ShortcutEvent, keymap: CodiffKeymap): boolean =>
   event.altKey &&
   isMac() &&

--- a/core/config/keymap.ts
+++ b/core/config/keymap.ts
@@ -1,3 +1,4 @@
+import { codeForCharacter, hasKeyboardLayout } from './keyboard-layout.ts';
 import type { CodiffKeymap, KeyCombo, KeyComboBinding } from './types.ts';
 
 type ParsedKeyCombo = {
@@ -48,13 +49,32 @@ const shiftedPunctuationCodes: Record<string, string> = {
   $: 'Digit4',
 };
 
-// US-layout `KeyboardEvent.code` for the letter, digit or punctuation key a
-// combo names, or null for a named key like `Enter` that no modifier rewrites.
+// `KeyboardEvent.code` for the letter, digit or punctuation key a combo names,
+// or null for a named key like `Enter` that no modifier rewrites.
+//
+// The user's own layout answers first, so `Alt+z` follows the key that really
+// types "z" rather than wherever US keyboards put it. A shifted spelling has to
+// keep using the tables below, because the layout reports unmodified characters
+// only; mixing the two sources within one Shift state would let a spelling the
+// layout placed and a spelling a table placed land on the same key.
+//
 // Combos name the resulting character, so `Shift+?` and `/` describe the same
-// key; keying the lookup on the combo's own Shift state keeps at most one
+// key; keying the tables on the combo's own Shift state keeps at most one
 // spelling able to claim each position and stops the two from colliding.
 // Shifted `Equal` has no spelling at all, since `+` is the combo delimiter.
 const physicalCode = (key: string, shiftKey: boolean): string | null => {
+  if (!shiftKey) {
+    const layoutCode = codeForCharacter(key);
+    if (layoutCode !== null) {
+      return layoutCode;
+    }
+    // With the real layout in hand, a character it cannot type has no key to
+    // match. Guessing the US position would fire the shortcut on whichever key
+    // the layout put there instead, which is the bug this replaces.
+    if (hasKeyboardLayout()) {
+      return null;
+    }
+  }
   if (/^[a-z]$/.test(key)) {
     return `Key${key.toUpperCase()}`;
   }

--- a/core/config/keymap.ts
+++ b/core/config/keymap.ts
@@ -2,6 +2,7 @@ import type { CodiffKeymap, KeyCombo, KeyComboBinding } from './types.ts';
 
 type ParsedKeyCombo = {
   altKey: boolean;
+  code: string | null;
   ctrlKey: boolean;
   key: string;
   metaKey: boolean;
@@ -10,22 +11,74 @@ type ParsedKeyCombo = {
 
 const isMac = () => navigator.platform.toLowerCase().includes('mac');
 
+const unshiftedPunctuationCodes: Record<string, string> = {
+  '-': 'Minus',
+  ',': 'Comma',
+  ';': 'Semicolon',
+  '.': 'Period',
+  "'": 'Quote',
+  '[': 'BracketLeft',
+  ']': 'BracketRight',
+  '/': 'Slash',
+  '\\': 'Backslash',
+  '`': 'Backquote',
+  '=': 'Equal',
+};
+
+const shiftedPunctuationCodes: Record<string, string> = {
+  _: 'Minus',
+  ':': 'Semicolon',
+  '!': 'Digit1',
+  '?': 'Slash',
+  '"': 'Quote',
+  '(': 'Digit9',
+  ')': 'Digit0',
+  '{': 'BracketLeft',
+  '}': 'BracketRight',
+  '@': 'Digit2',
+  '*': 'Digit8',
+  '&': 'Digit7',
+  '#': 'Digit3',
+  '%': 'Digit5',
+  '^': 'Digit6',
+  '<': 'Comma',
+  '>': 'Period',
+  '|': 'Backslash',
+  '~': 'Backquote',
+  $: 'Digit4',
+};
+
+// US-layout `KeyboardEvent.code` for the letter, digit or punctuation key a
+// combo names, or null for a named key like `Enter` that no modifier rewrites.
+// Combos name the resulting character, so `Shift+?` and `/` describe the same
+// key; keying the lookup on the combo's own Shift state keeps at most one
+// spelling able to claim each position and stops the two from colliding.
+// Shifted `Equal` has no spelling at all, since `+` is the combo delimiter.
+const physicalCode = (key: string, shiftKey: boolean): string | null => {
+  if (/^[a-z]$/.test(key)) {
+    return `Key${key.toUpperCase()}`;
+  }
+  if (/^[0-9]$/.test(key)) {
+    return shiftKey ? null : `Digit${key}`;
+  }
+  return (shiftKey ? shiftedPunctuationCodes : unshiftedPunctuationCodes)[key] ?? null;
+};
+
 const parseKeyCombo = (combo: KeyCombo): ParsedKeyCombo => {
   const parts = combo.split('+').map((part) => part.trim().toLowerCase());
   const mac = isMac();
+  const shiftKey = parts.includes('shift');
+  const key =
+    parts.find(
+      (part) =>
+        part !== 'mod' && part !== 'ctrl' && part !== 'alt' && part !== 'shift' && part !== 'meta',
+    ) ?? '';
 
   return {
     altKey: parts.includes('alt'),
+    code: physicalCode(key, shiftKey),
     ctrlKey: mac ? parts.includes('ctrl') : parts.includes('mod') || parts.includes('ctrl'),
-    key:
-      parts.find(
-        (part) =>
-          part !== 'mod' &&
-          part !== 'ctrl' &&
-          part !== 'alt' &&
-          part !== 'shift' &&
-          part !== 'meta',
-      ) ?? '',
+    key,
     metaKey: mac ? parts.includes('mod') || parts.includes('meta') : parts.includes('meta'),
     shiftKey: parts.includes('shift'),
   };
@@ -34,14 +87,35 @@ const parseKeyCombo = (combo: KeyCombo): ParsedKeyCombo => {
 const getBindingCombos = (binding: KeyComboBinding): ReadonlyArray<KeyCombo> =>
   Array.isArray(binding) ? binding : [binding as KeyCombo];
 
-const matchesKeyCombo = (
-  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
+type ShortcutEvent = Pick<
+  KeyboardEvent,
+  'altKey' | 'code' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'
+>;
+
+// Necessary but not sufficient evidence that Option swallowed the character:
+// it composed one outside ASCII ("Ω" for Option+z, "÷" for Option+/) or armed a
+// dead key. Layouts also produce non-ASCII characters natively, which is why
+// the caller additionally requires that nothing matched them. A value like
+// `Unidentified` carries no key information at all and is excluded, so the
+// shortcut does not match rather than guessing at a key position.
+const isDeadOrNonAsciiKey = (key: string): boolean =>
+  key === 'Dead' || (key.length === 1 && key.charCodeAt(0) > 0x7e);
+
+const matchesTypedKey = (event: ShortcutEvent, parsed: ParsedKeyCombo): boolean =>
+  event.key.toLowerCase() === parsed.key;
+
+const matchesPhysicalKey = (event: ShortcutEvent, parsed: ParsedKeyCombo): boolean =>
+  parsed.altKey && parsed.code !== null && event.code === parsed.code;
+
+const matchesCombo = (
+  event: ShortcutEvent,
   combo: KeyCombo,
+  matchesKey: (event: ShortcutEvent, parsed: ParsedKeyCombo) => boolean,
 ): boolean => {
   const parsed = parseKeyCombo(combo);
 
   return (
-    event.key.toLowerCase() === parsed.key &&
+    matchesKey(event, parsed) &&
     event.altKey === parsed.altKey &&
     event.ctrlKey === parsed.ctrlKey &&
     event.metaKey === parsed.metaKey &&
@@ -49,11 +123,37 @@ const matchesKeyCombo = (
   );
 };
 
+const matchesBinding = (
+  event: ShortcutEvent,
+  binding: KeyComboBinding,
+  matchesKey: (event: ShortcutEvent, parsed: ParsedKeyCombo) => boolean,
+): boolean => getBindingCombos(binding).some((combo) => matchesCombo(event, combo, matchesKey));
+
+// The US key position is a last resort, read only for an Alt press on macOS
+// whose character Option swallowed, and only when the character the event does
+// report matches no binding at all. So a character a layout produces natively
+// (AZERTY "é" on the US "2" key) can never be overruled by the key beneath it.
+//
+// The fallback is deliberately defined in terms of US key positions: telling a
+// composed character apart from one a layout produces natively needs layout
+// knowledge this matcher does not have. On a layout that moves keys it can
+// therefore resolve to a position the keycap does not advertise, but only for a
+// keypress that already matched nothing, never by taking one from a shortcut
+// that did match.
+const canFallBackToPhysicalKey = (event: ShortcutEvent, keymap: CodiffKeymap): boolean =>
+  event.altKey &&
+  isMac() &&
+  isDeadOrNonAsciiKey(event.key) &&
+  !Object.values(keymap).some((binding) => matchesBinding(event, binding, matchesTypedKey));
+
 export const matchesShortcut = (
-  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
+  event: ShortcutEvent,
   keymap: CodiffKeymap,
   action: keyof CodiffKeymap,
-): boolean => getBindingCombos(keymap[action]).some((combo) => matchesKeyCombo(event, combo));
+): boolean =>
+  matchesBinding(event, keymap[action], matchesTypedKey) ||
+  (canFallBackToPhysicalKey(event, keymap) &&
+    matchesBinding(event, keymap[action], matchesPhysicalKey));
 
 export const getShortcutLabel = (keymap: CodiffKeymap, action: keyof CodiffKeymap): string => {
   // Show the primary combo when an action has alias bindings.

--- a/core/config/keymap.ts
+++ b/core/config/keymap.ts
@@ -64,7 +64,7 @@ const shiftedPunctuationCodes: Record<string, string> = {
 // Shifted `Equal` has no spelling at all, since `+` is the combo delimiter.
 const physicalCode = (key: string, shiftKey: boolean): string | null => {
   if (!shiftKey) {
-    const layoutCode = codeForCharacter(key);
+    const layoutCode = codeForCharacter(key, false);
     if (layoutCode !== null) {
       return layoutCode;
     }

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -1,3 +1,4 @@
+import type { NativeKeyboardLayout } from './config/keyboard-layout.ts';
 import type { CodiffConfig } from './config/types.ts';
 import type {
   AgentSkillStatus,
@@ -53,6 +54,7 @@ declare global {
       getDiffSectionContent: (request: DiffSectionContentRequest) => Promise<DiffSection>;
       getFeatureFlags: () => Promise<CodiffFeatureFlags>;
       getGitIdentity: () => Promise<GitIdentity>;
+      getKeyboardLayout: () => Promise<NativeKeyboardLayout | null>;
       getLaunchOptions: () => Promise<CodiffLaunchOptions>;
       getMarkdownDocument: (request: {
         kind: CodiffMarkdownDocument['kind'];
@@ -75,6 +77,7 @@ declare global {
       onConfigChanged: (callback: (config: CodiffConfig) => void) => () => void;
       onCopyPendingCommentsRequest: (callback: () => string | Promise<string>) => () => void;
       onFindInDiffs: (callback: () => void) => () => void;
+      onKeyboardLayoutChanged: (callback: (layout: NativeKeyboardLayout) => void) => () => void;
       onMarkdownDocumentChanged: (
         callback: (
           change:

--- a/core/index.tsx
+++ b/core/index.tsx
@@ -2,6 +2,11 @@ import './App.css';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { trackKeyboardLayout } from './config/keyboard-layout.ts';
+
+// Reading the layout is asynchronous, so it starts here rather than blocking
+// the first paint. Shortcuts resolve against US key positions until it lands.
+trackKeyboardLayout();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/electron/__tests__/keyboard-layout.test.ts
+++ b/electron/__tests__/keyboard-layout.test.ts
@@ -1,0 +1,54 @@
+import { createRequire } from 'node:module';
+import { expect, test } from 'vite-plus/test';
+
+const require = createRequire(import.meta.url);
+
+const { normalizeKeyboardLayout } = require('../keyboard-layout.cjs') as {
+  normalizeKeyboardLayout: (raw: unknown) => Record<string, unknown> | null;
+};
+
+test('rejects the empty array the native module returns when it fails', () => {
+  // Arrange: native-keymap catches its own load and read errors internally and
+  // answers with an empty array, which is a missing answer, not a keyboard.
+  const raw: Array<never> = [];
+
+  // Act
+  const layout = normalizeKeyboardLayout(raw);
+
+  // Assert
+  expect(layout).toBe(null);
+});
+
+test('rejects a layout with no keys', () => {
+  // Act
+  const layout = normalizeKeyboardLayout({});
+
+  // Assert
+  expect(layout).toBe(null);
+});
+
+test('rejects a missing layout', () => {
+  // Assert
+  expect({
+    missing: normalizeKeyboardLayout(null),
+    undefined: normalizeKeyboardLayout(undefined),
+  }).toEqual({ missing: null, undefined: null });
+});
+
+test('rejects a layout that is not an object', () => {
+  // Assert
+  expect(normalizeKeyboardLayout('broken')).toBe(null);
+});
+
+test('keeps a real layout untouched', () => {
+  // Arrange
+  const raw = {
+    KeyZ: { value: 'z', valueIsDeadKey: false, withShift: 'Z', withShiftIsDeadKey: false },
+  };
+
+  // Act
+  const layout = normalizeKeyboardLayout(raw);
+
+  // Assert
+  expect(layout).toBe(raw);
+});

--- a/electron/keyboard-layout.cjs
+++ b/electron/keyboard-layout.cjs
@@ -4,6 +4,14 @@
 // `native-keymap` because Chromium reports unmodified characters only and has
 // no layout change event. A failed native module load must not take the app
 // down: without an answer the renderer falls back to US key positions.
+//
+// macOS ISO keyboards are left uncompensated on purpose. Apple historically
+// swaps the Backquote and IntlBackslash virtual key codes on some ISO
+// hardware, but `isISOKeyboard()` cannot say whether compensation is needed:
+// on the ISO MacBook this was measured on, Chromium's own `getLayoutMap()`
+// agrees exactly with native-keymap's uncompensated answer, so swapping
+// whenever `isISOKeyboard()` is true would break the very keys it is meant to
+// fix. VS Code ships the same uncompensated data.
 
 /** @typedef {import('../core/config/keyboard-layout.ts').NativeKeyboardLayout} NativeKeyboardLayout */
 
@@ -15,7 +23,7 @@ const readKeyboardLayout = () => {
   }
 
   try {
-    return /** @type {NativeKeyboardLayout} */ (nativeKeymap.getKeyMap());
+    return normalizeKeyboardLayout(nativeKeymap.getKeyMap());
   } catch {
     return null;
   }
@@ -40,6 +48,26 @@ const watchKeyboardLayout = (onChange) => {
   }
 };
 
+// native-keymap catches its own load and read errors internally and answers
+// with an empty array, which is a missing answer rather than a keyboard, and
+// applying it would pin letters onto a keyboard that was never read.
+/**
+ * @param {unknown} raw
+ * @returns {NativeKeyboardLayout | null}
+ */
+const normalizeKeyboardLayout = (raw) => {
+  if (
+    raw === null ||
+    typeof raw !== 'object' ||
+    Array.isArray(raw) ||
+    Object.keys(raw).length === 0
+  ) {
+    return null;
+  }
+
+  return /** @type {NativeKeyboardLayout} */ (raw);
+};
+
 const loadNativeKeymap = () => {
   try {
     return require('native-keymap');
@@ -48,4 +76,4 @@ const loadNativeKeymap = () => {
   }
 };
 
-module.exports = { readKeyboardLayout, watchKeyboardLayout };
+module.exports = { normalizeKeyboardLayout, readKeyboardLayout, watchKeyboardLayout };

--- a/electron/keyboard-layout.cjs
+++ b/electron/keyboard-layout.cjs
@@ -1,0 +1,51 @@
+// @ts-check
+
+// The keyboard layout for the renderer's shortcut matcher, read with
+// `native-keymap` because Chromium reports unmodified characters only and has
+// no layout change event. A failed native module load must not take the app
+// down: without an answer the renderer falls back to US key positions.
+
+/** @typedef {import('../core/config/keyboard-layout.ts').NativeKeyboardLayout} NativeKeyboardLayout */
+
+/** @returns {NativeKeyboardLayout | null} */
+const readKeyboardLayout = () => {
+  const nativeKeymap = loadNativeKeymap();
+  if (!nativeKeymap) {
+    return null;
+  }
+
+  try {
+    return /** @type {NativeKeyboardLayout} */ (nativeKeymap.getKeyMap());
+  } catch {
+    return null;
+  }
+};
+
+/** @param {(layout: NativeKeyboardLayout) => void} onChange */
+const watchKeyboardLayout = (onChange) => {
+  const nativeKeymap = loadNativeKeymap();
+  if (!nativeKeymap) {
+    return;
+  }
+
+  try {
+    nativeKeymap.onDidChangeKeyboardLayout(() => {
+      const layout = readKeyboardLayout();
+      if (layout) {
+        onChange(layout);
+      }
+    });
+  } catch {
+    // Without change events the layout read at startup stays in charge.
+  }
+};
+
+const loadNativeKeymap = () => {
+  try {
+    return require('native-keymap');
+  } catch {
+    return null;
+  }
+};
+
+module.exports = { readKeyboardLayout, watchKeyboardLayout };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -30,6 +30,7 @@ const { normalizeOpenAIModel } = require('./codex.cjs');
 const { normalizeClaudeModel } = require('./claude.cjs');
 const { normalizeOpenCodeModel, renderOpenCodeCommand } = require('./opencode.cjs');
 const { createWalkthroughCommit } = require('./walkthrough-commit.cjs');
+const { readKeyboardLayout, watchKeyboardLayout } = require('./keyboard-layout.cjs');
 const { diagnoseWalkthroughMismatch } = require('./walkthrough-diagnosis.cjs');
 const { readCommitMessageReply } = require('./walkthrough-commit-message.cjs');
 const { normalizePiModel } = require('./pi.cjs');
@@ -1231,6 +1232,14 @@ if (squirrelStartup || !lock) {
     nativeTheme.themeSource = config.settings.theme;
     Menu.setApplicationMenu(buildApplicationMenu());
 
+    watchKeyboardLayout((layout) => {
+      for (const window of BrowserWindow.getAllWindows()) {
+        if (!window.isDestroyed()) {
+          window.webContents.send('codiff:keyboardLayoutChanged', layout);
+        }
+      }
+    });
+
     const launchOptions = getLaunchOptions();
     focusOrCreateWindow(
       getInitialRepositoryPath(getLaunchPath(), launchOptions, config.settings.lastRepositoryPath),
@@ -1692,6 +1701,8 @@ ipcMain.handle('codiff:getGitIdentity', async (event) => {
 ipcMain.handle('codiff:getPreferences', () => configToPreferences(config));
 
 ipcMain.handle('codiff:getConfig', () => config);
+
+ipcMain.handle('codiff:getKeyboardLayout', () => readKeyboardLayout());
 
 ipcMain.handle('codiff:isWindowFullScreen', (event) => {
   const window = BrowserWindow.fromWebContents(event.sender);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -27,6 +27,7 @@ const codiff = {
   getFeatureFlags: () => ipcRenderer.invoke('codiff:getFeatureFlags'),
   getDiffImageContent: (request) => ipcRenderer.invoke('codiff:getDiffImageContent', request),
   getGitIdentity: () => ipcRenderer.invoke('codiff:getGitIdentity'),
+  getKeyboardLayout: () => ipcRenderer.invoke('codiff:getKeyboardLayout'),
   getLaunchOptions: () => ipcRenderer.invoke('codiff:getLaunchOptions'),
   getMarkdownDocument: (request) => ipcRenderer.invoke('codiff:getMarkdownDocument', request),
   getPreferences: () => ipcRenderer.invoke('codiff:getPreferences'),
@@ -71,6 +72,12 @@ const codiff = {
     const listener = () => callback();
     ipcRenderer.on('codiff:findInDiffs', listener);
     return () => ipcRenderer.removeListener('codiff:findInDiffs', listener);
+  },
+  onKeyboardLayoutChanged: (callback) => {
+    /** @param {Electron.IpcRendererEvent} _event @param {import('../core/config/keyboard-layout.ts').NativeKeyboardLayout} layout */
+    const listener = (_event, layout) => callback(layout);
+    ipcRenderer.on('codiff:keyboardLayoutChanged', listener);
+    return () => ipcRenderer.removeListener('codiff:keyboardLayoutChanged', listener);
   },
   onOpenReviewSource: (callback) => {
     /** @param {Electron.IpcRendererEvent} _event @param {import('../core/types.ts').OpenReviewSourceKind} kind */

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.1",
+    "native-keymap": "^3.3.9",
     "node-pty": "^1.1.0",
     "proper-lockfile": "^4.1.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,9 @@ settings:
 
 catalogs:
   default:
-    vite:
-      specifier: npm:@voidzero-dev/vite-plus-core@^0.2.4
-      version: 0.2.4
     vite-plus:
       specifier: ^0.2.4
       version: 0.2.4
-    vitest:
-      specifier: 4.1.10
-      version: 4.1.10
 
 overrides:
   extract-zip>yauzl: ^3.4.0
@@ -28,6 +22,9 @@ importers:
       electron-squirrel-startup:
         specifier: ^1.0.1
         version: 1.0.1
+      native-keymap:
+        specifier: ^3.3.9
+        version: 3.3.9
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -5239,6 +5236,9 @@ packages:
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  native-keymap@3.3.9:
+    resolution: {integrity: sha512-d/ydQ5x+GM5W0dyAjFPwexhtc9CDH1g/xWZESS5CXk16ThyFzSBLvlBJq1+FyzUIFf/F2g1MaHdOpa6G9150YQ==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -11763,6 +11763,8 @@ snapshots:
   nanostores@1.4.0: {}
 
   napi-build-utils@2.0.0: {}
+
+  native-keymap@3.3.9: {}
 
   natural-compare@1.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ allowBuilds:
   electron: true
   electron-winstaller: true
   esbuild: true
+  native-keymap: true
   node-pty: true
   protobufjs: false
   sharp: true


### PR DESCRIPTION
I was trying to use the `Alt+z` shortcut to trigger word wrap on macOS and didn't work, this PR fixes it.

Changes made by Opus 5 and Fable 5 xhigh, with review loop with Sol 5.6 xhigh. The diff is 2.2k lines, ~1.7k of which are tests.

-----

`Alt+z` never fires on macOS because Option+Z types `Ω` and the matcher compares `event.key`. Every `Alt` binding has the same problem, since there's no Cmd or Ctrl to suppress the composition.

`Alt` combos now fall back to the physical key when the character was composed away. Key positions come from `native-keymap` (the module VS Code uses) in the Electron main process: it reports what every key types plain and with Shift held and fires an event when the input source changes, and the renderer keeps a synchronous cache fed over IPC. So `Alt+z` follows the key that actually types `z` on QWERTZ, AZERTY, and Dvorak, `Alt+Shift+?` the key whose Shift types `?`, and a shifted keystroke can also be written by its key, VS Code style: `Shift+/` and `Shift+?` are the same shortcut.

The fallback is narrow: `Alt` on macOS only, only when the character was composed away, and only when that character matches no binding anywhere, so a character the layout produces natively always beats the key under it. Property tests walk every nameable character through both Shift states on US, German, AZERTY, Dvorak, and Russian layouts: no keystroke may fire two actions, and every combo must land on a key that really types its character.

Tried and discarded:

- Hardcoded US position tables: fire the shortcut on whatever key the layout put at that position instead.
- `navigator.keyboard.getLayoutMap()`: unshifted characters only and no change event, so layout switches had to be inferred from focus and keypress heuristics.
- Canonicalizing `Shift+/` through a static US pair table when no layout is available: quietly changed what existing combos match on non-US keyboards.
- Compensating the macOS ISO Backquote/IntlBackslash swap: measured on an ISO MacBook, the uncompensated data is already correct, and VS Code ships no compensation either.

With no layout available (the web build, and the Windows package until it builds on a Windows runner instead of cross-packaging on Linux), matching is exactly what shipped before this branch; failed native reads are rejected rather than applied, so they can't erase a good layout. Nothing changes on a US layout.
