### PR TITLE
ci: install native-keymap build dependencies on Linux runners

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt update
-          sudo apt install -y fakeroot rpm
+          sudo apt install -y fakeroot rpm libx11-dev libxkbfile-dev
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -120,6 +120,13 @@ jobs:
         id: pnpm-install
         with:
           run_install: false
+
+      # native-keymap compiles from source during install, and on a Linux host
+      # that requires the X11 headers even when packaging for another platform.
+      - name: Install native-keymap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libx11-dev libxkbfile-dev
 
       - name: Cache Electron Downloads
         uses: actions/cache@v4

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -35,6 +35,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install native-keymap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libx11-dev libxkbfile-dev
+
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: 24


### PR DESCRIPTION
`vp install` fails on Linux since #141 because `native-keymap` compiles from source and needs the X11 headers. 45bfa43 fixed the test workflow, but deploy-web still fails on main, and the build-app jobs only run on tags, so the next release would hit the same error.

This applies the same fix to the remaining Linux jobs:

- deploy-web gets the same step as test.yml
- build-linux gets the two packages appended to its existing apt install
- build-windows gets the step too, since it runs `pnpm install` on a Linux host before cross-packaging for win32

Moving `native-keymap` to `optionalDependencies` would have avoided the headers entirely, but a failed build on macOS would then silently ship the app without the Alt shortcut fix, so the loud failure seemed better.

deploy-web and build-app can't be exercised from a PR (they trigger on pushes to main and on tags), but these are the same two packages that turned test.yml green on the same runner image.

Change made by Fable 5 xhigh, with a review pass by Sol 5.6 xhigh.
