### PR TITLE
fix: authenticate gh through the login shell environment

### DIFF
--- a/electron/__tests__/login-shell-environment.test.ts
+++ b/electron/__tests__/login-shell-environment.test.ts
@@ -8,9 +8,14 @@ import {
 } from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
-const { getLoginShellEnvironment } = require('../login-shell-environment.cjs') as {
-  getLoginShellEnvironment: () => Promise<Readonly<Record<string, string>>>;
-};
+const { getLoginShellEnvironment, resolveLoginShellEnvironment } =
+  require('../login-shell-environment.cjs') as {
+    getLoginShellEnvironment: () => Promise<Readonly<Record<string, string>>>;
+    resolveLoginShellEnvironment: (
+      shell: string,
+      timeout?: number,
+    ) => Promise<Readonly<Record<string, string>>>;
+  };
 
 const createFakeLoginShell = async (directory: string, body: string) => {
   const shellPath = join(directory, 'fake-login-shell');
@@ -72,4 +77,33 @@ CODIFF_FAKE_TOKEN='from-login-shell' exec /bin/sh -c "$3"
   expect(second).toBe(first);
   expect(third).toBe(first);
   expect((await readFile(runsPath, 'utf8')).trim().split('\n')).toHaveLength(1);
+});
+
+test('salvages a clean environment dump when a background child holds stdout open', async () => {
+  await using directory = await createTemporaryDirectory('codiff-login-shell-');
+  // The shell finishes the dump and exits cleanly, but leaves behind a child
+  // that inherits stdout, so `close` stays hours away from `exit`.
+  const shell = await createFakeLoginShell(
+    directory.path,
+    `CODIFF_FAKE_TOKEN='from-login-shell' /bin/sh -c "$3"
+sleep 10 &
+exit 0
+`,
+  );
+
+  const environment = await resolveLoginShellEnvironment(shell, 500);
+
+  expect(environment.CODIFF_FAKE_TOKEN).toBe('from-login-shell');
+});
+
+test('abandons a login shell that ignores termination', async () => {
+  await using directory = await createTemporaryDirectory('codiff-login-shell-');
+  const shell = await createFakeLoginShell(
+    directory.path,
+    `trap '' TERM
+sleep 10
+`,
+  );
+
+  expect(await resolveLoginShellEnvironment(shell, 500)).toEqual({});
 });

--- a/electron/__tests__/login-shell-environment.test.ts
+++ b/electron/__tests__/login-shell-environment.test.ts
@@ -1,0 +1,75 @@
+import { chmod, readFile, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { expect, test } from 'vite-plus/test';
+import {
+  createTemporaryDirectory,
+  createTemporaryEnvironment,
+} from '../../core/__tests__/helpers/resources.ts';
+
+const require = createRequire(import.meta.url);
+const { getLoginShellEnvironment } = require('../login-shell-environment.cjs') as {
+  getLoginShellEnvironment: () => Promise<Readonly<Record<string, string>>>;
+};
+
+const createFakeLoginShell = async (directory: string, body: string) => {
+  const shellPath = join(directory, 'fake-login-shell');
+  await writeFile(shellPath, `#!/bin/sh\n${body}`);
+  await chmod(shellPath, 0o755);
+  return shellPath;
+};
+
+test('resolves variables exported by the login shell', async () => {
+  await using directory = await createTemporaryDirectory('codiff-login-shell-');
+  // Prints startup noise first, the way version managers do in real login
+  // shells, so parsing has to survive output preceding the marker.
+  const shell = await createFakeLoginShell(
+    directory.path,
+    `echo 'Using Node v24.15.0'
+CODIFF_FAKE_TOKEN='from-login-shell' CODIFF_FAKE_MULTILINE='first line
+second line' exec /bin/sh -c "$3"
+`,
+  );
+  await using _environment = createTemporaryEnvironment({ SHELL: shell });
+
+  const environment = await getLoginShellEnvironment();
+
+  expect(environment.CODIFF_FAKE_TOKEN).toBe('from-login-shell');
+  expect(environment.CODIFF_FAKE_MULTILINE).toBe('first line\nsecond line');
+});
+
+test('returns an empty environment when the login shell fails', async () => {
+  await using directory = await createTemporaryDirectory('codiff-login-shell-');
+  const shell = await createFakeLoginShell(directory.path, 'exit 1\n');
+  await using _environment = createTemporaryEnvironment({ SHELL: shell });
+
+  expect(await getLoginShellEnvironment()).toEqual({});
+});
+
+test('returns an empty environment when no login shell is configured', async () => {
+  await using _environment = createTemporaryEnvironment({ SHELL: undefined });
+
+  expect(await getLoginShellEnvironment()).toEqual({});
+});
+
+test('resolves each login shell once, even under concurrent calls', async () => {
+  await using directory = await createTemporaryDirectory('codiff-login-shell-');
+  const runsPath = join(directory.path, 'runs.txt');
+  const shell = await createFakeLoginShell(
+    directory.path,
+    `echo run >> '${runsPath}'
+CODIFF_FAKE_TOKEN='from-login-shell' exec /bin/sh -c "$3"
+`,
+  );
+  await using _environment = createTemporaryEnvironment({ SHELL: shell });
+
+  const [first, second] = await Promise.all([
+    getLoginShellEnvironment(),
+    getLoginShellEnvironment(),
+  ]);
+  const third = await getLoginShellEnvironment();
+
+  expect(second).toBe(first);
+  expect(third).toBe(first);
+  expect((await readFile(runsPath, 'utf8')).trim().split('\n')).toHaveLength(1);
+});

--- a/electron/__tests__/pull-request-command.test.ts
+++ b/electron/__tests__/pull-request-command.test.ts
@@ -95,7 +95,10 @@ test('reports a missing GitHub CLI when the resolved executable cannot be spawne
   await writeFile(fakeGh, '#!/codiff-missing-interpreter\n');
   await chmod(fakeGh, 0o755);
 
-  await using _environment = createTemporaryEnvironment({ CODIFF_GH_PATH: fakeGh });
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_GH_PATH: fakeGh,
+    SHELL: undefined,
+  });
 
   await expect(
     submitPullRequestReview(repo, {
@@ -158,6 +161,7 @@ printf '%s' '{}'
     CODIFF_GH_PATH: fakeGh,
     CODIFF_GITHUB_COMMAND_TEST_CALLS: callsPath,
     PATH: pathBin,
+    SHELL: undefined,
   });
 
   await submitPullRequestReview(repo, {
@@ -177,4 +181,67 @@ printf '%s' '{}'
     'api -X POST repos/nkzw-tech/codiff/pulls/12/reviews --input - | ' +
       '{"body":"General feedback.","comments":[],"event":"COMMENT"}',
   ]);
+});
+
+test('authenticates gh from the login shell environment when the app inherited none', async () => {
+  await using directory = await createTemporaryDirectory('codiff-gh-login-env-');
+  const repo = join(directory.path, 'repo');
+  const fakeGh = join(directory.path, 'gh');
+  const fakeShell = join(directory.path, 'fake-login-shell');
+
+  await mkdir(repo);
+  await execFileAsync('git', ['-C', repo, 'init']);
+  await execFileAsync('git', [
+    '-C',
+    repo,
+    'remote',
+    'add',
+    'origin',
+    'git@github.com:nkzw-tech/codiff.git',
+  ]);
+
+  // A GUI-launched Codiff keeps launchd's minimal environment: no GH_TOKEN,
+  // even when the user's login shell exports one. This gh fails auth exactly
+  // the way the real one does when the token never reaches it.
+  await writeFile(
+    fakeShell,
+    `#!/bin/sh
+GH_TOKEN='from-login-shell' exec /bin/sh -c "$3"
+`,
+  );
+  await writeFile(
+    fakeGh,
+    `#!/bin/sh
+if [ "$GH_TOKEN" != 'from-login-shell' ]; then
+  echo 'To get started with GitHub CLI, please run:  gh auth login' >&2
+  exit 4
+fi
+for arg in "$@"; do
+  if [ "$arg" = 'repos/nkzw-tech/codiff/pulls/12' ]; then
+    printf '%s' '{"head":{"sha":"0123456789abcdef0123456789abcdef01234567"}}'
+    exit 0
+  fi
+done
+printf '%s' '{}'
+`,
+  );
+  await Promise.all([chmod(fakeShell, 0o755), chmod(fakeGh, 0o755)]);
+
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_GH_PATH: fakeGh,
+    GH_TOKEN: undefined,
+    GITHUB_TOKEN: undefined,
+    SHELL: fakeShell,
+  });
+
+  await submitPullRequestReview(repo, {
+    body: 'General feedback.',
+    comments: [],
+    event: 'COMMENT',
+    source: {
+      provider: 'github',
+      type: 'pull-request',
+      url: 'https://github.com/nkzw-tech/codiff/pull/12',
+    },
+  });
 });

--- a/electron/__tests__/pull-request-command.test.ts
+++ b/electron/__tests__/pull-request-command.test.ts
@@ -245,3 +245,63 @@ printf '%s' '{}'
     },
   });
 });
+
+test('prefers the process environment over the login shell for gh', async () => {
+  await using directory = await createTemporaryDirectory('codiff-gh-env-precedence-');
+  const repo = join(directory.path, 'repo');
+  const fakeGh = join(directory.path, 'gh');
+  const fakeShell = join(directory.path, 'fake-login-shell');
+
+  await mkdir(repo);
+  await execFileAsync('git', ['-C', repo, 'init']);
+  await execFileAsync('git', [
+    '-C',
+    repo,
+    'remote',
+    'add',
+    'origin',
+    'git@github.com:nkzw-tech/codiff.git',
+  ]);
+
+  await writeFile(
+    fakeShell,
+    `#!/bin/sh
+GH_TOKEN='from-login-shell' exec /bin/sh -c "$3"
+`,
+  );
+  await writeFile(
+    fakeGh,
+    `#!/bin/sh
+if [ "$GH_TOKEN" != 'from-process' ]; then
+  echo 'Expected the process GH_TOKEN to win, got:' "$GH_TOKEN" >&2
+  exit 4
+fi
+for arg in "$@"; do
+  if [ "$arg" = 'repos/nkzw-tech/codiff/pulls/12' ]; then
+    printf '%s' '{"head":{"sha":"0123456789abcdef0123456789abcdef01234567"}}'
+    exit 0
+  fi
+done
+printf '%s' '{}'
+`,
+  );
+  await Promise.all([chmod(fakeShell, 0o755), chmod(fakeGh, 0o755)]);
+
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_GH_PATH: fakeGh,
+    GH_TOKEN: 'from-process',
+    GITHUB_TOKEN: undefined,
+    SHELL: fakeShell,
+  });
+
+  await submitPullRequestReview(repo, {
+    body: 'General feedback.',
+    comments: [],
+    event: 'COMMENT',
+    source: {
+      provider: 'github',
+      type: 'pull-request',
+      url: 'https://github.com/nkzw-tech/codiff/pull/12',
+    },
+  });
+});

--- a/electron/__tests__/pull-request-review.test.ts
+++ b/electron/__tests__/pull-request-review.test.ts
@@ -71,6 +71,7 @@ process.stdin.on('end', () => {
   await using _environment = createTemporaryEnvironment({
     CODIFF_GITHUB_REVIEW_TEST_CALLS: callsPath,
     PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+    SHELL: undefined,
   });
 
   const source = {

--- a/electron/git-state/pull-request.cjs
+++ b/electron/git-state/pull-request.cjs
@@ -4,6 +4,7 @@ const { spawn } = require('node:child_process');
 const { homedir } = require('node:os');
 const { join } = require('node:path');
 const { findExecutableOnPath, isExecutableFile } = require('../agent-shared.cjs');
+const { getLoginShellEnvironment } = require('../login-shell-environment.cjs');
 const {
   IMAGE_FILE_LIMIT,
   bufferToImageRevision,
@@ -276,10 +277,14 @@ const fetchPullRequestHistoryRefs = (repoRoot, remote, pullRequest, metadata) =>
  * @param {unknown} [input]
  * @returns {Promise<{code: number | null; stderr: string; stdout: Buffer}>}
  */
-const runGhApi = (repoRoot, args, input) =>
-  new Promise((resolve, reject) => {
+const runGhApi = async (repoRoot, args, input) => {
+  // GUI launches miss login shell variables like GH_TOKEN, so fill the gaps;
+  // the process environment wins for anything it already defines.
+  const environment = { ...(await getLoginShellEnvironment()), ...process.env };
+  return new Promise((resolve, reject) => {
     const child = spawn(getGhCommand(), ['api', ...args], {
       cwd: repoRoot,
+      env: environment,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     /** @type {Array<Buffer>} */
@@ -300,6 +305,7 @@ const runGhApi = (repoRoot, args, input) =>
 
     child.stdin.end(input == null ? undefined : JSON.stringify(input));
   });
+};
 
 /**
  * @param {string} repoRoot

--- a/electron/login-shell-environment.cjs
+++ b/electron/login-shell-environment.cjs
@@ -1,0 +1,81 @@
+// @ts-check
+
+const { spawn } = require('node:child_process');
+
+// Marks where login shell startup noise (version manager banners, greetings)
+// ends and the `env -0` dump begins.
+const ENVIRONMENT_MARKER = '__CODIFF_LOGIN_SHELL_ENVIRONMENT__';
+const ENVIRONMENT_COMMAND = `printf '${ENVIRONMENT_MARKER}'; /usr/bin/env -0`;
+const RESOLUTION_TIMEOUT = 10_000;
+const VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** @type {Map<string, Promise<Readonly<Record<string, string>>>>} */
+const cache = new Map();
+
+/**
+ * @param {string} output
+ * @returns {Readonly<Record<string, string>>}
+ */
+const parseEnvironment = (output) => {
+  const markerIndex = output.indexOf(ENVIRONMENT_MARKER);
+  if (markerIndex === -1) {
+    return {};
+  }
+
+  /** @type {Record<string, string>} */
+  const environment = {};
+  for (const entry of output.slice(markerIndex + ENVIRONMENT_MARKER.length).split('\0')) {
+    const separator = entry.indexOf('=');
+    if (separator > 0 && VARIABLE_NAME.test(entry.slice(0, separator))) {
+      environment[entry.slice(0, separator)] = entry.slice(separator + 1);
+    }
+  }
+  return environment;
+};
+
+/**
+ * @param {string} shell
+ * @returns {Promise<Readonly<Record<string, string>>>}
+ */
+const resolveLoginShellEnvironment = (shell) =>
+  new Promise((resolve) => {
+    const child = spawn(shell, ['-l', '-c', ENVIRONMENT_COMMAND], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: RESOLUTION_TIMEOUT,
+    });
+    /** @type {Array<Buffer>} */
+    const stdout = [];
+
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.on('error', () => resolve({}));
+    child.on('close', (code) =>
+      resolve(code === 0 ? parseEnvironment(Buffer.concat(stdout).toString('utf8')) : {}),
+    );
+  });
+
+/**
+ * The environment of the user's login shell, resolved once per shell and
+ * cached. GUI launches inherit launchd's minimal environment, so variables
+ * like `GH_TOKEN` may only exist in the login shell; resolving them lets CLI
+ * spawns behave the way they would in a terminal. Resolution failures yield
+ * an empty environment instead of an error.
+ *
+ * @returns {Promise<Readonly<Record<string, string>>>}
+ */
+const getLoginShellEnvironment = () => {
+  const shell = process.env.SHELL;
+  if (!shell) {
+    return Promise.resolve({});
+  }
+
+  let environment = cache.get(shell);
+  if (!environment) {
+    environment = resolveLoginShellEnvironment(shell);
+    cache.set(shell, environment);
+  }
+  return environment;
+};
+
+module.exports = {
+  getLoginShellEnvironment,
+};

--- a/electron/login-shell-environment.cjs
+++ b/electron/login-shell-environment.cjs
@@ -13,47 +13,6 @@ const VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const cache = new Map();
 
 /**
- * @param {string} output
- * @returns {Readonly<Record<string, string>>}
- */
-const parseEnvironment = (output) => {
-  const markerIndex = output.indexOf(ENVIRONMENT_MARKER);
-  if (markerIndex === -1) {
-    return {};
-  }
-
-  /** @type {Record<string, string>} */
-  const environment = {};
-  for (const entry of output.slice(markerIndex + ENVIRONMENT_MARKER.length).split('\0')) {
-    const separator = entry.indexOf('=');
-    if (separator > 0 && VARIABLE_NAME.test(entry.slice(0, separator))) {
-      environment[entry.slice(0, separator)] = entry.slice(separator + 1);
-    }
-  }
-  return environment;
-};
-
-/**
- * @param {string} shell
- * @returns {Promise<Readonly<Record<string, string>>>}
- */
-const resolveLoginShellEnvironment = (shell) =>
-  new Promise((resolve) => {
-    const child = spawn(shell, ['-l', '-c', ENVIRONMENT_COMMAND], {
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: RESOLUTION_TIMEOUT,
-    });
-    /** @type {Array<Buffer>} */
-    const stdout = [];
-
-    child.stdout.on('data', (chunk) => stdout.push(chunk));
-    child.on('error', () => resolve({}));
-    child.on('close', (code) =>
-      resolve(code === 0 ? parseEnvironment(Buffer.concat(stdout).toString('utf8')) : {}),
-    );
-  });
-
-/**
  * The environment of the user's login shell, resolved once per shell and
  * cached. GUI launches inherit launchd's minimal environment, so variables
  * like `GH_TOKEN` may only exist in the login shell; resolving them lets CLI
@@ -76,6 +35,62 @@ const getLoginShellEnvironment = () => {
   return environment;
 };
 
+/**
+ * Resolution settles no matter how the shell behaves: the deadline
+ * force-kills a shell that ignores termination and releases a stdout pipe
+ * kept open by a background child the shell left behind, the case where
+ * `close` trails `exit` indefinitely. A dump the shell completed cleanly
+ * before such a straggler is still used.
+ *
+ * @param {string} shell
+ * @param {number} [timeout]
+ * @returns {Promise<Readonly<Record<string, string>>>}
+ */
+const resolveLoginShellEnvironment = (shell, timeout = RESOLUTION_TIMEOUT) =>
+  new Promise((resolve) => {
+    const child = spawn(shell, ['-l', '-c', ENVIRONMENT_COMMAND], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    /** @type {Array<Buffer>} */
+    const stdout = [];
+    /** @param {number | null} code */
+    const finish = (code) => {
+      clearTimeout(deadline);
+      resolve(code === 0 ? parseEnvironment(Buffer.concat(stdout).toString('utf8')) : {});
+    };
+    const deadline = setTimeout(() => {
+      finish(child.exitCode);
+      child.kill('SIGKILL');
+      child.stdout.destroy();
+    }, timeout);
+
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.on('error', () => finish(null));
+    child.on('close', finish);
+  });
+
+/**
+ * @param {string} output
+ * @returns {Readonly<Record<string, string>>}
+ */
+const parseEnvironment = (output) => {
+  const markerIndex = output.indexOf(ENVIRONMENT_MARKER);
+  if (markerIndex === -1) {
+    return {};
+  }
+
+  /** @type {Record<string, string>} */
+  const environment = {};
+  for (const entry of output.slice(markerIndex + ENVIRONMENT_MARKER.length).split('\0')) {
+    const separator = entry.indexOf('=');
+    if (separator > 0 && VARIABLE_NAME.test(entry.slice(0, separator))) {
+      environment[entry.slice(0, separator)] = entry.slice(separator + 1);
+    }
+  }
+  return environment;
+};
+
 module.exports = {
   getLoginShellEnvironment,
+  resolveLoginShellEnvironment,
 };


### PR DESCRIPTION
Follow-up to #140. With `gh` now found reliably, opening a GitHub PR from a Dock-launched Codiff can still fail with:

```
Error invoking remote method 'codiff:getRepositoryState': Error: To get started with GitHub CLI, please run: gh auth login
```

This happens when the user's gh credentials exist only as an environment variable: `gh auth status` in a terminal reports logged in via `(GH_TOKEN)`, and there is no `~/.config/gh/hosts.yml` to fall back to. A GUI launch inherits launchd's minimal environment, which doesn't have `GH_TOKEN`, and the single-instance lock means a later terminal launch never refreshes the primary process's environment. So gh runs, finds no credentials, and gives up.

This PR resolves the login shell's environment and uses it to fill the gaps when spawning gh:

- `login-shell-environment.cjs` runs `$SHELL -l -c` with a marker followed by `/usr/bin/env -0`, parses the NUL-separated dump after the marker (so startup noise from version managers is ignored), and caches the result per shell.
- Resolution always settles. A deadline force-kills shells that ignore termination and releases stdout pipes held open by background children the shell leaves behind; a dump the shell completed cleanly before such a straggler is still used. Every failure mode resolves to an empty environment instead of an error.
- `runGhApi` spawns gh with `{ ...loginShellEnvironment, ...process.env }`, so the login shell only supplies variables the process doesn't already have. A terminal-launched Codiff behaves exactly as before.

The commits are ordered test first, then fix, with the regression test failing on the exact error above before the implementation.

`glab` has the same gap for users authenticating only through `GITLAB_TOKEN`. I left it out of scope here, happy to do it as a follow-up.

I built locally and tested the feature end-to-end, and all works now. 👍 