### PR TITLE
fix: open external links in the default browser

### DIFF
--- a/electron/__tests__/external-links.test.ts
+++ b/electron/__tests__/external-links.test.ts
@@ -1,0 +1,120 @@
+import { createRequire } from 'node:module';
+import { expect, test, vi } from 'vite-plus/test';
+
+const require = createRequire(import.meta.url);
+const { attachExternalLinkHandling } = require('../external-links.cjs') as {
+  attachExternalLinkHandling: (
+    webContents: FakeWebContents,
+    openExternal: (url: string) => Promise<void>,
+  ) => void;
+};
+
+type WindowOpenHandler = (details: { url: string }) => { action: 'allow' | 'deny' };
+
+type FakeNavigationEvent = { preventDefault: () => void };
+
+type FakeWebContents = {
+  getURL: () => string;
+  on: (event: string, listener: (event: FakeNavigationEvent, url: string) => void) => void;
+  setWindowOpenHandler: (handler: WindowOpenHandler) => void;
+};
+
+test('opens target="_blank" links in the default browser instead of an in-app window', () => {
+  const { openExternal, openWindow } = createFakeWebContents();
+
+  const result = openWindow('https://github.com/nkzw-tech/codiff/pull/1728');
+
+  expect(result).toEqual({ action: 'deny' });
+  expect(openExternal).toHaveBeenCalledExactlyOnceWith(
+    'https://github.com/nkzw-tech/codiff/pull/1728',
+  );
+});
+
+test('denies in-app windows without opening urls the browser should not receive', () => {
+  const { openExternal, openWindow } = createFakeWebContents();
+
+  for (const url of ['file:///etc/passwd', 'javascript:alert(1)', 'not a url']) {
+    expect(openWindow(url)).toEqual({ action: 'deny' });
+  }
+
+  expect(openExternal).not.toHaveBeenCalled();
+});
+
+test('redirects external navigation to the default browser', () => {
+  const { navigate, openExternal } = createFakeWebContents(
+    'file:///Applications/Codiff.app/Contents/Resources/app/web/dist/index.html',
+  );
+
+  const event = navigate('https://github.com/nkzw-tech/codiff/pull/1728');
+
+  expect(event.preventDefault).toHaveBeenCalledOnce();
+  expect(openExternal).toHaveBeenCalledExactlyOnceWith(
+    'https://github.com/nkzw-tech/codiff/pull/1728',
+  );
+});
+
+test('lets the renderer dev server navigate within its own origin', () => {
+  const { navigate, openExternal } = createFakeWebContents('http://127.0.0.1:5173/');
+
+  const event = navigate('http://127.0.0.1:5173/index.html');
+
+  expect(event.preventDefault).not.toHaveBeenCalled();
+  expect(openExternal).not.toHaveBeenCalled();
+});
+
+test('lets the packaged renderer reload its own file url', () => {
+  const url = 'file:///Applications/Codiff.app/Contents/Resources/app/web/dist/index.html';
+  const { navigate, openExternal } = createFakeWebContents(url);
+
+  const event = navigate(url);
+
+  expect(event.preventDefault).not.toHaveBeenCalled();
+  expect(openExternal).not.toHaveBeenCalled();
+});
+
+test('blocks navigation to other local files without opening anything', () => {
+  const { navigate, openExternal } = createFakeWebContents(
+    'file:///Applications/Codiff.app/Contents/Resources/app/web/dist/index.html',
+  );
+
+  const event = navigate('file:///etc/passwd');
+
+  expect(event.preventDefault).toHaveBeenCalledOnce();
+  expect(openExternal).not.toHaveBeenCalled();
+});
+
+function createFakeWebContents(currentUrl = 'http://127.0.0.1:5173/') {
+  let windowOpenHandler: WindowOpenHandler | null = null;
+  const navigationListeners: Array<(event: FakeNavigationEvent, url: string) => void> = [];
+  const openExternal = vi.fn(async () => {});
+
+  const webContents: FakeWebContents = {
+    getURL: () => currentUrl,
+    on: (event, listener) => {
+      if (event === 'will-navigate') {
+        navigationListeners.push(listener);
+      }
+    },
+    setWindowOpenHandler: (handler) => {
+      windowOpenHandler = handler;
+    },
+  };
+  attachExternalLinkHandling(webContents, openExternal);
+
+  return {
+    navigate: (url: string) => {
+      const event = { preventDefault: vi.fn() };
+      for (const listener of navigationListeners) {
+        listener(event, url);
+      }
+      return event;
+    },
+    openExternal,
+    openWindow: (url: string) => {
+      if (!windowOpenHandler) {
+        throw new Error('attachExternalLinkHandling did not register a window open handler.');
+      }
+      return windowOpenHandler({ url });
+    },
+  };
+}

--- a/electron/__tests__/external-links.test.ts
+++ b/electron/__tests__/external-links.test.ts
@@ -72,6 +72,21 @@ test('lets the packaged renderer reload its own file url', () => {
   expect(openExternal).not.toHaveBeenCalled();
 });
 
+test('attaches rejection handling so a failed browser launch cannot crash the app', () => {
+  const openExternalResult = { catch: vi.fn() };
+  const openExternal = vi.fn(() => openExternalResult as unknown as Promise<void>);
+  const { navigate, openWindow } = createFakeWebContents(
+    'file:///Applications/Codiff.app/Contents/Resources/app/web/dist/index.html',
+    openExternal,
+  );
+
+  openWindow('https://github.com/nkzw-tech/codiff/pull/1728');
+  navigate('https://github.com/nkzw-tech/codiff/pull/1728');
+
+  expect(openExternal).toHaveBeenCalledTimes(2);
+  expect(openExternalResult.catch).toHaveBeenCalledTimes(2);
+});
+
 test('blocks navigation to other local files without opening anything', () => {
   const { navigate, openExternal } = createFakeWebContents(
     'file:///Applications/Codiff.app/Contents/Resources/app/web/dist/index.html',
@@ -83,10 +98,12 @@ test('blocks navigation to other local files without opening anything', () => {
   expect(openExternal).not.toHaveBeenCalled();
 });
 
-function createFakeWebContents(currentUrl = 'http://127.0.0.1:5173/') {
+function createFakeWebContents(
+  currentUrl = 'http://127.0.0.1:5173/',
+  openExternal: (url: string) => Promise<void> = vi.fn(async () => {}),
+) {
   let windowOpenHandler: WindowOpenHandler | null = null;
   const navigationListeners: Array<(event: FakeNavigationEvent, url: string) => void> = [];
-  const openExternal = vi.fn(async () => {});
 
   const webContents: FakeWebContents = {
     getURL: () => currentUrl,

--- a/electron/external-links.cjs
+++ b/electron/external-links.cjs
@@ -11,9 +11,14 @@
  * @param {(url: string) => Promise<void>} openExternal
  */
 const attachExternalLinkHandling = (webContents, openExternal) => {
+  // shell.openExternal rejects when the operating system cannot open the url;
+  // an unhandled rejection in the main process is all that would come of it.
+  const openSafely = (url) => {
+    void openExternal(url).catch(() => {});
+  };
   webContents.setWindowOpenHandler(({ url }) => {
     if (isOpenableExternally(url)) {
-      void openExternal(url);
+      openSafely(url);
     }
     return { action: 'deny' };
   });
@@ -23,7 +28,7 @@ const attachExternalLinkHandling = (webContents, openExternal) => {
     }
     event.preventDefault();
     if (isOpenableExternally(url)) {
-      void openExternal(url);
+      openSafely(url);
     }
   });
 };

--- a/electron/external-links.cjs
+++ b/electron/external-links.cjs
@@ -1,0 +1,64 @@
+// @ts-check
+
+/**
+ * Electron's default window-open behavior spawns an in-app child window with
+ * its own cookie-less session, so target="_blank" links such as the pull
+ * request badge land on GitHub unauthenticated (a 404 for private
+ * repositories). Deny every in-app window and hand openable links to the
+ * operating system's default browser instead; navigation away from the
+ * renderer gets the same treatment so the app window never leaves the app.
+ * @param {Pick<import('electron').WebContents, 'getURL' | 'on' | 'setWindowOpenHandler'>} webContents
+ * @param {(url: string) => Promise<void>} openExternal
+ */
+const attachExternalLinkHandling = (webContents, openExternal) => {
+  webContents.setWindowOpenHandler(({ url }) => {
+    if (isOpenableExternally(url)) {
+      void openExternal(url);
+    }
+    return { action: 'deny' };
+  });
+  webContents.on('will-navigate', (event, url) => {
+    if (isInAppNavigation(url, webContents.getURL())) {
+      return;
+    }
+    event.preventDefault();
+    if (isOpenableExternally(url)) {
+      void openExternal(url);
+    }
+  });
+};
+
+const EXTERNAL_PROTOCOLS = new Set(['http:', 'https:']);
+
+/** @param {string} url */
+const isOpenableExternally = (url) => {
+  try {
+    return EXTERNAL_PROTOCOLS.has(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * In-app navigation is a reload of the current url or, for the dev server,
+ * another url on the renderer's own origin. Everything else (including other
+ * file: urls) stays blocked so the window cannot be steered off the app.
+ * @param {string} target
+ * @param {string} current
+ */
+const isInAppNavigation = (target, current) => {
+  try {
+    const targetUrl = new URL(target);
+    const currentUrl = new URL(current);
+    return (
+      targetUrl.href === currentUrl.href ||
+      (EXTERNAL_PROTOCOLS.has(targetUrl.protocol) &&
+        EXTERNAL_PROTOCOLS.has(currentUrl.protocol) &&
+        targetUrl.origin === currentUrl.origin)
+    );
+  } catch {
+    return false;
+  }
+};
+
+module.exports = { attachExternalLinkHandling };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -26,6 +26,7 @@ const {
   submitPullRequestReview,
   validateRepositoryPath,
 } = require('./git-state.cjs');
+const { attachExternalLinkHandling } = require('./external-links.cjs');
 const { normalizeOpenAIModel } = require('./codex.cjs');
 const { normalizeClaudeModel } = require('./claude.cjs');
 const { normalizeOpenCodeModel, renderOpenCodeCommand } = require('./opencode.cjs');
@@ -903,6 +904,8 @@ const createWindow = (
   if (validatedState?.isFullScreen) {
     window.setFullScreen(true);
   }
+
+  attachExternalLinkHandling(window.webContents, (url) => shell.openExternal(url));
 
   const webContentsId = window.webContents.id;
   openWindows.add(window);


### PR DESCRIPTION
Clicking the PR link in the top bar opened GitHub in an in-app Electron window. That window has no cookies or login session, so private repos render GitHub's 404 page:

<img width="912" height="712" alt="image" src="https://github.com/user-attachments/assets/baaa040b-78c3-4882-a9cc-846f19c97b2e" />

The root cause is that no window open handler was registered, so Electron's default behavior (spawn a child window) applied to every `target="_blank"` link: the PR link, CI check links, and links in rendered markdown.

This PR adds a `setWindowOpenHandler` that denies in-app windows and hands http(s) urls to `shell.openExternal`, so links open in the user's default browser on macOS, Windows, and Linux. A `will-navigate` guard keeps the app window itself from being steered off the app, other schemes like `file:` and `javascript:` are dropped entirely, and rejections from `shell.openExternal` are handled so a failed launch can't crash the main process.

Changes made using Fable 5 xhigh, with review loop by Sol 5.6 xhigh.
I built the app with these changes and can confirm they work as intended.