### PR TITLE
feat: add a top bar menu for opening a PR, branch, or commit

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -946,7 +946,6 @@ a.review-top-bar-source:focus-visible {
   -webkit-app-region: no-drag;
   display: inline-flex;
   flex: none;
-  position: relative;
 }
 
 .open-review-source-menu-list {
@@ -962,11 +961,9 @@ a.review-top-bar-source:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  left: 0;
   min-width: 176px;
   padding: 4px;
-  position: absolute;
-  top: calc(100% + 6px);
+  position: fixed;
   z-index: 60;
 }
 

--- a/core/App.css
+++ b/core/App.css
@@ -908,7 +908,8 @@ a.review-top-bar-source:focus-visible {
   width: 6px;
 }
 
-.sidebar-toggle-button {
+.sidebar-toggle-button,
+.open-review-source-trigger {
   -webkit-app-region: no-drag;
   align-items: center;
   background: transparent;
@@ -928,13 +929,72 @@ a.review-top-bar-source:focus-visible {
   width: 28px;
 }
 
-.sidebar-toggle-button:hover {
+.sidebar-toggle-button:hover,
+.open-review-source-trigger:hover {
   background: rgb(127 127 127 / 0.14);
   color: var(--sidebar-text);
 }
 
-.sidebar-toggle-button:active {
+.sidebar-toggle-button:active,
+.open-review-source-trigger:active,
+.open-review-source-trigger[aria-expanded='true'] {
   background: rgb(127 127 127 / 0.2);
+  color: var(--sidebar-text);
+}
+
+.open-review-source-menu {
+  -webkit-app-region: no-drag;
+  display: inline-flex;
+  flex: none;
+  position: relative;
+}
+
+.open-review-source-menu-list {
+  backdrop-filter: blur(28px) saturate(1.4);
+  background: color-mix(in srgb, var(--code-bg) 92%, transparent);
+  border: 1px solid var(--file-border);
+  border-radius: 14px;
+  box-shadow:
+    0 0 0 1px rgb(255 255 255 / 0.08) inset,
+    0 12px 32px -18px rgb(0 0 0 / 0.6),
+    0 4px 12px -8px rgb(0 0 0 / 0.5);
+  corner-shape: squircle;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  left: 0;
+  min-width: 176px;
+  padding: 4px;
+  position: absolute;
+  top: calc(100% + 6px);
+  z-index: 60;
+}
+
+.open-review-source-menu-item {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 10px;
+  color: var(--text);
+  corner-shape: squircle;
+  cursor: pointer;
+  display: flex;
+  font: 600 12px/1 var(--font-sans);
+  gap: 8px;
+  padding: 7px 9px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.open-review-source-menu-item:hover,
+.open-review-source-menu-item:focus {
+  background: rgb(127 127 127 / 0.14);
+  outline: none;
+}
+
+.open-review-source-menu-item svg {
+  color: var(--muted);
+  flex: none;
 }
 
 .sidebar-resizer {

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CommandBar } from './app/components/CommandBar.tsx';
 import { KeyboardShortcutsHelp } from './app/components/KeyboardShortcutsHelp.tsx';
 import { OpenReviewSourceDialog } from './app/components/OpenReviewSourceDialog.tsx';
+import { OpenReviewSourceMenu } from './app/components/OpenReviewSourceMenu.tsx';
 import {
   AgentUnavailablePanel,
   CopyCommentsButton,
@@ -1819,6 +1820,7 @@ export default function App() {
         }
         repositoryTooltip={state.root}
         sidebarCollapsed={sidebarCollapsed}
+        sourceMenu={<OpenReviewSourceMenu onOpen={showOpenReviewSourceDialog} />}
         toggleTitle={`${sidebarCollapsed ? 'Expand' : 'Collapse'} sidebar (${getShortcutLabel(
           codiffConfig.keymap,
           'toggleSidebar',

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -495,9 +495,9 @@ test('top bar source menu opens the review source dialog', async () => {
     trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
 
-  const pullRequestItem = [...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')].find(
-    (item) => item.textContent === 'Open PR',
-  );
+  const pullRequestItem = [
+    ...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+  ].find((item) => item.textContent === 'Open PR');
   if (!pullRequestItem) {
     throw new Error('Expected an Open PR menu item.');
   }

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -479,6 +479,37 @@ test('keeps source-loading errors in the open-source dialog', async () => {
   expect(app.container.textContent).not.toContain('Unable to read repository');
 });
 
+test('top bar source menu opens the review source dialog', async () => {
+  window.codiff = createCodiffMock();
+
+  await using app = await renderReact(<App />);
+  await waitFor(() => expect(app.container.querySelector('.app-shell')).not.toBeNull());
+
+  const trigger = app.container.querySelector<HTMLButtonElement>(
+    '.review-top-bar .open-review-source-trigger',
+  );
+  if (!trigger) {
+    throw new Error('Expected the open review source trigger in the top bar.');
+  }
+  await act(async () => {
+    trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  const pullRequestItem = [
+    ...app.container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+  ].find((item) => item.textContent === 'Open PR');
+  if (!pullRequestItem) {
+    throw new Error('Expected an Open PR menu item.');
+  }
+  await act(async () => {
+    pullRequestItem.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  const input = app.container.querySelector<HTMLInputElement>('#open-review-source-input');
+  expect(input?.placeholder).toBe('#123 or https://github.com/owner/repo/pull/123');
+  expect(app.container.querySelector('[role="menu"]')).toBeNull();
+});
+
 test('empty repository state fills the review pane for centered layout', async () => {
   window.codiff = createCodiffMock();
 

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -495,9 +495,9 @@ test('top bar source menu opens the review source dialog', async () => {
     trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
 
-  const pullRequestItem = [
-    ...app.container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
-  ].find((item) => item.textContent === 'Open PR');
+  const pullRequestItem = [...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')].find(
+    (item) => item.textContent === 'Open PR',
+  );
   if (!pullRequestItem) {
     throw new Error('Expected an Open PR menu item.');
   }
@@ -507,7 +507,7 @@ test('top bar source menu opens the review source dialog', async () => {
 
   const input = app.container.querySelector<HTMLInputElement>('#open-review-source-input');
   expect(input?.placeholder).toBe('#123 or https://github.com/owner/repo/pull/123');
-  expect(app.container.querySelector('[role="menu"]')).toBeNull();
+  expect(document.querySelector('[role="menu"]')).toBeNull();
 });
 
 test('empty repository state fills the review pane for centered layout', async () => {

--- a/core/__tests__/OpenReviewSourceMenu.test.tsx
+++ b/core/__tests__/OpenReviewSourceMenu.test.tsx
@@ -19,11 +19,7 @@ test('opens the menu from the trigger and moves focus to the first action', asyn
 
   expect(trigger.getAttribute('aria-expanded')).toBe('true');
   const items = getMenuItems(view.container);
-  expect(items.map((item) => item.textContent)).toEqual([
-    'Open PR',
-    'Open Branch',
-    'Open Commit',
-  ]);
+  expect(items.map((item) => item.textContent)).toEqual(['Open PR', 'Open Branch', 'Open Commit']);
   expect(document.activeElement).toBe(items[0]);
 });
 

--- a/core/__tests__/OpenReviewSourceMenu.test.tsx
+++ b/core/__tests__/OpenReviewSourceMenu.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from 'react';
+import { expect, test, vi } from 'vite-plus/test';
+import { OpenReviewSourceMenu } from '../app/components/OpenReviewSourceMenu.tsx';
+import { renderReact } from './helpers/react.tsx';
+
+test('opens the menu from the trigger and moves focus to the first action', async () => {
+  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+  const trigger = getTrigger(view.container);
+
+  expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
+  expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  expect(view.container.querySelector('[role="menu"]')).toBeNull();
+
+  await click(trigger);
+
+  expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  const items = getMenuItems(view.container);
+  expect(items.map((item) => item.textContent)).toEqual([
+    'Open PR',
+    'Open Branch',
+    'Open Commit',
+  ]);
+  expect(document.activeElement).toBe(items[0]);
+});
+
+test('selecting an action reports its kind and closes the menu', async () => {
+  const onOpen = vi.fn();
+  await using view = await renderReact(<OpenReviewSourceMenu onOpen={onOpen} />);
+
+  await click(getTrigger(view.container));
+  const commitItem = getMenuItems(view.container).find(
+    (item) => item.textContent === 'Open Commit',
+  );
+  if (!commitItem) {
+    throw new Error('Expected an Open Commit menu item.');
+  }
+  await click(commitItem);
+
+  expect(onOpen).toHaveBeenCalledExactlyOnceWith('commit');
+  expect(view.container.querySelector('[role="menu"]')).toBeNull();
+  expect(getTrigger(view.container).getAttribute('aria-expanded')).toBe('false');
+});
+
+test('arrow keys move through the actions and wrap around', async () => {
+  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+
+  await click(getTrigger(view.container));
+  const [pullRequest, branch, commit] = getMenuItems(view.container);
+
+  await pressKey('ArrowDown');
+  expect(document.activeElement).toBe(branch);
+  await pressKey('ArrowDown');
+  expect(document.activeElement).toBe(commit);
+  await pressKey('ArrowDown');
+  expect(document.activeElement).toBe(pullRequest);
+  await pressKey('ArrowUp');
+  expect(document.activeElement).toBe(commit);
+  await pressKey('Home');
+  expect(document.activeElement).toBe(pullRequest);
+  await pressKey('End');
+  expect(document.activeElement).toBe(commit);
+});
+
+test('Escape closes the menu and returns focus to the trigger', async () => {
+  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+  const trigger = getTrigger(view.container);
+
+  await click(trigger);
+  await pressKey('Escape');
+
+  expect(view.container.querySelector('[role="menu"]')).toBeNull();
+  expect(document.activeElement).toBe(trigger);
+});
+
+test('clicking outside dismisses the menu without opening anything', async () => {
+  const onOpen = vi.fn();
+  await using view = await renderReact(<OpenReviewSourceMenu onOpen={onOpen} />);
+
+  await click(getTrigger(view.container));
+  await act(async () => {
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+  });
+
+  expect(view.container.querySelector('[role="menu"]')).toBeNull();
+  expect(onOpen).not.toHaveBeenCalled();
+});
+
+function getTrigger(container: HTMLElement) {
+  const trigger = container.querySelector<HTMLButtonElement>('.open-review-source-trigger');
+  if (!trigger) {
+    throw new Error('Expected the open review source trigger.');
+  }
+  return trigger;
+}
+
+function getMenuItems(container: HTMLElement) {
+  return [...container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')];
+}
+
+async function click(element: HTMLElement) {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+async function pressKey(key: string) {
+  await act(async () => {
+    document.activeElement?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key }));
+  });
+}

--- a/core/__tests__/OpenReviewSourceMenu.test.tsx
+++ b/core/__tests__/OpenReviewSourceMenu.test.tsx
@@ -13,14 +13,25 @@ test('opens the menu from the trigger and moves focus to the first action', asyn
 
   expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
   expect(trigger.getAttribute('aria-expanded')).toBe('false');
-  expect(view.container.querySelector('[role="menu"]')).toBeNull();
+  expect(queryMenu()).toBeNull();
 
   await click(trigger);
 
   expect(trigger.getAttribute('aria-expanded')).toBe('true');
-  const items = getMenuItems(view.container);
+  const items = getMenuItems();
   expect(items.map((item) => item.textContent)).toEqual(['Open PR', 'Open Branch', 'Open Commit']);
   expect(document.activeElement).toBe(items[0]);
+});
+
+test('renders the open menu outside the top bar so stacking contexts cannot trap it', async () => {
+  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+
+  await click(getTrigger(view.container));
+
+  const menu = queryMenu();
+  expect(menu).not.toBeNull();
+  expect(view.container.contains(menu)).toBe(false);
+  expect(menu?.parentElement).toBe(document.body);
 });
 
 test('selecting an action reports its kind and closes the menu', async () => {
@@ -28,16 +39,14 @@ test('selecting an action reports its kind and closes the menu', async () => {
   await using view = await renderReact(<OpenReviewSourceMenu onOpen={onOpen} />);
 
   await click(getTrigger(view.container));
-  const commitItem = getMenuItems(view.container).find(
-    (item) => item.textContent === 'Open Commit',
-  );
+  const commitItem = getMenuItems().find((item) => item.textContent === 'Open Commit');
   if (!commitItem) {
     throw new Error('Expected an Open Commit menu item.');
   }
   await click(commitItem);
 
   expect(onOpen).toHaveBeenCalledExactlyOnceWith('commit');
-  expect(view.container.querySelector('[role="menu"]')).toBeNull();
+  expect(queryMenu()).toBeNull();
   expect(getTrigger(view.container).getAttribute('aria-expanded')).toBe('false');
 });
 
@@ -45,7 +54,7 @@ test('arrow keys move through the actions and wrap around', async () => {
   await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
 
   await click(getTrigger(view.container));
-  const [pullRequest, branch, commit] = getMenuItems(view.container);
+  const [pullRequest, branch, commit] = getMenuItems();
 
   await pressKey('ArrowDown');
   expect(document.activeElement).toBe(branch);
@@ -68,7 +77,7 @@ test('Escape closes the menu and returns focus to the trigger', async () => {
   await click(trigger);
   await pressKey('Escape');
 
-  expect(view.container.querySelector('[role="menu"]')).toBeNull();
+  expect(queryMenu()).toBeNull();
   expect(document.activeElement).toBe(trigger);
 });
 
@@ -81,7 +90,7 @@ test('clicking outside dismisses the menu without opening anything', async () =>
     document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
   });
 
-  expect(view.container.querySelector('[role="menu"]')).toBeNull();
+  expect(queryMenu()).toBeNull();
   expect(onOpen).not.toHaveBeenCalled();
 });
 
@@ -93,8 +102,12 @@ function getTrigger(container: HTMLElement) {
   return trigger;
 }
 
-function getMenuItems(container: HTMLElement) {
-  return [...container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')];
+function queryMenu() {
+  return document.querySelector('[role="menu"]');
+}
+
+function getMenuItems() {
+  return [...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')];
 }
 
 async function click(element: HTMLElement) {

--- a/core/__tests__/OpenReviewSourceMenu.test.tsx
+++ b/core/__tests__/OpenReviewSourceMenu.test.tsx
@@ -81,6 +81,23 @@ test('Escape closes the menu and returns focus to the trigger', async () => {
   expect(document.activeElement).toBe(trigger);
 });
 
+test('Tab hands focus back to the trigger so traversal continues from the top bar', async () => {
+  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+  const trigger = getTrigger(view.container);
+
+  await click(trigger);
+  await pressKey('Tab');
+
+  expect(queryMenu()).toBeNull();
+  expect(document.activeElement).toBe(trigger);
+
+  await click(trigger);
+  await pressKey('Tab', { shiftKey: true });
+
+  expect(queryMenu()).toBeNull();
+  expect(document.activeElement).toBe(trigger);
+});
+
 test('clicking outside dismisses the menu without opening anything', async () => {
   const onOpen = vi.fn();
   await using view = await renderReact(<OpenReviewSourceMenu onOpen={onOpen} />);
@@ -116,8 +133,10 @@ async function click(element: HTMLElement) {
   });
 }
 
-async function pressKey(key: string) {
+async function pressKey(key: string, { shiftKey = false } = {}) {
   await act(async () => {
-    document.activeElement?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key }));
+    document.activeElement?.dispatchEvent(
+      new KeyboardEvent('keydown', { bubbles: true, key, shiftKey }),
+    );
   });
 }

--- a/core/app/components/OpenReviewSourceMenu.tsx
+++ b/core/app/components/OpenReviewSourceMenu.tsx
@@ -96,7 +96,10 @@ export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSour
   const handleMenuKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
       if (event.key === 'Tab') {
-        close();
+        // The portal lives at the end of the body, so native traversal from a
+        // menu item would wrap to the document edges. Refocusing the trigger
+        // before the default action makes Tab continue from the top bar.
+        closeWithFocus();
         return;
       }
       if (event.key === 'Escape') {
@@ -125,7 +128,7 @@ export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSour
         items[nextIndex]?.focus();
       }
     },
-    [close, closeWithFocus],
+    [closeWithFocus],
   );
 
   return (

--- a/core/app/components/OpenReviewSourceMenu.tsx
+++ b/core/app/components/OpenReviewSourceMenu.tsx
@@ -1,0 +1,154 @@
+import { GitBranchIcon as GitBranch } from '@phosphor-icons/react/GitBranch';
+import { GitCommitIcon as GitCommit } from '@phosphor-icons/react/GitCommit';
+import { GitPullRequestIcon as GitPullRequest } from '@phosphor-icons/react/GitPullRequest';
+import { PlusIcon as Plus } from '@phosphor-icons/react/Plus';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import type { OpenReviewSourceKind } from '../../types.ts';
+
+const menuActions: ReadonlyArray<{
+  icon: ReactNode;
+  kind: OpenReviewSourceKind;
+  label: string;
+}> = [
+  {
+    icon: <GitPullRequest aria-hidden size={15} weight="bold" />,
+    kind: 'pull-request',
+    label: 'Open PR',
+  },
+  {
+    icon: <GitBranch aria-hidden size={15} weight="bold" />,
+    kind: 'branch',
+    label: 'Open Branch',
+  },
+  {
+    icon: <GitCommit aria-hidden size={15} weight="bold" />,
+    kind: 'commit',
+    label: 'Open Commit',
+  },
+];
+
+export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSourceKind) => void }) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    itemRefs.current[0]?.focus();
+    const dismiss = (event: PointerEvent) => {
+      // oxlint-disable-next-line @nkzw/no-instanceof
+      if (event.target instanceof Node && !rootRef.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', dismiss);
+    return () => document.removeEventListener('pointerdown', dismiss);
+  }, [open]);
+
+  const closeWithFocus = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  const handleTriggerKeyDown = useCallback((event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setOpen(true);
+    }
+  }, []);
+
+  const handleMenuKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Tab') {
+        setOpen(false);
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeWithFocus();
+        return;
+      }
+
+      const items = itemRefs.current.filter((item) => item != null);
+      if (!items.length) {
+        return;
+      }
+      const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+      const nextIndex =
+        event.key === 'ArrowDown'
+          ? (currentIndex + 1) % items.length
+          : event.key === 'ArrowUp'
+            ? (currentIndex - 1 + items.length) % items.length
+            : event.key === 'Home'
+              ? 0
+              : event.key === 'End'
+                ? items.length - 1
+                : null;
+      if (nextIndex != null) {
+        event.preventDefault();
+        items[nextIndex]?.focus();
+      }
+    },
+    [closeWithFocus],
+  );
+
+  return (
+    <div className="open-review-source-menu" ref={rootRef}>
+      <button
+        aria-controls={open ? 'open-review-source-menu' : undefined}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Open a PR, branch, or commit"
+        className="open-review-source-trigger"
+        id="open-review-source-trigger"
+        onClick={() => setOpen((previous) => !previous)}
+        onKeyDown={handleTriggerKeyDown}
+        ref={triggerRef}
+        title="Open a PR, branch, or commit"
+        type="button"
+      >
+        <Plus aria-hidden size={16} weight="bold" />
+      </button>
+      {open ? (
+        <div
+          aria-labelledby="open-review-source-trigger"
+          className="open-review-source-menu-list"
+          id="open-review-source-menu"
+          onKeyDown={handleMenuKeyDown}
+          role="menu"
+        >
+          {menuActions.map((action, index) => (
+            <button
+              className="open-review-source-menu-item"
+              key={action.kind}
+              onClick={() => {
+                setOpen(false);
+                onOpen(action.kind);
+              }}
+              ref={(element) => {
+                itemRefs.current[index] = element;
+              }}
+              role="menuitem"
+              tabIndex={-1}
+              type="button"
+            >
+              {action.icon}
+              <span>{action.label}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/core/app/components/OpenReviewSourceMenu.tsx
+++ b/core/app/components/OpenReviewSourceMenu.tsx
@@ -10,6 +10,7 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from 'react';
+import { createPortal } from 'react-dom';
 import type { OpenReviewSourceKind } from '../../types.ts';
 
 const menuActions: ReadonlyArray<{
@@ -35,10 +36,23 @@ const menuActions: ReadonlyArray<{
 ];
 
 export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSourceKind) => void }) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
+  // The top bar creates a stacking context (backdrop-filter) that later
+  // sibling rows paint over on non-macOS platforms, so the menu is portaled to
+  // the document body and positioned from the trigger's viewport rect.
+  const [menuPosition, setMenuPosition] = useState<{ left: number; top: number } | null>(null);
+  const open = menuPosition != null;
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const openMenu = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    setMenuPosition({ left: rect?.left ?? 0, top: (rect?.bottom ?? 0) + 6 });
+  }, []);
+
+  const close = useCallback(() => {
+    setMenuPosition(null);
+  }, []);
 
   useEffect(() => {
     if (!open) {
@@ -47,31 +61,42 @@ export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSour
 
     itemRefs.current[0]?.focus();
     const dismiss = (event: PointerEvent) => {
-      // oxlint-disable-next-line @nkzw/no-instanceof
-      if (event.target instanceof Node && !rootRef.current?.contains(event.target)) {
-        setOpen(false);
+      if (
+        // oxlint-disable-next-line @nkzw/no-instanceof
+        event.target instanceof Node &&
+        !triggerRef.current?.contains(event.target) &&
+        !menuRef.current?.contains(event.target)
+      ) {
+        close();
       }
     };
     document.addEventListener('pointerdown', dismiss);
-    return () => document.removeEventListener('pointerdown', dismiss);
-  }, [open]);
+    window.addEventListener('resize', close);
+    return () => {
+      document.removeEventListener('pointerdown', dismiss);
+      window.removeEventListener('resize', close);
+    };
+  }, [close, open]);
 
   const closeWithFocus = useCallback(() => {
-    setOpen(false);
+    close();
     triggerRef.current?.focus();
-  }, []);
+  }, [close]);
 
-  const handleTriggerKeyDown = useCallback((event: KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      setOpen(true);
-    }
-  }, []);
+  const handleTriggerKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        openMenu();
+      }
+    },
+    [openMenu],
+  );
 
   const handleMenuKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
       if (event.key === 'Tab') {
-        setOpen(false);
+        close();
         return;
       }
       if (event.key === 'Escape') {
@@ -100,11 +125,11 @@ export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSour
         items[nextIndex]?.focus();
       }
     },
-    [closeWithFocus],
+    [close, closeWithFocus],
   );
 
   return (
-    <div className="open-review-source-menu" ref={rootRef}>
+    <div className="open-review-source-menu">
       <button
         aria-controls={open ? 'open-review-source-menu' : undefined}
         aria-expanded={open}
@@ -112,7 +137,7 @@ export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSour
         aria-label="Open a PR, branch, or commit"
         className="open-review-source-trigger"
         id="open-review-source-trigger"
-        onClick={() => setOpen((previous) => !previous)}
+        onClick={open ? close : openMenu}
         onKeyDown={handleTriggerKeyDown}
         ref={triggerRef}
         title="Open a PR, branch, or commit"
@@ -120,35 +145,40 @@ export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSour
       >
         <Plus aria-hidden size={16} weight="bold" />
       </button>
-      {open ? (
-        <div
-          aria-labelledby="open-review-source-trigger"
-          className="open-review-source-menu-list"
-          id="open-review-source-menu"
-          onKeyDown={handleMenuKeyDown}
-          role="menu"
-        >
-          {menuActions.map((action, index) => (
-            <button
-              className="open-review-source-menu-item"
-              key={action.kind}
-              onClick={() => {
-                setOpen(false);
-                onOpen(action.kind);
-              }}
-              ref={(element) => {
-                itemRefs.current[index] = element;
-              }}
-              role="menuitem"
-              tabIndex={-1}
-              type="button"
+      {menuPosition
+        ? createPortal(
+            <div
+              aria-labelledby="open-review-source-trigger"
+              className="open-review-source-menu-list"
+              id="open-review-source-menu"
+              onKeyDown={handleMenuKeyDown}
+              ref={menuRef}
+              role="menu"
+              style={{ left: menuPosition.left, top: menuPosition.top }}
             >
-              {action.icon}
-              <span>{action.label}</span>
-            </button>
-          ))}
-        </div>
-      ) : null}
+              {menuActions.map((action, index) => (
+                <button
+                  className="open-review-source-menu-item"
+                  key={action.kind}
+                  onClick={() => {
+                    close();
+                    onOpen(action.kind);
+                  }}
+                  ref={(element) => {
+                    itemRefs.current[index] = element;
+                  }}
+                  role="menuitem"
+                  tabIndex={-1}
+                  type="button"
+                >
+                  {action.icon}
+                  <span>{action.label}</span>
+                </button>
+              ))}
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   );
 }

--- a/core/app/components/ReviewTopBar.tsx
+++ b/core/app/components/ReviewTopBar.tsx
@@ -21,6 +21,7 @@ export function ReviewTopBar<Mode extends string>({
   repository,
   repositoryTooltip,
   sidebarCollapsed,
+  sourceMenu,
   toggleTitle,
 }: {
   actions?: ReactNode;
@@ -33,6 +34,7 @@ export function ReviewTopBar<Mode extends string>({
   repository: ReactNode;
   repositoryTooltip?: string;
   sidebarCollapsed: boolean;
+  sourceMenu?: ReactNode;
   toggleTitle: string;
 }) {
   return (
@@ -48,6 +50,7 @@ export function ReviewTopBar<Mode extends string>({
         >
           <SidebarSimple aria-hidden size={18} weight="bold" />
         </button>
+        {sourceMenu}
         <div className="review-top-bar-repository-slot" title={repositoryTooltip}>
           {repository}
         </div>


### PR DESCRIPTION
Open PR, Open Branch, and Open Commit only exist in the native application menu and the command palette, which makes them hard to discover. This adds a small plus button in the top bar, next to the sidebar toggle, that opens a menu with the three actions. Selecting one opens the same dialog the native menu and palette use, so all entry points share one code path.

<img width="643" height="281" alt="image" src="https://github.com/user-attachments/assets/43d356b8-2e97-40ce-a442-a0a07c7ac371" />


A couple of implementation notes:

- The menu follows the ARIA menu button pattern: focus lands on the first item, arrow keys wrap, Home and End jump, Escape returns focus to the trigger, Tab continues traversal from the trigger, and clicking outside dismisses.
- The popover is portaled to the document body. The top bar's `backdrop-filter` creates a stacking context on non-macOS platforms, and without the portal the open menu paints underneath the sidebar and can't receive clicks.

Changes made by Fable 5 xhigh in loop with 5.6 Sol xhigh as a reviewer.
Built and tested the changes and they achieve the desired result.