### PR TITLE
feat: make switching repositories discoverable and show complete paths

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -3844,6 +3844,7 @@ diffs-container .review-comment-thread {
 
 .empty-panel code {
   color: var(--text);
+  overflow-wrap: anywhere;
 }
 
 .empty-panel-menu-path {

--- a/core/App.css
+++ b/core/App.css
@@ -768,17 +768,10 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
   white-space: nowrap;
 }
 
-button.review-top-bar-repository {
+.review-top-bar-repository-path {
   align-items: center;
-  background: transparent;
-  border: 0;
-  color: inherit;
-  cursor: pointer;
   display: flex;
   flex: 0 1 auto;
-  font: inherit;
-  padding: 0;
-  text-align: left;
 }
 
 .review-top-bar-repository-head {
@@ -816,14 +809,12 @@ a.review-top-bar-source {
 }
 
 a.review-top-bar-repository:hover,
-a.review-top-bar-source:hover,
-button.review-top-bar-repository:hover {
+a.review-top-bar-source:hover {
   color: var(--text);
 }
 
 a.review-top-bar-repository:focus-visible,
-a.review-top-bar-source:focus-visible,
-button.review-top-bar-repository:focus-visible {
+a.review-top-bar-source:focus-visible {
   border-radius: 3px;
   outline: 1px solid var(--tree-selection-focus);
   outline-offset: 2px;

--- a/core/App.css
+++ b/core/App.css
@@ -768,6 +768,32 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
   white-space: nowrap;
 }
 
+button.review-top-bar-repository {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex: 0 1 auto;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+}
+
+.review-top-bar-repository-head {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.review-top-bar-repository-tail {
+  flex: none;
+  white-space: nowrap;
+}
+
 .review-top-bar-branch {
   align-items: center;
   border-radius: 14px;
@@ -790,12 +816,14 @@ a.review-top-bar-source {
 }
 
 a.review-top-bar-repository:hover,
-a.review-top-bar-source:hover {
+a.review-top-bar-source:hover,
+button.review-top-bar-repository:hover {
   color: var(--text);
 }
 
 a.review-top-bar-repository:focus-visible,
-a.review-top-bar-source:focus-visible {
+a.review-top-bar-source:focus-visible,
+button.review-top-bar-repository:focus-visible {
   border-radius: 3px;
   outline: 1px solid var(--tree-selection-focus);
   outline-offset: 2px;

--- a/core/App.css
+++ b/core/App.css
@@ -784,6 +784,10 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
 
 .review-top-bar-repository-tail {
   flex: none;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -1810,6 +1810,7 @@ export default function App() {
         onToggleSidebar={toggleSidebar}
         repository={
           <button
+            aria-label={`Open a different repository (current: ${state.root})`}
             className="review-top-bar-repository"
             onClick={openRepositoryFolder}
             type="button"

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -67,7 +67,7 @@ import {
   shouldLoadDiffSectionContents,
   shouldPreloadSectionContentsForSearch,
 } from './lib/diff.ts';
-import { compactPath, sortFiles } from './lib/files.ts';
+import { sortFiles, splitRepositoryPath } from './lib/files.ts';
 import {
   consumeReloadSelection,
   getChangedPaths,
@@ -1496,6 +1496,10 @@ export default function App() {
     setOpenReviewSourceKind(kind);
   }, []);
 
+  const openRepositoryFolder = useCallback(() => {
+    void window.codiff.openRepositoryFolder().catch(() => {});
+  }, []);
+
   useEffect(
     () => window.codiff.onOpenReviewSource(showOpenReviewSourceDialog),
     [showOpenReviewSourceDialog],
@@ -1649,7 +1653,7 @@ export default function App() {
       walkthroughError?.code === 'OPENCODE_NOT_FOUND' ||
       walkthroughError?.code === 'PI_NOT_FOUND');
 
-  const sidebarLabel = compactPath(state.root);
+  const repositoryPathParts = splitRepositoryPath(state.root);
   const sidebarSourceLabel =
     state.source.type !== 'working-tree' ? getSourceLabel(state.source) : null;
   const pullRequestUrl = state.source.type === 'pull-request' ? state.source.url : null;
@@ -1805,22 +1809,23 @@ export default function App() {
         onModeChange={changeSidebarMode}
         onToggleSidebar={toggleSidebar}
         repository={
-          pullRequestUrl ? (
-            <a
-              className="review-top-bar-repository"
-              href={pullRequestUrl}
-              rel="noreferrer"
-              target="_blank"
-            >
-              {sidebarLabel}
-            </a>
-          ) : (
-            <span className="review-top-bar-repository">{sidebarLabel}</span>
-          )
+          <button
+            className="review-top-bar-repository"
+            onClick={openRepositoryFolder}
+            type="button"
+          >
+            <span className="review-top-bar-repository-head">{repositoryPathParts.head}</span>
+            <span className="review-top-bar-repository-tail">{repositoryPathParts.tail}</span>
+          </button>
         }
         repositoryTooltip={state.root}
         sidebarCollapsed={sidebarCollapsed}
-        sourceMenu={<OpenReviewSourceMenu onOpen={showOpenReviewSourceDialog} />}
+        sourceMenu={
+          <OpenReviewSourceMenu
+            onOpen={showOpenReviewSourceDialog}
+            onOpenFolder={openRepositoryFolder}
+          />
+        }
         toggleTitle={`${sidebarCollapsed ? 'Expand' : 'Collapse'} sidebar (${getShortcutLabel(
           codiffConfig.keymap,
           'toggleSidebar',

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -1809,15 +1809,10 @@ export default function App() {
         onModeChange={changeSidebarMode}
         onToggleSidebar={toggleSidebar}
         repository={
-          <button
-            aria-label={`Open a different repository (current: ${state.root})`}
-            className="review-top-bar-repository"
-            onClick={openRepositoryFolder}
-            type="button"
-          >
+          <span className="review-top-bar-repository review-top-bar-repository-path">
             <span className="review-top-bar-repository-head">{repositoryPathParts.head}</span>
             <span className="review-top-bar-repository-tail">{repositoryPathParts.tail}</span>
-          </button>
+          </span>
         }
         repositoryTooltip={state.root}
         sidebarCollapsed={sidebarCollapsed}

--- a/core/Desktop.css
+++ b/core/Desktop.css
@@ -54,3 +54,10 @@
   color: var(--muted);
   flex: none;
 }
+
+.open-review-source-menu-separator {
+  background: var(--file-border);
+  flex: none;
+  height: 1px;
+  margin: 3px 6px;
+}

--- a/core/SharedWalkthroughApp.tsx
+++ b/core/SharedWalkthroughApp.tsx
@@ -51,7 +51,7 @@ import {
   getTotalDiffLineCount,
   isMarkdownFilePath,
 } from './lib/diff.ts';
-import { compactPath, fuzzyMatches, sortFiles } from './lib/files.ts';
+import { abbreviateHomePath, fuzzyMatches, sortFiles } from './lib/files.ts';
 import { isNativeInputTarget } from './lib/keyboard.ts';
 import { isGeneratedWalkthroughFile } from './lib/narrative-walkthrough-diff.js';
 import {
@@ -886,7 +886,7 @@ export function ReviewSurface({
       : getSourceLabel(snapshot.repository.source);
   const rootLabel = repositoryUrl
     ? snapshot.repository.root
-    : compactPath(snapshot.repository.root);
+    : abbreviateHomePath(snapshot.repository.root);
   const sourceExternalUrl =
     snapshot.repository.source.type === 'pull-request'
       ? (externalUrl ?? snapshot.repository.source.url)

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -523,6 +523,7 @@ test('repository label opens the folder picker instead of linking to the pull re
     throw new Error('Expected the repository label button in the top bar.');
   }
   expect(label.textContent).toBe('/repo');
+  expect(label.getAttribute('aria-label')).toBe('Open a different repository (current: /repo)');
   expect(app.container.querySelector('a.review-top-bar-repository')).toBeNull();
 
   await act(async () => {

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -511,26 +511,28 @@ test('top bar source menu opens the review source dialog', async () => {
   expect(document.querySelector('[role="menu"]')).toBeNull();
 });
 
-test('repository label opens the folder picker instead of linking to the pull request', async () => {
+test('repository label is plain text and clicking it does nothing', async () => {
   const openRepositoryFolder = vi.fn(async () => {});
   window.codiff = createCodiffMock({ openRepositoryFolder });
 
   await using app = await renderReact(<App />);
   await waitFor(() => expect(app.container.querySelector('.app-shell')).not.toBeNull());
 
-  const label = app.container.querySelector<HTMLButtonElement>('button.review-top-bar-repository');
+  const label = app.container.querySelector<HTMLElement>('.review-top-bar-repository');
   if (!label) {
-    throw new Error('Expected the repository label button in the top bar.');
+    throw new Error('Expected the repository label in the top bar.');
   }
+  expect(label.tagName).toBe('SPAN');
   expect(label.textContent).toBe('/repo');
-  expect(label.getAttribute('aria-label')).toBe('Open a different repository (current: /repo)');
+  expect(label.closest('.review-top-bar-repository-slot')?.getAttribute('title')).toBe('/repo');
   expect(app.container.querySelector('a.review-top-bar-repository')).toBeNull();
+  expect(app.container.querySelector('button.review-top-bar-repository')).toBeNull();
 
   await act(async () => {
     label.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
 
-  expect(openRepositoryFolder).toHaveBeenCalledOnce();
+  expect(openRepositoryFolder).not.toHaveBeenCalled();
 });
 
 test('empty repository state fills the review pane for centered layout', async () => {
@@ -1478,11 +1480,9 @@ test('pull request description collapse button toggles the markdown body', async
   await waitFor(() => {
     expect(app.container.querySelector('.source-description-markdown')).not.toBeNull();
   });
-  const repositoryButton = app.container.querySelector<HTMLButtonElement>(
-    'button.review-top-bar-repository',
-  );
+  const repositoryLabel = app.container.querySelector<HTMLElement>('.review-top-bar-repository');
   const sourceLink = app.container.querySelector<HTMLAnchorElement>('.review-top-bar-source');
-  expect(repositoryButton).not.toBeNull();
+  expect(repositoryLabel).not.toBeNull();
   expect(sourceLink?.href).toBe(source.url);
   expect(sourceLink?.textContent).toBe('PR #12');
   expect(sourceLink?.querySelector('svg')).not.toBeNull();

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -238,6 +238,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
   onWindowFullScreenChanged: vi.fn(() => () => {}),
   openConfigFile: vi.fn(async () => {}),
   openFile: vi.fn(async () => {}),
+  openRepositoryFolder: vi.fn(async () => {}),
   resetCodeFontSize: vi.fn(async () => {}),
   resolvePullRequestUrl: vi.fn(async () => 'https://github.com/owner/repo/pull/1'),
   saveMarkdownDocument: vi.fn(async (request) => ({
@@ -508,6 +509,27 @@ test('top bar source menu opens the review source dialog', async () => {
   const input = app.container.querySelector<HTMLInputElement>('#open-review-source-input');
   expect(input?.placeholder).toBe('#123 or https://github.com/owner/repo/pull/123');
   expect(document.querySelector('[role="menu"]')).toBeNull();
+});
+
+test('repository label opens the folder picker instead of linking to the pull request', async () => {
+  const openRepositoryFolder = vi.fn(async () => {});
+  window.codiff = createCodiffMock({ openRepositoryFolder });
+
+  await using app = await renderReact(<App />);
+  await waitFor(() => expect(app.container.querySelector('.app-shell')).not.toBeNull());
+
+  const label = app.container.querySelector<HTMLButtonElement>('button.review-top-bar-repository');
+  if (!label) {
+    throw new Error('Expected the repository label button in the top bar.');
+  }
+  expect(label.textContent).toBe('/repo');
+  expect(app.container.querySelector('a.review-top-bar-repository')).toBeNull();
+
+  await act(async () => {
+    label.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
+  expect(openRepositoryFolder).toHaveBeenCalledOnce();
 });
 
 test('empty repository state fills the review pane for centered layout', async () => {
@@ -1455,11 +1477,11 @@ test('pull request description collapse button toggles the markdown body', async
   await waitFor(() => {
     expect(app.container.querySelector('.source-description-markdown')).not.toBeNull();
   });
-  const repositoryLink = app.container.querySelector<HTMLAnchorElement>(
-    '.review-top-bar-repository',
+  const repositoryButton = app.container.querySelector<HTMLButtonElement>(
+    'button.review-top-bar-repository',
   );
   const sourceLink = app.container.querySelector<HTMLAnchorElement>('.review-top-bar-source');
-  expect(repositoryLink?.href).toBe(source.url);
+  expect(repositoryButton).not.toBeNull();
   expect(sourceLink?.href).toBe(source.url);
   expect(sourceLink?.textContent).toBe('PR #12');
   expect(sourceLink?.querySelector('svg')).not.toBeNull();

--- a/core/__tests__/OpenReviewSourceMenu.test.tsx
+++ b/core/__tests__/OpenReviewSourceMenu.test.tsx
@@ -15,6 +15,8 @@ test('opens the menu from the trigger and moves focus to the first action', asyn
 
   expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
   expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  expect(trigger.getAttribute('aria-label')).toBe('Open a PR, branch, commit, or folder');
+  expect(trigger.title).toBe('Open a PR, branch, commit, or folder');
   expect(queryMenu()).toBeNull();
 
   await click(trigger);

--- a/core/__tests__/OpenReviewSourceMenu.test.tsx
+++ b/core/__tests__/OpenReviewSourceMenu.test.tsx
@@ -8,7 +8,9 @@ import { OpenReviewSourceMenu } from '../app/components/OpenReviewSourceMenu.tsx
 import { renderReact } from './helpers/react.tsx';
 
 test('opens the menu from the trigger and moves focus to the first action', async () => {
-  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+  await using view = await renderReact(
+    <OpenReviewSourceMenu onOpen={() => {}} onOpenFolder={() => {}} />,
+  );
   const trigger = getTrigger(view.container);
 
   expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
@@ -19,12 +21,19 @@ test('opens the menu from the trigger and moves focus to the first action', asyn
 
   expect(trigger.getAttribute('aria-expanded')).toBe('true');
   const items = getMenuItems();
-  expect(items.map((item) => item.textContent)).toEqual(['Open PR', 'Open Branch', 'Open Commit']);
+  expect(items.map((item) => item.textContent)).toEqual([
+    'Open PR',
+    'Open Branch',
+    'Open Commit',
+    'Open Folder',
+  ]);
   expect(document.activeElement).toBe(items[0]);
 });
 
 test('renders the open menu outside the top bar so stacking contexts cannot trap it', async () => {
-  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+  await using view = await renderReact(
+    <OpenReviewSourceMenu onOpen={() => {}} onOpenFolder={() => {}} />,
+  );
 
   await click(getTrigger(view.container));
 
@@ -36,7 +45,9 @@ test('renders the open menu outside the top bar so stacking contexts cannot trap
 
 test('selecting an action reports its kind and closes the menu', async () => {
   const onOpen = vi.fn();
-  await using view = await renderReact(<OpenReviewSourceMenu onOpen={onOpen} />);
+  await using view = await renderReact(
+    <OpenReviewSourceMenu onOpen={onOpen} onOpenFolder={() => {}} />,
+  );
 
   await click(getTrigger(view.container));
   const commitItem = getMenuItems().find((item) => item.textContent === 'Open Commit');
@@ -51,27 +62,33 @@ test('selecting an action reports its kind and closes the menu', async () => {
 });
 
 test('arrow keys move through the actions and wrap around', async () => {
-  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+  await using view = await renderReact(
+    <OpenReviewSourceMenu onOpen={() => {}} onOpenFolder={() => {}} />,
+  );
 
   await click(getTrigger(view.container));
-  const [pullRequest, branch, commit] = getMenuItems();
+  const [pullRequest, branch, commit, folder] = getMenuItems();
 
   await pressKey('ArrowDown');
   expect(document.activeElement).toBe(branch);
   await pressKey('ArrowDown');
   expect(document.activeElement).toBe(commit);
   await pressKey('ArrowDown');
+  expect(document.activeElement).toBe(folder);
+  await pressKey('ArrowDown');
   expect(document.activeElement).toBe(pullRequest);
   await pressKey('ArrowUp');
-  expect(document.activeElement).toBe(commit);
+  expect(document.activeElement).toBe(folder);
   await pressKey('Home');
   expect(document.activeElement).toBe(pullRequest);
   await pressKey('End');
-  expect(document.activeElement).toBe(commit);
+  expect(document.activeElement).toBe(folder);
 });
 
 test('Escape closes the menu and returns focus to the trigger', async () => {
-  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+  await using view = await renderReact(
+    <OpenReviewSourceMenu onOpen={() => {}} onOpenFolder={() => {}} />,
+  );
   const trigger = getTrigger(view.container);
 
   await click(trigger);
@@ -81,8 +98,29 @@ test('Escape closes the menu and returns focus to the trigger', async () => {
   expect(document.activeElement).toBe(trigger);
 });
 
+test('opens the folder picker from a separated menu action', async () => {
+  const onOpenFolder = vi.fn();
+  await using view = await renderReact(
+    <OpenReviewSourceMenu onOpen={() => {}} onOpenFolder={onOpenFolder} />,
+  );
+
+  await click(getTrigger(view.container));
+  expect(document.querySelector('[role="menu"] [role="separator"]')).not.toBeNull();
+
+  const folderItem = getMenuItems().find((item) => item.textContent === 'Open Folder');
+  if (!folderItem) {
+    throw new Error('Expected an Open Folder menu item.');
+  }
+  await click(folderItem);
+
+  expect(onOpenFolder).toHaveBeenCalledOnce();
+  expect(queryMenu()).toBeNull();
+});
+
 test('Tab hands focus back to the trigger so traversal continues from the top bar', async () => {
-  await using view = await renderReact(<OpenReviewSourceMenu onOpen={() => {}} />);
+  await using view = await renderReact(
+    <OpenReviewSourceMenu onOpen={() => {}} onOpenFolder={() => {}} />,
+  );
   const trigger = getTrigger(view.container);
 
   await click(trigger);
@@ -100,7 +138,9 @@ test('Tab hands focus back to the trigger so traversal continues from the top ba
 
 test('clicking outside dismisses the menu without opening anything', async () => {
   const onOpen = vi.fn();
-  await using view = await renderReact(<OpenReviewSourceMenu onOpen={onOpen} />);
+  await using view = await renderReact(
+    <OpenReviewSourceMenu onOpen={onOpen} onOpenFolder={() => {}} />,
+  );
 
   await click(getTrigger(view.container));
   await act(async () => {

--- a/core/__tests__/SharedWalkthroughApp.test.tsx
+++ b/core/__tests__/SharedWalkthroughApp.test.tsx
@@ -96,6 +96,63 @@ test('review top bar renders its leading control at the far left', async () => {
   container.remove();
 });
 
+test('share viewer shows the complete repository path when there is no repository link', async () => {
+  const file = createChangedFile('src/app.ts');
+  const source = { type: 'working-tree' } as const;
+  const snapshot = {
+    branch: 'main',
+    codiffVersion: '1.4.1',
+    exportedAt: '2026-06-19T00:00:00.000Z',
+    files: [file],
+    kind: 'codiff-walkthrough-share',
+    preferences: {
+      codeFontFamily: 'Fira Code',
+      codeFontSize: 13,
+      diffStyle: 'split',
+      showWhitespace: false,
+      theme: 'system',
+      wordWrap: false,
+    },
+    repository: { root: '/Users/ada/dev/codiff-web', source },
+    version: 1,
+    walkthrough: {
+      agent: 'codex',
+      chapters: [],
+      focus: 'Focus on the implementation.',
+      generatedAt: '2026-06-19T00:00:00.000Z',
+      kind: 'narrative',
+      repo: { branch: 'main', root: '/Users/ada/dev/codiff-web' },
+      source,
+      support: [],
+      title: 'Shared walkthrough',
+      version: 4,
+    },
+  } satisfies SharedWalkthroughSnapshot;
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  let root: Root | null = null;
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+    },
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<ReviewSurface snapshot={snapshot} title="Review shared walkthrough" />);
+  });
+
+  await waitFor(() => {
+    expect(container.querySelector('.review-top-bar-repository')).not.toBeNull();
+  });
+  expect(container.querySelector('.review-top-bar-repository')?.textContent).toBe(
+    '~/dev/codiff-web',
+  );
+});
+
 test('shared walkthroughs switch between walkthrough and tree review modes', async () => {
   const onDeleteShare = vi.fn();
   const confirmDelete = vi.spyOn(window, 'confirm').mockReturnValue(false);

--- a/core/__tests__/app-command-hooks.test.tsx
+++ b/core/__tests__/app-command-hooks.test.tsx
@@ -103,6 +103,7 @@ test('app commands register the complete command set and delegate dynamic action
     'open-pull-request',
     'open-commit',
     'open-branch',
+    'open-folder',
     'sidebar-tree',
     'sidebar-history',
     'sidebar-walkthrough',

--- a/core/__tests__/files.test.ts
+++ b/core/__tests__/files.test.ts
@@ -1,5 +1,16 @@
 import { expect, test } from 'vite-plus/test';
-import { splitRepositoryPath } from '../lib/files.ts';
+import { abbreviateHomePath, splitRepositoryPath } from '../lib/files.ts';
+
+test('abbreviates the home directory but keeps the rest of the path complete', () => {
+  expect(abbreviateHomePath('/Users/hafez/dev/websites/blog')).toBe('~/dev/websites/blog');
+  expect(abbreviateHomePath('/home/ada/projects/analytical-engine')).toBe(
+    '~/projects/analytical-engine',
+  );
+  expect(abbreviateHomePath(String.raw`C:\Users\Ada\dev\analytical-engine`)).toBe(
+    String.raw`~\dev\analytical-engine`,
+  );
+  expect(abbreviateHomePath('/srv/git/deploy-tools')).toBe('/srv/git/deploy-tools');
+});
 
 test('splits a home repository path into a head and a repository tail', () => {
   expect(splitRepositoryPath('/Users/hafez/dev/websites/blog')).toEqual({

--- a/core/__tests__/files.test.ts
+++ b/core/__tests__/files.test.ts
@@ -20,6 +20,21 @@ test('keeps paths outside the home directory absolute', () => {
   expect(splitRepositoryPath('/repo')).toEqual({ head: '', tail: '/repo' });
 });
 
+test('splits and abbreviates Windows repository paths', () => {
+  expect(splitRepositoryPath(String.raw`C:\Users\Ada\dev\analytical-engine`)).toEqual({
+    head: String.raw`~\dev`,
+    tail: String.raw`\analytical-engine`,
+  });
+  expect(splitRepositoryPath('C:/Users/Ada/dev/analytical-engine')).toEqual({
+    head: '~/dev',
+    tail: '/analytical-engine',
+  });
+  expect(splitRepositoryPath(String.raw`D:\srv\deploy-tools`)).toEqual({
+    head: String.raw`D:\srv`,
+    tail: String.raw`\deploy-tools`,
+  });
+});
+
 test('handles the home directory itself and short paths', () => {
   expect(splitRepositoryPath('/Users/hafez')).toEqual({ head: '', tail: '~' });
   expect(splitRepositoryPath('~/blog')).toEqual({ head: '~', tail: '/blog' });

--- a/core/__tests__/files.test.ts
+++ b/core/__tests__/files.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vite-plus/test';
+import { splitRepositoryPath } from '../lib/files.ts';
+
+test('splits a home repository path into a head and a repository tail', () => {
+  expect(splitRepositoryPath('/Users/hafez/dev/websites/blog')).toEqual({
+    head: '~/dev/websites',
+    tail: '/blog',
+  });
+  expect(splitRepositoryPath('/home/ada/projects/analytical-engine')).toEqual({
+    head: '~/projects',
+    tail: '/analytical-engine',
+  });
+});
+
+test('keeps paths outside the home directory absolute', () => {
+  expect(splitRepositoryPath('/srv/git/deploy-tools')).toEqual({
+    head: '/srv/git',
+    tail: '/deploy-tools',
+  });
+  expect(splitRepositoryPath('/repo')).toEqual({ head: '', tail: '/repo' });
+});
+
+test('handles the home directory itself and short paths', () => {
+  expect(splitRepositoryPath('/Users/hafez')).toEqual({ head: '', tail: '~' });
+  expect(splitRepositoryPath('~/blog')).toEqual({ head: '~', tail: '/blog' });
+});

--- a/core/__tests__/source-empty-detail.test.ts
+++ b/core/__tests__/source-empty-detail.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vite-plus/test';
+import { getEmptySourceDetail } from '../lib/source.ts';
+
+test('shows the complete repository path when the working tree has no changes', () => {
+  expect(getEmptySourceDetail({ type: 'working-tree' }, '/Users/hafez/dev/websites/blog')).toEqual({
+    kind: 'code',
+    text: '~/dev/websites/blog',
+    title: '/Users/hafez/dev/websites/blog',
+  });
+});

--- a/core/app/components/OpenReviewSourceMenu.tsx
+++ b/core/app/components/OpenReviewSourceMenu.tsx
@@ -144,13 +144,13 @@ export function OpenReviewSourceMenu({
         aria-controls={open ? 'open-review-source-menu' : undefined}
         aria-expanded={open}
         aria-haspopup="menu"
-        aria-label="Open a PR, branch, or commit"
+        aria-label="Open a PR, branch, commit, or folder"
         className="open-review-source-trigger review-top-bar-icon-button"
         id="open-review-source-trigger"
         onClick={open ? close : openMenu}
         onKeyDown={handleTriggerKeyDown}
         ref={triggerRef}
-        title="Open a PR, branch, or commit"
+        title="Open a PR, branch, commit, or folder"
         type="button"
       >
         <Plus aria-hidden size={16} weight="bold" />

--- a/core/app/components/OpenReviewSourceMenu.tsx
+++ b/core/app/components/OpenReviewSourceMenu.tsx
@@ -1,3 +1,4 @@
+import { FolderOpenIcon as FolderOpen } from '@phosphor-icons/react/FolderOpen';
 import { GitBranchIcon as GitBranch } from '@phosphor-icons/react/GitBranch';
 import { GitCommitIcon as GitCommit } from '@phosphor-icons/react/GitCommit';
 import { GitPullRequestIcon as GitPullRequest } from '@phosphor-icons/react/GitPullRequest';
@@ -35,7 +36,13 @@ const menuActions: ReadonlyArray<{
   },
 ];
 
-export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSourceKind) => void }) {
+export function OpenReviewSourceMenu({
+  onOpen,
+  onOpenFolder,
+}: {
+  onOpen: (kind: OpenReviewSourceKind) => void;
+  onOpenFolder: () => void;
+}) {
   // The top bar creates a stacking context (backdrop-filter) that later
   // sibling rows paint over on non-macOS platforms, so the menu is portaled to
   // the document body and positioned from the trigger's viewport rect.
@@ -178,6 +185,23 @@ export function OpenReviewSourceMenu({ onOpen }: { onOpen: (kind: OpenReviewSour
                   <span>{action.label}</span>
                 </button>
               ))}
+              <div className="open-review-source-menu-separator" role="separator" />
+              <button
+                className="open-review-source-menu-item"
+                onClick={() => {
+                  close();
+                  onOpenFolder();
+                }}
+                ref={(element) => {
+                  itemRefs.current[menuActions.length] = element;
+                }}
+                role="menuitem"
+                tabIndex={-1}
+                type="button"
+              >
+                <FolderOpen aria-hidden size={15} weight="bold" />
+                <span>Open Folder</span>
+              </button>
             </div>,
             document.body,
           )

--- a/core/app/hooks/useAppCommands.ts
+++ b/core/app/hooks/useAppCommands.ts
@@ -78,6 +78,13 @@ export function useAppCommands({
         title: 'Open Branch',
       }),
       registry.register({
+        execute: () => {
+          void window.codiff.openRepositoryFolder().catch(() => {});
+        },
+        id: 'open-folder',
+        title: 'Open Folder',
+      }),
+      registry.register({
         execute: () => changeSidebarMode('tree'),
         id: 'sidebar-tree',
         title: 'Show File Tree',

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -94,6 +94,7 @@ declare global {
       onWindowFullScreenChanged: (callback: (isFullScreen: boolean) => void) => () => void;
       openConfigFile: () => Promise<void>;
       openFile: (path: string) => Promise<void>;
+      openRepositoryFolder: () => Promise<void>;
       resetCodeFontSize: () => Promise<void>;
       resolvePullRequestUrl: (value: string) => Promise<string>;
       saveMarkdownDocument: (

--- a/core/lib/files.ts
+++ b/core/lib/files.ts
@@ -16,10 +16,11 @@ export const fileTreeSort = (
   right: { isDirectory: boolean; path: string; segments?: ReadonlyArray<string> },
 ) => compareTreePaths(left.path, right.path);
 
+const abbreviateHome = (path: string) =>
+  path.replace(/^\/Users\/[^/]+(?=\/|$)/, '~').replace(/^\/home\/[^/]+(?=\/|$)/, '~');
+
 export const compactPath = (path: string) => {
-  const homePath = path
-    .replace(/^\/Users\/[^/]+(?=\/|$)/, '~')
-    .replace(/^\/home\/[^/]+(?=\/|$)/, '~');
+  const homePath = abbreviateHome(path);
   const parts = homePath.split('/').filter(Boolean);
 
   if (parts.length <= 2) {
@@ -32,6 +33,19 @@ export const compactPath = (path: string) => {
   const middle = rest.map((part) => part[0]).join('/');
 
   return `${prefix}${first}/${middle ? `${middle}/` : ''}${last}`;
+};
+
+/**
+ * Splits a repository path into a shrinkable head and the repository's own
+ * directory, so the top bar can keep the repository name visible and put the
+ * ellipsis in the middle when the full path overflows.
+ */
+export const splitRepositoryPath = (path: string) => {
+  const homePath = abbreviateHome(path);
+  const separator = homePath.lastIndexOf('/');
+  return separator > 0
+    ? { head: homePath.slice(0, separator), tail: homePath.slice(separator) }
+    : { head: '', tail: homePath };
 };
 
 function compareTreePaths(leftPath: string, rightPath: string) {

--- a/core/lib/files.ts
+++ b/core/lib/files.ts
@@ -16,27 +16,11 @@ export const fileTreeSort = (
   right: { isDirectory: boolean; path: string; segments?: ReadonlyArray<string> },
 ) => compareTreePaths(left.path, right.path);
 
-const abbreviateHome = (path: string) =>
+export const abbreviateHomePath = (path: string) =>
   path
     .replace(/^\/Users\/[^/]+(?=\/|$)/, '~')
     .replace(/^\/home\/[^/]+(?=\/|$)/, '~')
     .replace(/^[A-Za-z]:[/\\]Users[/\\][^/\\]+(?=[/\\]|$)/, '~');
-
-export const compactPath = (path: string) => {
-  const homePath = abbreviateHome(path);
-  const parts = homePath.split('/').filter(Boolean);
-
-  if (parts.length <= 2) {
-    return homePath;
-  }
-
-  const prefix = homePath.startsWith('/') ? '/' : '';
-  const [first, ...rest] = parts;
-  const last = rest.pop();
-  const middle = rest.map((part) => part[0]).join('/');
-
-  return `${prefix}${first}/${middle ? `${middle}/` : ''}${last}`;
-};
 
 /**
  * Splits a repository path into a shrinkable head and the repository's own
@@ -44,7 +28,7 @@ export const compactPath = (path: string) => {
  * ellipsis in the middle when the full path overflows.
  */
 export const splitRepositoryPath = (path: string) => {
-  const homePath = abbreviateHome(path);
+  const homePath = abbreviateHomePath(path);
   const separator = Math.max(homePath.lastIndexOf('/'), homePath.lastIndexOf('\\'));
   return separator > 0
     ? { head: homePath.slice(0, separator), tail: homePath.slice(separator) }

--- a/core/lib/files.ts
+++ b/core/lib/files.ts
@@ -17,7 +17,10 @@ export const fileTreeSort = (
 ) => compareTreePaths(left.path, right.path);
 
 const abbreviateHome = (path: string) =>
-  path.replace(/^\/Users\/[^/]+(?=\/|$)/, '~').replace(/^\/home\/[^/]+(?=\/|$)/, '~');
+  path
+    .replace(/^\/Users\/[^/]+(?=\/|$)/, '~')
+    .replace(/^\/home\/[^/]+(?=\/|$)/, '~')
+    .replace(/^[A-Za-z]:[/\\]Users[/\\][^/\\]+(?=[/\\]|$)/, '~');
 
 export const compactPath = (path: string) => {
   const homePath = abbreviateHome(path);
@@ -42,7 +45,7 @@ export const compactPath = (path: string) => {
  */
 export const splitRepositoryPath = (path: string) => {
   const homePath = abbreviateHome(path);
-  const separator = homePath.lastIndexOf('/');
+  const separator = Math.max(homePath.lastIndexOf('/'), homePath.lastIndexOf('\\'));
   return separator > 0
     ? { head: homePath.slice(0, separator), tail: homePath.slice(separator) }
     : { head: '', tail: homePath };

--- a/core/lib/source.ts
+++ b/core/lib/source.ts
@@ -1,6 +1,6 @@
 import type { ReviewSource } from '../types.ts';
 import type { RepositoryLoadError } from './app-types.ts';
-import { compactPath } from './files.ts';
+import { abbreviateHomePath } from './files.ts';
 
 const rangeLabel = (source: Extract<ReviewSource, { type: 'range' }>) =>
   `${source.base}${source.symmetric ? '...' : '..'}${source.head}`;
@@ -162,4 +162,4 @@ export const getEmptySourceDetail = (
         source.type === 'branch-diff' ||
         source.type === 'branch-working-tree'
       ? { kind: 'text', text: source.ref }
-      : { kind: 'code', text: compactPath(root), title: root };
+      : { kind: 'code', text: abbreviateHomePath(root), title: root };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1743,6 +1743,10 @@ ipcMain.handle('codiff:resetCodeFontSize', () => {
 
 ipcMain.handle('codiff:openConfigFile', () => openConfigFile());
 
+ipcMain.handle('codiff:openRepositoryFolder', (event) =>
+  openRepositoryFolder(BrowserWindow.fromWebContents(event.sender) ?? undefined),
+);
+
 ipcMain.handle('codiff:openFile', async (event, filePath) => {
   const repositoryRoot = getWindowRepositoryRoot(event.sender.id);
   const repositoryFilePath = validateRepositoryPath(filePath);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -126,6 +126,7 @@ const codiff = {
   },
   openConfigFile: () => ipcRenderer.invoke('codiff:openConfigFile'),
   openFile: (path) => ipcRenderer.invoke('codiff:openFile', path),
+  openRepositoryFolder: () => ipcRenderer.invoke('codiff:openRepositoryFolder'),
   resolvePullRequestUrl: (value) => ipcRenderer.invoke('codiff:resolvePullRequestUrl', value),
   setDiffStyle: (value) => ipcRenderer.invoke('codiff:setDiffStyle', value),
   setShowOutdated: (value) => ipcRenderer.invoke('codiff:setShowOutdated', value),


### PR DESCRIPTION
Based on feat/open-review-source-ui (#146), so the diff here includes those commits until it merges.

There was no way to switch repositories from within the app, only through the native menu bar. The repository label in the top bar also linked to the PR page, which the PR badge on the right already does. And paths rendered as fish-style abbreviations (`~/d/w/blog` instead of `~/dev/websites/blog`), which reads like line noise if you don't live in fish.

This PR:

- adds an Open Folder entry to the + menu and the command palette
- makes the repository label plain text with the full path in its tooltip, instead of duplicating the PR link
- shows complete repository paths everywhere, abbreviating only the home directory to `~`

The top bar label keeps the repository name visible when space runs out: the head of the path shrinks with an ellipsis in the middle, the last segment never truncates. Paths outside the home directory stay absolute, and Windows paths keep their drive prefix.

<img width="652" height="249" alt="image" src="https://github.com/user-attachments/assets/fa20c4dc-8406-4004-aaa5-303c5babd3a7" />

<img width="655" height="253" alt="image" src="https://github.com/user-attachments/assets/39a8d593-9f8c-4686-bcce-977b8efa34b1" />

Created with Fable 5 xhigh, review iteration with Sol 5.6 xhigh. Built and tested and everything works as expected.