### PR TITLE
fix: authenticate glab and agent CLIs through the login shell environment

### DIFF
--- a/core/__tests__/gitlab.test.ts
+++ b/core/__tests__/gitlab.test.ts
@@ -118,6 +118,7 @@ process.stdin.on('end', () => {
   await using _environment = createTemporaryEnvironment({
     CODIFF_GLAB_PATH: fakeGlabPath,
     CODIFF_GLAB_TEST_CALLS: callsPath,
+    SHELL: undefined,
   });
 
   await callback(repo, async () =>
@@ -419,6 +420,112 @@ describe('GitLab merge requests', () => {
       );
       expect(call.args).toContain('Content-Type: application/json');
       expect(JSON.parse(call.input)).toEqual({ body: 'Reply in the existing discussion.' });
+    });
+  });
+
+  test('authenticates glab from the login shell environment when the app inherited none', async () => {
+    await using directory = await createTemporaryDirectory('codiff-glab-login-env-');
+    const repo = join(directory.path, 'repo');
+    const fakeGlab = join(directory.path, 'glab');
+    const fakeShell = join(directory.path, 'fake-login-shell');
+
+    await execFileAsync('git', ['init', repo]);
+    await execFileAsync('git', [
+      '-C',
+      repo,
+      'remote',
+      'add',
+      'origin',
+      'ssh://git@gitlab.example.com/group/project.git',
+    ]);
+
+    // A GUI-launched Codiff keeps launchd's minimal environment: no
+    // GITLAB_TOKEN, even when the user's login shell exports one. This glab
+    // fails auth exactly the way the real one does when the token never
+    // reaches it.
+    await writeFile(
+      fakeShell,
+      `#!/bin/sh
+GITLAB_TOKEN='from-login-shell' exec /bin/sh -c "$4"
+`,
+    );
+    await writeFile(
+      fakeGlab,
+      `#!/bin/sh
+if [ "$GITLAB_TOKEN" != 'from-login-shell' ]; then
+  echo 'To get started with GitLab CLI, please run:  glab auth login.' >&2
+  exit 4
+fi
+printf '%s' '{}'
+`,
+    );
+    await Promise.all([chmod(fakeShell, 0o755), chmod(fakeGlab, 0o755)]);
+
+    await using _environment = createTemporaryEnvironment({
+      CODIFF_GLAB_PATH: fakeGlab,
+      GITLAB_TOKEN: undefined,
+      SHELL: fakeShell,
+    });
+
+    await submitMergeRequestReview(repo, {
+      comments: [],
+      event: 'REQUEST_CHANGES',
+      source: {
+        provider: 'gitlab',
+        type: 'pull-request',
+        url: 'https://gitlab.example.com/group/project/-/merge_requests/23',
+      },
+    });
+  });
+
+  test('prefers the process environment over the login shell for glab', async () => {
+    await using directory = await createTemporaryDirectory('codiff-glab-env-precedence-');
+    const repo = join(directory.path, 'repo');
+    const fakeGlab = join(directory.path, 'glab');
+    const fakeShell = join(directory.path, 'fake-login-shell');
+
+    await execFileAsync('git', ['init', repo]);
+    await execFileAsync('git', [
+      '-C',
+      repo,
+      'remote',
+      'add',
+      'origin',
+      'ssh://git@gitlab.example.com/group/project.git',
+    ]);
+
+    await writeFile(
+      fakeShell,
+      `#!/bin/sh
+GITLAB_TOKEN='from-login-shell' exec /bin/sh -c "$4"
+`,
+    );
+    await writeFile(
+      fakeGlab,
+      `#!/bin/sh
+if [ "$GITLAB_TOKEN" != 'from-process' ]; then
+  echo 'Expected the process GITLAB_TOKEN to win, got:' "$GITLAB_TOKEN" >&2
+  exit 4
+fi
+printf '%s' '{}'
+`,
+    );
+    await Promise.all([chmod(fakeShell, 0o755), chmod(fakeGlab, 0o755)]);
+
+    await using _environment = createTemporaryEnvironment({
+      CODIFF_GLAB_PATH: fakeGlab,
+      GITLAB_TOKEN: 'from-process',
+      SHELL: fakeShell,
+    });
+
+    await submitMergeRequestReview(repo, {
+      comments: [],
+      event: 'REQUEST_CHANGES',
+      source: {
+        provider: 'gitlab',
+        type: 'pull-request',
+        url: 'https://gitlab.example.com/group/project/-/merge_requests/23',
+      },
     });
   });
 });

--- a/electron/__tests__/claude.test.ts
+++ b/electron/__tests__/claude.test.ts
@@ -1,7 +1,7 @@
 import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
-import { expect, test, vi } from 'vite-plus/test';
+import { beforeEach, expect, test, vi } from 'vite-plus/test';
 import {
   createTemporaryDirectory,
   createTemporaryEnvironment,
@@ -36,6 +36,20 @@ const {
     },
   ) => Promise<string>;
 };
+
+// Spawning Claude resolves the login shell environment, so tests either
+// provide their own fake shell or run without one.
+beforeEach(() => {
+  const shell = process.env.SHELL;
+  delete process.env.SHELL;
+  return () => {
+    if (shell === undefined) {
+      delete process.env.SHELL;
+    } else {
+      process.env.SHELL = shell;
+    }
+  };
+});
 
 test('normalizes Claude Code model preferences to known models', () => {
   expect(normalizeClaudeModel('claude-opus-4-8')).toBe('claude-opus-4-8');
@@ -239,4 +253,78 @@ test('surfaces a helpful message when Claude Code is not logged in', async () =>
       commandTransport: transport,
     }),
   ).rejects.toThrow(/not logged in/i);
+});
+
+test('authenticates Claude Code from the login shell environment when the app inherited none', async () => {
+  await using directory = await createTemporaryDirectory('codiff-claude-login-env-');
+  const fakeShell = join(directory.path, 'fake-login-shell');
+  // A GUI-launched Codiff keeps launchd's minimal environment: no
+  // ANTHROPIC_API_KEY, even when the user's login shell exports one.
+  await writeFile(
+    fakeShell,
+    `#!/bin/sh
+ANTHROPIC_API_KEY='from-login-shell' exec /bin/sh -c "$4"
+`,
+  );
+  await chmod(fakeShell, 0o755);
+  await using _environment = createTemporaryEnvironment({
+    ANTHROPIC_API_KEY: undefined,
+    SHELL: fakeShell,
+  });
+  const { calls, transport } = createCommandTransport(({ close, stdin, stdout }) => {
+    stdin.on('finish', () => {
+      stdout(
+        JSON.stringify({
+          is_error: false,
+          result: '{"version":1}',
+          structured_output: { version: 1 },
+        }),
+      );
+      close();
+    });
+  });
+
+  await expect(
+    runClaude('/repo', 'prompt', { type: 'object' }, 'walkthrough.json', 'Timed out.', {
+      commandTransport: transport,
+    }),
+  ).resolves.toBe('{"version":1}');
+
+  expect(calls[0].options.env?.ANTHROPIC_API_KEY).toBe('from-login-shell');
+});
+
+test('prefers the process environment over the login shell for Claude Code', async () => {
+  await using directory = await createTemporaryDirectory('codiff-claude-env-precedence-');
+  const fakeShell = join(directory.path, 'fake-login-shell');
+  await writeFile(
+    fakeShell,
+    `#!/bin/sh
+ANTHROPIC_API_KEY='from-login-shell' exec /bin/sh -c "$4"
+`,
+  );
+  await chmod(fakeShell, 0o755);
+  await using _environment = createTemporaryEnvironment({
+    ANTHROPIC_API_KEY: 'from-process',
+    SHELL: fakeShell,
+  });
+  const { calls, transport } = createCommandTransport(({ close, stdin, stdout }) => {
+    stdin.on('finish', () => {
+      stdout(
+        JSON.stringify({
+          is_error: false,
+          result: '{"version":1}',
+          structured_output: { version: 1 },
+        }),
+      );
+      close();
+    });
+  });
+
+  await expect(
+    runClaude('/repo', 'prompt', { type: 'object' }, 'walkthrough.json', 'Timed out.', {
+      commandTransport: transport,
+    }),
+  ).resolves.toBe('{"version":1}');
+
+  expect(calls[0].options.env?.ANTHROPIC_API_KEY).toBe('from-process');
 });

--- a/electron/__tests__/codex.test.ts
+++ b/electron/__tests__/codex.test.ts
@@ -1,7 +1,7 @@
 import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
-import { expect, test } from 'vite-plus/test';
+import { beforeEach, expect, test } from 'vite-plus/test';
 import {
   createTemporaryDirectory,
   createTemporaryEnvironment,
@@ -70,6 +70,20 @@ const completeCodexExec = async (
   }
   commandProcess.close();
 };
+
+// Spawning Codex resolves the login shell environment, so tests either
+// provide their own fake shell or run without one.
+beforeEach(() => {
+  const shell = process.env.SHELL;
+  delete process.env.SHELL;
+  return () => {
+    if (shell === undefined) {
+      delete process.env.SHELL;
+    } else {
+      process.env.SHELL = shell;
+    }
+  };
+});
 
 test('normalizes OpenAI model preferences to known models', () => {
   expect(normalizeOpenAIModel('gpt-5.6-sol')).toBe('gpt-5.6-sol');
@@ -404,4 +418,46 @@ test('surfaces structured Codex CLI errors without the full prompt stream', asyn
 
   expect(message).toContain('Invalid schema for response_format.');
   expect(message).not.toContain('very long prompt');
+});
+
+test('authenticates Codex from the login shell environment when the app inherited none', async () => {
+  await using directory = await createTemporaryDirectory('codiff-codex-login-env-');
+  const fakeShell = join(directory.path, 'fake-login-shell');
+  // A GUI-launched Codiff keeps launchd's minimal environment: no
+  // OPENAI_API_KEY, even when the user's login shell exports one. Both the
+  // app-server and exec transports must receive the login shell variables.
+  await writeFile(
+    fakeShell,
+    `#!/bin/sh
+OPENAI_API_KEY='from-login-shell' exec /bin/sh -c "$4"
+`,
+  );
+  await chmod(fakeShell, 0o755);
+  await using _environment = createTemporaryEnvironment({
+    OPENAI_API_KEY: undefined,
+    SHELL: fakeShell,
+  });
+  const { calls, transport } = createCommandTransport((commandProcess) => {
+    if (commandProcess.args[0] === 'app-server') {
+      queueMicrotask(() => {
+        commandProcess.stderr("error: unrecognized subcommand 'app-server'");
+        commandProcess.close(2);
+      });
+      return;
+    }
+    commandProcess.stdin.on('finish', () => void completeCodexExec(commandProcess));
+  });
+
+  await expect(
+    runCodex('/repo', 'prompt', {}, 'walkthrough.json', 'Timed out.', {
+      commandTransport: transport,
+      onProgress: () => {},
+    }),
+  ).resolves.toBe('{"version":1}');
+
+  expect(calls[0].args[0]).toBe('app-server');
+  expect(calls).toHaveLength(2);
+  for (const call of calls) {
+    expect(call.options.env?.OPENAI_API_KEY).toBe('from-login-shell');
+  }
 });

--- a/electron/__tests__/login-shell-environment.test.ts
+++ b/electron/__tests__/login-shell-environment.test.ts
@@ -8,8 +8,9 @@ import {
 } from '../../core/__tests__/helpers/resources.ts';
 
 const require = createRequire(import.meta.url);
-const { getLoginShellEnvironment, resolveLoginShellEnvironment } =
+const { getCommandEnvironment, getLoginShellEnvironment, resolveLoginShellEnvironment } =
   require('../login-shell-environment.cjs') as {
+    getCommandEnvironment: () => Promise<Record<string, string | undefined>>;
     getLoginShellEnvironment: () => Promise<Readonly<Record<string, string>>>;
     resolveLoginShellEnvironment: (
       shell: string,
@@ -117,6 +118,25 @@ CODIFF_FAKE_TOKEN='from-login-shell' exec /bin/sh -c "$4"
   expect(second).toBe(first);
   expect(third).toBe(first);
   expect((await readFile(runsPath, 'utf8')).trim().split('\n')).toHaveLength(1);
+});
+
+test('builds command environments where the process wins over the login shell', async () => {
+  await using directory = await createTemporaryDirectory('codiff-login-shell-');
+  const shell = await createFakeLoginShell(
+    directory.path,
+    `CODIFF_FAKE_TOKEN='from-login-shell' CODIFF_FAKE_SHARED='from-login-shell' exec /bin/sh -c "$4"
+`,
+  );
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_FAKE_SHARED: 'from-process',
+    CODIFF_FAKE_TOKEN: undefined,
+    SHELL: shell,
+  });
+
+  const environment = await getCommandEnvironment();
+
+  expect(environment.CODIFF_FAKE_TOKEN).toBe('from-login-shell');
+  expect(environment.CODIFF_FAKE_SHARED).toBe('from-process');
 });
 
 test('salvages a clean environment dump when a background child holds stdout open', async () => {

--- a/electron/__tests__/opencode.test.ts
+++ b/electron/__tests__/opencode.test.ts
@@ -1,7 +1,7 @@
 import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
-import { expect, test } from 'vite-plus/test';
+import { beforeEach, expect, test } from 'vite-plus/test';
 import {
   createTemporaryDirectory,
   createTemporaryEnvironment,
@@ -47,6 +47,20 @@ const {
     },
   ) => Promise<string>;
 };
+
+// Spawning OpenCode resolves the login shell environment, so tests either
+// provide their own fake shell or run without one.
+beforeEach(() => {
+  const shell = process.env.SHELL;
+  delete process.env.SHELL;
+  return () => {
+    if (shell === undefined) {
+      delete process.env.SHELL;
+    } else {
+      process.env.SHELL = shell;
+    }
+  };
+});
 
 test('exposes selectable OpenCode models while keeping its configured default', () => {
   expect(DEFAULT_OPENCODE_MODEL).toBe('opencode-default');
@@ -355,4 +369,63 @@ test('passes explicit models to OpenCode and falls back when they are unavailabl
   expect(calls[0].args).toContain('anthropic/claude-sonnet-4-6');
   expect(calls[1].args).not.toContain('--model');
   expect(fallbacks).toEqual([[DEFAULT_OPENCODE_MODEL, 'anthropic/claude-sonnet-4-6']]);
+});
+
+test('authenticates OpenCode from the login shell environment when the app inherited none', async () => {
+  await using directory = await createTemporaryDirectory('codiff-opencode-login-env-');
+  const fakeShell = join(directory.path, 'fake-login-shell');
+  // A GUI-launched Codiff keeps launchd's minimal environment: no
+  // OPENAI_API_KEY, even when the user's login shell exports one. Both the
+  // event server and the CLI fallback must receive the login shell variables
+  // without losing the permission overrides.
+  await writeFile(
+    fakeShell,
+    `#!/bin/sh
+OPENAI_API_KEY='from-login-shell' exec /bin/sh -c "$4"
+`,
+  );
+  await chmod(fakeShell, 0o755);
+  await using _environment = createTemporaryEnvironment({
+    OPENAI_API_KEY: undefined,
+    SHELL: fakeShell,
+  });
+  const { calls, transport } = createCommandTransport((commandProcess) => {
+    if (commandProcess.args[0] === 'serve') {
+      queueMicrotask(() => {
+        commandProcess.stderr('unknown command: serve');
+        commandProcess.close(1);
+      });
+      return;
+    }
+    commandProcess.stdin.on('finish', () => {
+      commandProcess.stdout(
+        `${JSON.stringify({
+          part: { id: 'answer', text: '{"version":1}' },
+          type: 'text',
+        })}\n`,
+      );
+      commandProcess.close();
+    });
+  });
+
+  await expect(
+    runOpenCode(
+      '/repo',
+      'prompt',
+      { required: ['version'], type: 'object' },
+      undefined,
+      undefined,
+      {
+        commandTransport: transport,
+        onProgress: () => {},
+      },
+    ),
+  ).resolves.toBe('{"version":1}');
+
+  expect(calls[0].args[0]).toBe('serve');
+  expect(calls).toHaveLength(2);
+  for (const call of calls) {
+    expect(call.options.env?.OPENAI_API_KEY).toBe('from-login-shell');
+    expect(JSON.parse(String(call.options.env?.OPENCODE_PERMISSION))).toEqual({ '*': 'deny' });
+  }
 });

--- a/electron/__tests__/pi.test.ts
+++ b/electron/__tests__/pi.test.ts
@@ -1,11 +1,14 @@
 import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
-import { expect, test } from 'vite-plus/test';
+import { beforeEach, expect, test } from 'vite-plus/test';
 import {
   createTemporaryDirectory,
   createTemporaryEnvironment,
 } from '../../core/__tests__/helpers/resources.ts';
+import { createCommandTransport } from './helpers/command-transport.ts';
+
+type CommandTransport = ReturnType<typeof createCommandTransport>['transport'];
 
 const require = createRequire(import.meta.url);
 const {
@@ -31,9 +34,23 @@ const {
     schema: unknown,
     outputName?: string,
     timeoutMessage?: string,
-    options?: { model?: string },
+    options?: { commandTransport?: CommandTransport; model?: string },
   ) => Promise<string>;
 };
+
+// Spawning Pi resolves the login shell environment, so tests either provide
+// their own fake shell or run without one.
+beforeEach(() => {
+  const shell = process.env.SHELL;
+  delete process.env.SHELL;
+  return () => {
+    if (shell === undefined) {
+      delete process.env.SHELL;
+    } else {
+      process.env.SHELL = shell;
+    }
+  };
+});
 
 test('exposes the Pi default model identifier', () => {
   expect(DEFAULT_PI_MODEL).toBe('pi-default');
@@ -116,4 +133,43 @@ process.stdin.on('end', () => {
   const stdin = await readFile(stdinPath, 'utf8');
   expect(stdin).toContain('prompt');
   expect(stdin).toContain('Follow this JSON Schema exactly');
+});
+
+test('authenticates Pi from the login shell environment when the app inherited none', async () => {
+  await using directory = await createTemporaryDirectory('codiff-pi-login-env-');
+  const fakeShell = join(directory.path, 'fake-login-shell');
+  // A GUI-launched Codiff keeps launchd's minimal environment: no
+  // ANTHROPIC_API_KEY, even when the user's login shell exports one.
+  await writeFile(
+    fakeShell,
+    `#!/bin/sh
+ANTHROPIC_API_KEY='from-login-shell' exec /bin/sh -c "$4"
+`,
+  );
+  await chmod(fakeShell, 0o755);
+  await using _environment = createTemporaryEnvironment({
+    ANTHROPIC_API_KEY: undefined,
+    SHELL: fakeShell,
+  });
+  const { calls, transport } = createCommandTransport(({ close, stdin, stdout }) => {
+    stdin.on('finish', () => {
+      stdout('{"version":1}');
+      close();
+    });
+  });
+
+  await expect(
+    runPi(
+      '/repo',
+      'prompt',
+      { required: ['version'], type: 'object' },
+      'walkthrough.json',
+      undefined,
+      {
+        commandTransport: transport,
+      },
+    ),
+  ).resolves.toBe('{"version":1}');
+
+  expect(calls[0].options.env?.ANTHROPIC_API_KEY).toBe('from-login-shell');
 });

--- a/electron/claude.cjs
+++ b/electron/claude.cjs
@@ -3,6 +3,7 @@
 const { homedir } = require('node:os');
 const { join } = require('node:path');
 const { resolveAgentCommandTransport } = require('./agent-command.cjs');
+const { getCommandEnvironment } = require('./login-shell-environment.cjs');
 const {
   findExecutableOnPath,
   isExecutableFile,
@@ -234,8 +235,9 @@ const runClaude = async (
   const timeoutMs = options.timeoutMs ?? CLAUDE_TIMEOUT_MS;
 
   /** @param {string} claudeModel @returns {Promise<string>} */
-  const invokeClaude = async (claudeModel) =>
-    /** @type {Promise<string>} */ (
+  const invokeClaude = async (claudeModel) => {
+    const environment = await getCommandEnvironment();
+    return /** @type {Promise<string>} */ (
       new Promise((resolve, reject) => {
         let stderr = '';
         /** @type {Error | null} */
@@ -267,7 +269,7 @@ const runClaude = async (
         ];
         const child = commandTransport.spawn(commandTransport.command, claudeArgs, {
           cwd: repoRoot,
-          env: process.env,
+          env: environment,
           stdio: ['pipe', 'pipe', 'pipe'],
         });
         const streamParser = streamProgress ? createClaudeStreamParser(options.onProgress) : null;
@@ -349,6 +351,7 @@ const runClaude = async (
         child.stdin.end(prompt, () => {});
       })
     );
+  };
 
   try {
     return await invokeClaude(model);

--- a/electron/codex.cjs
+++ b/electron/codex.cjs
@@ -4,6 +4,7 @@ const { promises: fs } = require('node:fs');
 const { homedir, tmpdir } = require('node:os');
 const { join } = require('node:path');
 const { resolveAgentCommandTransport } = require('./agent-command.cjs');
+const { getCommandEnvironment } = require('./login-shell-environment.cjs');
 const {
   cleanText,
   findExecutableOnPath,
@@ -386,6 +387,7 @@ const runCodex = async (
     const outputPath = join(directory, outputName);
     const schemaPath = join(directory, 'schema.json');
     await fs.writeFile(schemaPath, JSON.stringify(schema), 'utf8');
+    const environment = await getCommandEnvironment();
 
     return await /** @type {Promise<string>} */ (
       new Promise((resolve, reject) => {
@@ -421,7 +423,7 @@ const runCodex = async (
           '-',
         ];
         const child = commandTransport.spawn(commandTransport.command, codexArgs, {
-          env: process.env,
+          env: environment,
           stdio: ['pipe', 'pipe', 'pipe'],
         });
         const eventParser = createCodexEventParser(options.onProgress);
@@ -498,8 +500,9 @@ const runCodex = async (
    * @param {string} codexModel
    * @returns {Promise<string>}
    */
-  const invokeCodexAppServer = (codexModel) => {
+  const invokeCodexAppServer = async (codexModel) => {
     const reasoningEffort = getOpenAIModelReasoningEffort(codexModel, options.reasoningEffort);
+    const environment = await getCommandEnvironment();
     return new Promise((resolve, reject) => {
       const commandTransport = resolveAgentCommandTransport(
         options.commandTransport,
@@ -510,7 +513,7 @@ const runCodex = async (
         ['app-server', '--stdio', '-c', `model_reasoning_effort="${reasoningEffort}"`],
         {
           cwd: repoRoot,
-          env: process.env,
+          env: environment,
           stdio: ['pipe', 'pipe', 'pipe'],
         },
       );

--- a/electron/git-state/merge-request.cjs
+++ b/electron/git-state/merge-request.cjs
@@ -5,6 +5,7 @@ const { spawn } = require('node:child_process');
 const { homedir } = require('node:os');
 const { join } = require('node:path');
 const { findExecutableOnPath, isExecutableFile } = require('../agent-shared.cjs');
+const { getLoginShellEnvironment } = require('../login-shell-environment.cjs');
 const {
   getFingerprint,
   git,
@@ -100,8 +101,11 @@ const createGlabApiArgs = (mergeRequest, args, input) => [
  * @param {ReadonlyArray<string>} args
  * @param {unknown} [input]
  */
-const glabApi = (repoRoot, mergeRequest, args, input) =>
-  new Promise((resolve, reject) => {
+const glabApi = async (repoRoot, mergeRequest, args, input) => {
+  // GUI launches miss login shell variables like GITLAB_TOKEN, so fill the
+  // gaps; the process environment wins for anything it already defines.
+  const environment = { ...(await getLoginShellEnvironment()), ...process.env };
+  return new Promise((resolve, reject) => {
     let command;
     try {
       command = getGlabCommand();
@@ -112,6 +116,7 @@ const glabApi = (repoRoot, mergeRequest, args, input) =>
 
     const child = spawn(command, createGlabApiArgs(mergeRequest, args, input), {
       cwd: repoRoot,
+      env: environment,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     const stdout = [];
@@ -134,6 +139,7 @@ const glabApi = (repoRoot, mergeRequest, args, input) =>
     });
     child.stdin.end(input == null ? undefined : JSON.stringify(input));
   });
+};
 
 /** @param {string} value */
 const parseGlabJsonPages = (value) => {

--- a/electron/git-state/merge-request.cjs
+++ b/electron/git-state/merge-request.cjs
@@ -5,7 +5,7 @@ const { spawn } = require('node:child_process');
 const { homedir } = require('node:os');
 const { join } = require('node:path');
 const { findExecutableOnPath, isExecutableFile } = require('../agent-shared.cjs');
-const { getLoginShellEnvironment } = require('../login-shell-environment.cjs');
+const { getCommandEnvironment } = require('../login-shell-environment.cjs');
 const {
   getFingerprint,
   git,
@@ -102,9 +102,7 @@ const createGlabApiArgs = (mergeRequest, args, input) => [
  * @param {unknown} [input]
  */
 const glabApi = async (repoRoot, mergeRequest, args, input) => {
-  // GUI launches miss login shell variables like GITLAB_TOKEN, so fill the
-  // gaps; the process environment wins for anything it already defines.
-  const environment = { ...(await getLoginShellEnvironment()), ...process.env };
+  const environment = await getCommandEnvironment();
   return new Promise((resolve, reject) => {
     let command;
     try {

--- a/electron/git-state/pull-request.cjs
+++ b/electron/git-state/pull-request.cjs
@@ -4,7 +4,7 @@ const { spawn } = require('node:child_process');
 const { homedir } = require('node:os');
 const { join } = require('node:path');
 const { findExecutableOnPath, isExecutableFile } = require('../agent-shared.cjs');
-const { getLoginShellEnvironment } = require('../login-shell-environment.cjs');
+const { getCommandEnvironment } = require('../login-shell-environment.cjs');
 const {
   IMAGE_FILE_LIMIT,
   bufferToImageRevision,
@@ -278,9 +278,7 @@ const fetchPullRequestHistoryRefs = (repoRoot, remote, pullRequest, metadata) =>
  * @returns {Promise<{code: number | null; stderr: string; stdout: Buffer}>}
  */
 const runGhApi = async (repoRoot, args, input) => {
-  // GUI launches miss login shell variables like GH_TOKEN, so fill the gaps;
-  // the process environment wins for anything it already defines.
-  const environment = { ...(await getLoginShellEnvironment()), ...process.env };
+  const environment = await getCommandEnvironment();
   return new Promise((resolve, reject) => {
     const child = spawn(getGhCommand(), ['api', ...args], {
       cwd: repoRoot,

--- a/electron/login-shell-environment.cjs
+++ b/electron/login-shell-environment.cjs
@@ -13,6 +13,19 @@ const VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const cache = new Map();
 
 /**
+ * Environment for spawning CLIs on the user's behalf: the login shell fills
+ * variables a GUI launch never inherited, such as `GH_TOKEN` or
+ * `ANTHROPIC_API_KEY`, and the process environment wins for anything it
+ * already defines.
+ *
+ * @returns {Promise<Record<string, string | undefined>>}
+ */
+const getCommandEnvironment = async () => ({
+  ...(await getLoginShellEnvironment()),
+  ...process.env,
+});
+
+/**
  * The environment of the user's interactive login shell, resolved once per
  * shell and cached. GUI launches inherit launchd's minimal environment, so variables
  * like `GH_TOKEN` may only exist in the login shell; resolving them lets CLI
@@ -91,6 +104,7 @@ const parseEnvironment = (output) => {
 };
 
 module.exports = {
+  getCommandEnvironment,
   getLoginShellEnvironment,
   resolveLoginShellEnvironment,
 };

--- a/electron/opencode.cjs
+++ b/electron/opencode.cjs
@@ -4,6 +4,7 @@ const { createServer } = require('node:net');
 const { homedir } = require('node:os');
 const { join } = require('node:path');
 const { resolveAgentCommandTransport } = require('./agent-command.cjs');
+const { getCommandEnvironment } = require('./login-shell-environment.cjs');
 const {
   buildSchemaReminder,
   findExecutableOnPath,
@@ -343,8 +344,9 @@ const runOpenCode = async (
   const effectivePrompt = `${prompt}${buildSchemaReminder(schema)}`;
 
   /** @param {string} openCodeModel */
-  const invokeOpenCodeCli = (openCodeModel) =>
-    /** @type {Promise<string>} */ (
+  const invokeOpenCodeCli = async (openCodeModel) => {
+    const environment = await getCommandEnvironment();
+    return /** @type {Promise<string>} */ (
       new Promise((resolve, reject) => {
         let stderr = '';
         /** @type {Error | null} */
@@ -370,7 +372,7 @@ const runOpenCode = async (
         const child = commandTransport.spawn(commandTransport.command, opencodeArgs, {
           cwd: repoRoot,
           env: {
-            ...process.env,
+            ...environment,
             OPENCODE_PERMISSION: JSON.stringify({ '*': 'deny' }),
           },
           stdio: ['pipe', 'pipe', 'pipe'],
@@ -430,6 +432,7 @@ const runOpenCode = async (
         child.stdin.end(effectivePrompt, () => {});
       })
     );
+  };
 
   /** @param {string} openCodeModel */
   const invokeOpenCodeServer = async (openCodeModel) => {
@@ -438,13 +441,14 @@ const runOpenCode = async (
       getOpenCodeCommand,
     );
     const port = await reserveOpenCodePort();
+    const environment = await getCommandEnvironment();
     const child = commandTransport.spawn(
       commandTransport.command,
       ['serve', '--pure', '--hostname=127.0.0.1', `--port=${port}`],
       {
         cwd: repoRoot,
         env: {
-          ...process.env,
+          ...environment,
           OPENCODE_PERMISSION: JSON.stringify({ '*': 'deny' }),
         },
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/electron/pi.cjs
+++ b/electron/pi.cjs
@@ -3,6 +3,7 @@
 const { homedir } = require('node:os');
 const { join } = require('node:path');
 const { resolveAgentCommandTransport } = require('./agent-command.cjs');
+const { getCommandEnvironment } = require('./login-shell-environment.cjs');
 const {
   buildSchemaReminder,
   findExecutableOnPath,
@@ -125,6 +126,7 @@ const runPi = async (
   const model = normalizePiModel(options.model);
   const timeoutMs = options.timeoutMs ?? PI_TIMEOUT_MS;
   const effectivePrompt = `${prompt}${buildSchemaReminder(schema)}`;
+  const environment = await getCommandEnvironment();
 
   return await /** @type {Promise<string>} */ (
     new Promise((resolve, reject) => {
@@ -147,7 +149,7 @@ const runPi = async (
       ];
       const child = commandTransport.spawn(commandTransport.command, piArgs, {
         cwd: repoRoot,
-        env: process.env,
+        env: environment,
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 


### PR DESCRIPTION
Follow-up to #144, which fixed `gh` authentication for GUI launches and left `glab` out of scope. Same story: a Dock-launched Codiff inherits launchd's minimal environment, the single-instance lock keeps it for the lifetime of the process, and `glab` never sees a `GITLAB_TOKEN` that only exists as a login shell export. GitLab requests fail with:

```
To get started with GitLab CLI, please run: glab auth login
```

While auditing the other spawn sites for the same gap, I found the agent CLIs have it too: `claude`, `codex` (exec and app-server), `opencode` (run and serve) and `pi` all spawn with plain `process.env`, so keys like `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` that only live in the user's shell profile never reach them from a GUI launch.

This PR:

- Adds `getCommandEnvironment` to `login-shell-environment.cjs`: `{ ...(await getLoginShellEnvironment()), ...process.env }`, so the login shell only fills variables the process doesn't already have
- Spawns `glab` with it in `glabApi`, mirroring the `gh` fix
- Spawns the six agent CLI sites with it, keeping `OPENCODE_PERMISSION` as an explicit override on top for OpenCode
- Routes `runGhApi` through the same helper so the precedence rule is defined once
- Keeps the agent suites hermetic with a `beforeEach` that clears `SHELL`, since every runner now resolves the login shell; the new tests bring their own fake login shell

The commits are ordered test first, then fix, for both halves. The glab regression test fails on the exact error above before the implementation, and the agent tests assert the spawned environment through the existing command transport capture, including that the process environment wins over the login shell.

I looked at the remaining spawn sites and left them alone on purpose: `opencode export` reads local session files, `cloudflared` authenticates through a browser flow and an on-disk cert, and the git spawns work fine from GUI launches today.

Created with Fable 5 xhigh, reviewed by Sol 5.6 xhigh.