### PR TITLE
Move the review mode tabs into the sidebar

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -721,6 +721,7 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   min-width: 0;
   padding: 0 14px 0 78px;
+  position: relative;
 }
 
 .share-shell .review-top-bar {
@@ -740,11 +741,26 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
 }
 
 .review-top-bar-left {
+  grid-column: 1;
   justify-content: flex-start;
 }
 
 .review-top-bar-right {
+  grid-column: 3;
   justify-content: flex-end;
+}
+
+.review-top-bar-center {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  left: 50%;
+  max-width: min(38%, 320px);
+  min-width: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .review-top-bar-repository-slot {
@@ -904,6 +920,40 @@ a.review-top-bar-source:focus-visible {
   background: var(--hover-wash);
   box-shadow: 0 1px 2px rgb(0 0 0 / 0.08);
   color: var(--sidebar-text);
+}
+
+.sidebar .review-mode-control {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--sidebar-border);
+  border-radius: 0;
+  corner-shape: initial;
+  display: flex;
+  gap: 4px;
+  height: 38px;
+  padding: 6px 8px;
+  width: 100%;
+}
+
+.sidebar .review-mode-control button {
+  flex: 1 1 0;
+  height: 26px;
+  overflow: hidden;
+  padding: 0 6px;
+}
+
+.sidebar .review-mode-control button > svg {
+  flex: none;
+}
+
+@container sidebar (max-width: 200px) {
+  .sidebar .review-mode-control button {
+    padding: 0 4px;
+  }
+
+  .sidebar .review-mode-label {
+    display: none;
+  }
 }
 
 .review-mode-label {
@@ -4256,11 +4306,11 @@ diffs-container .review-comment-thread {
 }
 
 @media (max-width: 480px) {
-  .review-mode-control button {
+  .review-top-bar .review-mode-control button {
     padding-inline: 7px;
   }
 
-  .review-mode-label {
+  .review-top-bar .review-mode-label {
     display: none;
   }
 }

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -23,7 +23,8 @@ import {
 } from './app/components/Panels.tsx';
 import { PlanEditorView } from './app/components/PlanEditorView.tsx';
 import { ReviewCodeView, type ReviewDiffBlock } from './app/components/ReviewCodeView.tsx';
-import { ReviewTopBar, type ReviewModeItem } from './app/components/ReviewTopBar.tsx';
+import type { ReviewModeItem } from './app/components/ReviewModeControl.tsx';
+import { ReviewTopBar } from './app/components/ReviewTopBar.tsx';
 import { Sidebar } from './app/components/Sidebar.tsx';
 import { CommitView } from './app/components/walkthrough/CommitView.tsx';
 import {
@@ -1826,9 +1827,6 @@ export default function App() {
             ) : null}
           </>
         }
-        mode={sidebarMode}
-        modes={reviewModes}
-        onModeChange={changeSidebarMode}
         onToggleSidebar={toggleSidebar}
         repository={
           <span className="review-top-bar-repository review-top-bar-repository-path">
@@ -1922,10 +1920,12 @@ export default function App() {
           historyLoading={historyLoading}
           keymap={codiffConfig.keymap}
           mode={sidebarMode}
+          modes={reviewModes}
           narrativeNavigation={narrativeNavigation}
           narrativeWalkthrough={narrativeWalkthrough}
           onActivatePath={activatePath}
           onLoadMoreHistory={loadMoreHistory}
+          onModeChange={changeSidebarMode}
           onSearchQueryChange={
             sidebarMode === 'history' ? setHistorySearchQuery : setFileSearchQuery
           }

--- a/core/SharedWalkthroughApp.tsx
+++ b/core/SharedWalkthroughApp.tsx
@@ -23,7 +23,8 @@ import {
   ReviewCodeView,
   type ReviewDiffBlock,
 } from './app/components/ReviewCodeView.tsx';
-import { ReviewTopBar, type ReviewModeItem } from './app/components/ReviewTopBar.tsx';
+import type { ReviewModeItem } from './app/components/ReviewModeControl.tsx';
+import { ReviewTopBar } from './app/components/ReviewTopBar.tsx';
 import { DiffLineCountBadge } from './app/components/Sidebar.tsx';
 import { NarrativeSidebar } from './app/components/walkthrough/NarrativeSidebar.tsx';
 import {

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -438,11 +438,14 @@ test('stale persisted collapsed sidebar state does not hide the sidebar on launc
       false,
     );
     expect(app.container.querySelector('.sidebar')).not.toBeNull();
-    expect(app.container.querySelector('.sidebar [role="tablist"]')).toBeNull();
+    expect(app.container.querySelector('.sidebar [role="tablist"]')).not.toBeNull();
   });
 
   const topBar = app.container.querySelector('.review-top-bar');
-  const modes = topBar?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [];
+  expect(topBar?.querySelector('[role="tablist"]')).toBeNull();
+  const modeControl = app.container.querySelector('.sidebar .review-mode-control');
+  expect(modeControl?.nextElementSibling?.className).toBe('sidebar-search-row');
+  const modes = modeControl?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [];
   expect([...modes].map((mode) => mode.textContent)).toEqual(['Walkthrough', 'Tree', 'History']);
   const sidebarToggle = topBar?.querySelector<HTMLButtonElement>('.sidebar-toggle-button');
   await act(async () => sidebarToggle?.click());

--- a/core/app/components/ReviewModeControl.tsx
+++ b/core/app/components/ReviewModeControl.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+export type ReviewModeItem<Mode extends string> = {
+  ariaLabel?: string;
+  icon: ReactNode;
+  indicator?: ReactNode;
+  label: string;
+  title?: string;
+  value: Mode;
+};
+
+export function ReviewModeControl<Mode extends string>({
+  mode,
+  modes,
+  onModeChange,
+}: {
+  mode: Mode;
+  modes: ReadonlyArray<ReviewModeItem<Mode>>;
+  onModeChange: (mode: Mode) => void;
+}) {
+  return (
+    <div aria-label="Review mode" className="review-mode-control" role="tablist">
+      {modes.map((item) => (
+        <button
+          aria-label={item.ariaLabel}
+          aria-selected={mode === item.value}
+          key={item.value}
+          onClick={() => onModeChange(item.value)}
+          role="tab"
+          title={item.title}
+          type="button"
+        >
+          {item.icon}
+          <span className="review-mode-label">{item.label}</span>
+          {item.indicator}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/core/app/components/ReviewTopBar.tsx
+++ b/core/app/components/ReviewTopBar.tsx
@@ -1,17 +1,10 @@
 import { SidebarSimpleIcon as SidebarSimple } from '@phosphor-icons/react/SidebarSimple';
 import type { ReactNode } from 'react';
-
-export type ReviewModeItem<Mode extends string> = {
-  ariaLabel?: string;
-  icon: ReactNode;
-  indicator?: ReactNode;
-  label: string;
-  title?: string;
-  value: Mode;
-};
+import { ReviewModeControl, type ReviewModeItem } from './ReviewModeControl.tsx';
 
 export function ReviewTopBar<Mode extends string>({
   actions,
+  center,
   context,
   leading,
   mode,
@@ -25,18 +18,23 @@ export function ReviewTopBar<Mode extends string>({
   toggleTitle,
 }: {
   actions?: ReactNode;
+  center?: ReactNode;
   context?: ReactNode;
   leading?: ReactNode;
-  mode: Mode;
-  modes: ReadonlyArray<ReviewModeItem<Mode>>;
-  onModeChange: (mode: Mode) => void;
   onToggleSidebar: () => void;
   repository: ReactNode;
   repositoryTooltip?: string;
   sidebarCollapsed: boolean;
   sourceMenu?: ReactNode;
   toggleTitle: string;
-}) {
+} & (
+  | {
+      mode: Mode;
+      modes: ReadonlyArray<ReviewModeItem<Mode>>;
+      onModeChange: (mode: Mode) => void;
+    }
+  | { mode?: undefined; modes?: undefined; onModeChange?: undefined }
+)) {
   return (
     <header className="review-top-bar workspace-top-bar">
       <div className="review-top-bar-left">
@@ -55,23 +53,11 @@ export function ReviewTopBar<Mode extends string>({
           {repository}
         </div>
       </div>
-      <div aria-label="Review mode" className="review-mode-control" role="tablist">
-        {modes.map((item) => (
-          <button
-            aria-label={item.ariaLabel}
-            aria-selected={mode === item.value}
-            key={item.value}
-            onClick={() => onModeChange(item.value)}
-            role="tab"
-            title={item.title}
-            type="button"
-          >
-            {item.icon}
-            <span className="review-mode-label">{item.label}</span>
-            {item.indicator}
-          </button>
-        ))}
-      </div>
+      {modes ? (
+        <ReviewModeControl mode={mode} modes={modes} onModeChange={onModeChange} />
+      ) : (
+        <div className="review-top-bar-center">{center}</div>
+      )}
       <div className="review-top-bar-right">
         {context ? <div className="review-top-bar-context">{context}</div> : null}
         {actions ? <div className="review-top-bar-actions">{actions}</div> : null}

--- a/core/app/components/Sidebar.tsx
+++ b/core/app/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import type { ChangedFile, HistoryEntry, NarrativeWalkthrough, ReviewSource } fr
 import { Avatar } from './Avatar.tsx';
 import { Button } from './Button.tsx';
 import { ReviewFileTree } from './FileTree.tsx';
+import { ReviewModeControl, type ReviewModeItem } from './ReviewModeControl.tsx';
 import { NarrativeSidebar } from './walkthrough/NarrativeSidebar.tsx';
 import type { NarrativeNavigation } from './walkthrough/useNarrativeNavigation.ts';
 import { WalkthroughProgress } from './walkthrough/WalkthroughProgress.tsx';
@@ -34,10 +35,12 @@ export function Sidebar({
   historyLoading,
   keymap,
   mode,
+  modes,
   narrativeNavigation,
   narrativeWalkthrough,
   onActivatePath,
   onLoadMoreHistory,
+  onModeChange,
   onSearchQueryChange,
   onSelectSource,
   onShareWalkthrough,
@@ -63,10 +66,12 @@ export function Sidebar({
   historyLoading: boolean;
   keymap: CodiffKeymap;
   mode: SidebarMode;
+  modes: ReadonlyArray<ReviewModeItem<SidebarMode>>;
   narrativeNavigation: NarrativeNavigation;
   narrativeWalkthrough: NarrativeWalkthrough | null;
   onActivatePath: (path: string) => void;
   onLoadMoreHistory: () => void;
+  onModeChange: (mode: SidebarMode) => void;
   onSearchQueryChange: (query: string) => void;
   onSelectSource: (source: ReviewSource) => void;
   onShareWalkthrough?: () => void;
@@ -115,6 +120,7 @@ export function Sidebar({
 
   return (
     <>
+      <ReviewModeControl mode={mode} modes={modes} onModeChange={onModeChange} />
       <div className="sidebar-search-row">
         <input
           aria-label="Filter changed files"


### PR DESCRIPTION
# Move the review mode tabs into the sidebar

> First of three stacked title-bar PRs; the other two build on this one.

## Problem

- Walkthrough / Tree / History live in the title bar, but they only change what the sidebar shows.
- The title bar's center slot is the most prominent spot in the window, spent on a control whose effect is confined to the left column.

## What changed

- The tab list is now its own component, so the title bar and the sidebar can each render it.
- The desktop app renders it at the top of the sidebar, directly above the file filter; the title bar's center slot is freed for the next change in this stack.
- The shared walkthrough app keeps its tabs in the title bar — its mode set includes Comments and its sidebar is a different component, so moving it was out of scope here.
- `ReviewTopBar`'s mode props became a union: either all three are passed or none are, so a caller can't specify `modes` without `onModeChange`.

## Risks

- The sidebar is user-resizable. Labels collapse to icons below 200px via the existing `sidebar` container query; between 200px and the default width the three tabs share the row evenly.
- The `@media (max-width: 480px)` label-hiding rules are now scoped to `.review-top-bar`, so they only affect the shared app's title-bar tabs. A sidebar narrowed on a small window is handled by the container query instead.

## Omissions / not verified

- No change to tab semantics — `changeSidebarMode` and the walkthrough unread dot behave exactly as before. The existing tab-clicking test passes untouched, which is the evidence for that.

## Screen recording

https://github.com/user-attachments/assets/a92d22fe-039a-4b49-9ec5-f3ec1d13ba28

## Test plan

1. Open a repository with a walkthrough. **Expected:** Walkthrough / Tree / History appear at the top of the sidebar above the filter field, and no longer in the title bar.
2. Click each tab. **Expected:** the sidebar content switches exactly as before; Walkthrough still opens the narrative view in the main pane.
3. Trigger a walkthrough while on Tree. **Expected:** the unread dot still renders on the Walkthrough tab and clears when you switch to it.
4. Drag the sidebar divider narrower than ~200px. **Expected:** labels disappear, icons remain, all three tabs stay clickable and evenly spaced.
5. Drag it back to full width. **Expected:** labels return without the strip wrapping or clipping.
6. Collapse the sidebar entirely. **Expected:** no orphaned tab strip, no layout shift in the title bar.
7. Open a shared walkthrough in the browser. **Expected:** unchanged — its tabs, including Comments, are still in the title bar.

---

This PR was written primarily with Claude Code.
