### PR TITLE
Center the branch name in the title bar

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -763,6 +763,11 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
   transform: translate(-50%, -50%);
 }
 
+.review-top-bar-center .review-top-bar-branch {
+  max-width: 100%;
+  pointer-events: auto;
+}
+
 .review-top-bar-repository-slot {
   align-items: center;
   color: var(--sidebar-text);
@@ -4300,6 +4305,7 @@ diffs-container .review-comment-thread {
 
 @media (max-width: 720px) {
   .review-top-bar-repository-slot,
+  .review-top-bar-center,
   .review-top-bar-context {
     display: none;
   }

--- a/core/App.css
+++ b/core/App.css
@@ -721,6 +721,7 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   min-width: 0;
   padding: 0 14px 0 78px;
+  position: relative;
 }
 
 .share-shell .review-top-bar {
@@ -740,11 +741,26 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
 }
 
 .review-top-bar-left {
+  grid-column: 1;
   justify-content: flex-start;
 }
 
 .review-top-bar-right {
+  grid-column: 3;
   justify-content: flex-end;
+}
+
+.review-top-bar-center {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  left: 50%;
+  max-width: min(38%, 320px);
+  min-width: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .review-top-bar-repository-slot {
@@ -904,6 +920,40 @@ a.review-top-bar-source:focus-visible {
   background: var(--hover-wash);
   box-shadow: 0 1px 2px rgb(0 0 0 / 0.08);
   color: var(--sidebar-text);
+}
+
+.sidebar .review-mode-control {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--sidebar-border);
+  border-radius: 0;
+  corner-shape: initial;
+  display: flex;
+  gap: 4px;
+  height: 38px;
+  padding: 6px 8px;
+  width: 100%;
+}
+
+.sidebar .review-mode-control button {
+  flex: 1 1 0;
+  height: 26px;
+  overflow: hidden;
+  padding: 0 6px;
+}
+
+.sidebar .review-mode-control button > svg {
+  flex: none;
+}
+
+@container sidebar (max-width: 200px) {
+  .sidebar .review-mode-control button {
+    padding: 0 4px;
+  }
+
+  .sidebar .review-mode-label {
+    display: none;
+  }
 }
 
 .review-mode-label {
@@ -4256,11 +4306,11 @@ diffs-container .review-comment-thread {
 }
 
 @media (max-width: 480px) {
-  .review-mode-control button {
+  .review-top-bar .review-mode-control button {
     padding-inline: 7px;
   }
 
-  .review-mode-label {
+  .review-top-bar .review-mode-label {
     display: none;
   }
 }

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -23,7 +23,8 @@ import {
 } from './app/components/Panels.tsx';
 import { PlanEditorView } from './app/components/PlanEditorView.tsx';
 import { ReviewCodeView, type ReviewDiffBlock } from './app/components/ReviewCodeView.tsx';
-import { ReviewTopBar, type ReviewModeItem } from './app/components/ReviewTopBar.tsx';
+import type { ReviewModeItem } from './app/components/ReviewModeControl.tsx';
+import { ReviewTopBar } from './app/components/ReviewTopBar.tsx';
 import { Sidebar } from './app/components/Sidebar.tsx';
 import { CommitView } from './app/components/walkthrough/CommitView.tsx';
 import {
@@ -1826,9 +1827,6 @@ export default function App() {
             ) : null}
           </>
         }
-        mode={sidebarMode}
-        modes={reviewModes}
-        onModeChange={changeSidebarMode}
         onToggleSidebar={toggleSidebar}
         repository={
           <span className="review-top-bar-repository review-top-bar-repository-path">
@@ -1922,10 +1920,12 @@ export default function App() {
           historyLoading={historyLoading}
           keymap={codiffConfig.keymap}
           mode={sidebarMode}
+          modes={reviewModes}
           narrativeNavigation={narrativeNavigation}
           narrativeWalkthrough={narrativeWalkthrough}
           onActivatePath={activatePath}
           onLoadMoreHistory={loadMoreHistory}
+          onModeChange={changeSidebarMode}
           onSearchQueryChange={
             sidebarMode === 'history' ? setHistorySearchQuery : setFileSearchQuery
           }

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -1803,29 +1803,29 @@ export default function App() {
     >
       <div aria-hidden className="window-drag-region" />
       <ReviewTopBar
+        center={
+          state.branch ? (
+            <span className="review-top-bar-branch" title={state.branch}>
+              {state.branch}
+            </span>
+          ) : null
+        }
         context={
-          <>
-            {state.branch ? (
-              <span className="review-top-bar-branch" title={state.branch}>
-                {state.branch}
-              </span>
-            ) : null}
-            {sidebarSourceLabel ? (
-              pullRequestUrl ? (
-                <a
-                  className="review-top-bar-source"
-                  href={pullRequestUrl}
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  <span>{sidebarSourceLabel}</span>
-                  <ArrowSquareOut aria-hidden size={14} weight="bold" />
-                </a>
-              ) : (
-                <span className="review-top-bar-source">{sidebarSourceLabel}</span>
-              )
-            ) : null}
-          </>
+          sidebarSourceLabel ? (
+            pullRequestUrl ? (
+              <a
+                className="review-top-bar-source"
+                href={pullRequestUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <span>{sidebarSourceLabel}</span>
+                <ArrowSquareOut aria-hidden size={14} weight="bold" />
+              </a>
+            ) : (
+              <span className="review-top-bar-source">{sidebarSourceLabel}</span>
+            )
+          ) : null
         }
         onToggleSidebar={toggleSidebar}
         repository={

--- a/core/SharedWalkthroughApp.tsx
+++ b/core/SharedWalkthroughApp.tsx
@@ -23,7 +23,8 @@ import {
   ReviewCodeView,
   type ReviewDiffBlock,
 } from './app/components/ReviewCodeView.tsx';
-import { ReviewTopBar, type ReviewModeItem } from './app/components/ReviewTopBar.tsx';
+import type { ReviewModeItem } from './app/components/ReviewModeControl.tsx';
+import { ReviewTopBar } from './app/components/ReviewTopBar.tsx';
 import { DiffLineCountBadge } from './app/components/Sidebar.tsx';
 import { NarrativeSidebar } from './app/components/walkthrough/NarrativeSidebar.tsx';
 import {

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -438,11 +438,14 @@ test('stale persisted collapsed sidebar state does not hide the sidebar on launc
       false,
     );
     expect(app.container.querySelector('.sidebar')).not.toBeNull();
-    expect(app.container.querySelector('.sidebar [role="tablist"]')).toBeNull();
+    expect(app.container.querySelector('.sidebar [role="tablist"]')).not.toBeNull();
   });
 
   const topBar = app.container.querySelector('.review-top-bar');
-  const modes = topBar?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [];
+  expect(topBar?.querySelector('[role="tablist"]')).toBeNull();
+  const modeControl = app.container.querySelector('.sidebar .review-mode-control');
+  expect(modeControl?.nextElementSibling?.className).toBe('sidebar-search-row');
+  const modes = modeControl?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [];
   expect([...modes].map((mode) => mode.textContent)).toEqual(['Walkthrough', 'Tree', 'History']);
   const sidebarToggle = topBar?.querySelector<HTMLButtonElement>('.sidebar-toggle-button');
   await act(async () => sidebarToggle?.click());

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -552,6 +552,19 @@ test('repository label is plain text and clicking it does nothing', async () => 
   expect(openRepositoryFolder).not.toHaveBeenCalled();
 });
 
+test('the branch name renders in the center of the top bar', async () => {
+  window.codiff = createCodiffMock();
+
+  await using app = await renderReact(<App />);
+  await waitFor(() => expect(app.container.querySelector('.app-shell')).not.toBeNull());
+
+  const branch = app.container.querySelector<HTMLElement>('.review-top-bar-branch');
+  expect(branch?.textContent).toBe('main');
+  expect(branch?.getAttribute('title')).toBe('main');
+  expect(branch?.parentElement?.className).toBe('review-top-bar-center');
+  expect(app.container.querySelector('.review-top-bar-context .review-top-bar-branch')).toBeNull();
+});
+
 test('empty repository state fills the review pane for centered layout', async () => {
   window.codiff = createCodiffMock();
 

--- a/core/app/components/ReviewModeControl.tsx
+++ b/core/app/components/ReviewModeControl.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+export type ReviewModeItem<Mode extends string> = {
+  ariaLabel?: string;
+  icon: ReactNode;
+  indicator?: ReactNode;
+  label: string;
+  title?: string;
+  value: Mode;
+};
+
+export function ReviewModeControl<Mode extends string>({
+  mode,
+  modes,
+  onModeChange,
+}: {
+  mode: Mode;
+  modes: ReadonlyArray<ReviewModeItem<Mode>>;
+  onModeChange: (mode: Mode) => void;
+}) {
+  return (
+    <div aria-label="Review mode" className="review-mode-control" role="tablist">
+      {modes.map((item) => (
+        <button
+          aria-label={item.ariaLabel}
+          aria-selected={mode === item.value}
+          key={item.value}
+          onClick={() => onModeChange(item.value)}
+          role="tab"
+          title={item.title}
+          type="button"
+        >
+          {item.icon}
+          <span className="review-mode-label">{item.label}</span>
+          {item.indicator}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/core/app/components/ReviewTopBar.tsx
+++ b/core/app/components/ReviewTopBar.tsx
@@ -1,17 +1,10 @@
 import { SidebarSimpleIcon as SidebarSimple } from '@phosphor-icons/react/SidebarSimple';
 import type { ReactNode } from 'react';
-
-export type ReviewModeItem<Mode extends string> = {
-  ariaLabel?: string;
-  icon: ReactNode;
-  indicator?: ReactNode;
-  label: string;
-  title?: string;
-  value: Mode;
-};
+import { ReviewModeControl, type ReviewModeItem } from './ReviewModeControl.tsx';
 
 export function ReviewTopBar<Mode extends string>({
   actions,
+  center,
   context,
   leading,
   mode,
@@ -25,18 +18,23 @@ export function ReviewTopBar<Mode extends string>({
   toggleTitle,
 }: {
   actions?: ReactNode;
+  center?: ReactNode;
   context?: ReactNode;
   leading?: ReactNode;
-  mode: Mode;
-  modes: ReadonlyArray<ReviewModeItem<Mode>>;
-  onModeChange: (mode: Mode) => void;
   onToggleSidebar: () => void;
   repository: ReactNode;
   repositoryTooltip?: string;
   sidebarCollapsed: boolean;
   sourceMenu?: ReactNode;
   toggleTitle: string;
-}) {
+} & (
+  | {
+      mode: Mode;
+      modes: ReadonlyArray<ReviewModeItem<Mode>>;
+      onModeChange: (mode: Mode) => void;
+    }
+  | { mode?: undefined; modes?: undefined; onModeChange?: undefined }
+)) {
   return (
     <header className="review-top-bar workspace-top-bar">
       <div className="review-top-bar-left">
@@ -55,23 +53,11 @@ export function ReviewTopBar<Mode extends string>({
           {repository}
         </div>
       </div>
-      <div aria-label="Review mode" className="review-mode-control" role="tablist">
-        {modes.map((item) => (
-          <button
-            aria-label={item.ariaLabel}
-            aria-selected={mode === item.value}
-            key={item.value}
-            onClick={() => onModeChange(item.value)}
-            role="tab"
-            title={item.title}
-            type="button"
-          >
-            {item.icon}
-            <span className="review-mode-label">{item.label}</span>
-            {item.indicator}
-          </button>
-        ))}
-      </div>
+      {modes ? (
+        <ReviewModeControl mode={mode} modes={modes} onModeChange={onModeChange} />
+      ) : (
+        <div className="review-top-bar-center">{center}</div>
+      )}
       <div className="review-top-bar-right">
         {context ? <div className="review-top-bar-context">{context}</div> : null}
         {actions ? <div className="review-top-bar-actions">{actions}</div> : null}

--- a/core/app/components/Sidebar.tsx
+++ b/core/app/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import type { ChangedFile, HistoryEntry, NarrativeWalkthrough, ReviewSource } fr
 import { Avatar } from './Avatar.tsx';
 import { Button } from './Button.tsx';
 import { ReviewFileTree } from './FileTree.tsx';
+import { ReviewModeControl, type ReviewModeItem } from './ReviewModeControl.tsx';
 import { NarrativeSidebar } from './walkthrough/NarrativeSidebar.tsx';
 import type { NarrativeNavigation } from './walkthrough/useNarrativeNavigation.ts';
 import { WalkthroughProgress } from './walkthrough/WalkthroughProgress.tsx';
@@ -34,10 +35,12 @@ export function Sidebar({
   historyLoading,
   keymap,
   mode,
+  modes,
   narrativeNavigation,
   narrativeWalkthrough,
   onActivatePath,
   onLoadMoreHistory,
+  onModeChange,
   onSearchQueryChange,
   onSelectSource,
   onShareWalkthrough,
@@ -63,10 +66,12 @@ export function Sidebar({
   historyLoading: boolean;
   keymap: CodiffKeymap;
   mode: SidebarMode;
+  modes: ReadonlyArray<ReviewModeItem<SidebarMode>>;
   narrativeNavigation: NarrativeNavigation;
   narrativeWalkthrough: NarrativeWalkthrough | null;
   onActivatePath: (path: string) => void;
   onLoadMoreHistory: () => void;
+  onModeChange: (mode: SidebarMode) => void;
   onSearchQueryChange: (query: string) => void;
   onSelectSource: (source: ReviewSource) => void;
   onShareWalkthrough?: () => void;
@@ -115,6 +120,7 @@ export function Sidebar({
 
   return (
     <>
+      <ReviewModeControl mode={mode} modes={modes} onModeChange={onModeChange} />
       <div className="sidebar-search-row">
         <input
           aria-label="Filter changed files"


### PR DESCRIPTION
# Center the branch name in the title bar

> **Stacked on the review-mode-tabs PR.** It is branched off that work, so until that one merges this diff also shows its commits. Review it after, and this diff narrows to just the change below once the parent lands.

## Problem

- The branch name sat in the right-hand group, sharing space with the source label and any action buttons.
- It is the single most useful piece of orientation in the window and was the easiest thing to lose track of.

## What changed

- New `center` slot on the title bar, holding the branch; the source label and pull-request link stay on the right.
- The slot is positioned against the header's padding box rather than placed in the grid's middle column.

## Risks

- **Why absolute rather than a grid column:** the middle grid column centers on the *content* box, which the 78px macOS traffic-light padding shifts right by roughly half that. Positioning against the padding box centers the branch on the window itself, and keeps it centered as the two side groups change width.
- The trade-off is that the branch is out of flow, so a long repository path on a narrow window can slide underneath it before the 720px rule hides the center slot. Worth a look if you run a deep path in a small window.
- The wrapper is `pointer-events: none` with the branch pill re-enabling itself, so the window drag region behind it still works.

## Omissions / not verified

- The shared walkthrough app is unchanged: it still renders mode tabs in the center, so it has no center slot to fill.

## Screenshot

<img width="1508" height="965" alt="Screenshot 2026-08-09 at 12 19 15" src="https://github.com/user-attachments/assets/2cbd94fa-dcbf-43ab-bbdd-81b96a97a28d" />

## Test plan

1. Open a repository on a named branch. **Expected:** the branch is horizontally centered in the window, not offset right by the traffic lights.
2. Resize the window wider and narrower. **Expected:** it stays centered on the window rather than drifting with the side groups.
3. Open a repository with a very long path so the left group grows. **Expected:** the branch stays centered and the path truncates.
4. Check out a branch with a very long name. **Expected:** it truncates with an ellipsis and the full name shows on hover.
5. Open a pull request source. **Expected:** the source label and external link stay on the right, with the branch still centered.
6. Open a repository in detached HEAD (no branch). **Expected:** the center slot is empty and nothing shifts.
7. Drag the window by the empty title bar area either side of the branch. **Expected:** the window still moves.

---

This PR was written primarily with Claude Code.
