### PR TITLE
Show the copy review comments button in the title bar

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -3616,26 +3616,27 @@ diffs-container .review-comment-thread {
   word-break: break-word;
 }
 
+/* Matches .review-top-bar-icon-button, the sidebar toggle two controls over,
+   so the two read as siblings rather than as different kinds of control. */
 .copy-comments-button {
   -webkit-app-region: no-drag;
   align-items: center;
-  background: color-mix(in srgb, var(--sidebar-ref) 12%, var(--code-bg));
-  border: 1px solid color-mix(in srgb, var(--sidebar-ref) 38%, transparent);
-  border-radius: 14px;
-  color: var(--sidebar-ref);
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  color: var(--muted);
   corner-shape: squircle;
   cursor: pointer;
   display: inline-flex;
   flex: none;
   font: 700 11px/1 var(--font-sans);
   gap: 5px;
-  height: 26px;
+  height: 28px;
   justify-content: center;
-  padding: 0 10px;
+  padding: 0 8px;
   transition:
-    background 150ms ease,
-    border-color 150ms ease,
-    transform 150ms cubic-bezier(0.34, 1.56, 0.64, 1);
+    background 120ms ease,
+    color 120ms ease;
 }
 
 .review-submit-button {
@@ -3787,13 +3788,20 @@ diffs-container .review-comment-thread {
   color: var(--text);
 }
 
-.copy-comments-button:hover {
-  background: color-mix(in srgb, var(--sidebar-ref) 20%, var(--code-bg));
-  border-color: color-mix(in srgb, var(--sidebar-ref) 52%, transparent);
+.copy-comments-button:hover:not(:disabled) {
+  background: rgb(127 127 127 / 0.14);
+  color: var(--sidebar-text);
 }
 
-.copy-comments-button:active {
-  transform: scale(0.96);
+.copy-comments-button:active:not(:disabled) {
+  background: rgb(127 127 127 / 0.2);
+  color: var(--sidebar-text);
+}
+
+.copy-comments-button:disabled {
+  color: var(--muted);
+  cursor: default;
+  opacity: 0.5;
 }
 
 .review-submit-button:disabled {

--- a/core/App.css
+++ b/core/App.css
@@ -763,6 +763,11 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
   transform: translate(-50%, -50%);
 }
 
+.review-top-bar-center .review-top-bar-branch {
+  max-width: 100%;
+  pointer-events: auto;
+}
+
 .review-top-bar-repository-slot {
   align-items: center;
   color: var(--sidebar-text);
@@ -4300,6 +4305,7 @@ diffs-container .review-comment-thread {
 
 @media (max-width: 720px) {
   .review-top-bar-repository-slot,
+  .review-top-bar-center,
   .review-top-bar-context {
     display: none;
   }

--- a/core/App.css
+++ b/core/App.css
@@ -747,9 +747,6 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
 
 .review-top-bar-right {
   grid-column: 3;
-  /* Wider than the left group so the copy button reads as its own control
-     rather than as part of the source label it sits beside. */
-  gap: 16px;
   justify-content: flex-end;
 }
 

--- a/core/App.css
+++ b/core/App.css
@@ -33,6 +33,11 @@
     --file-border: rgb(17 17 17 / 0.09);
     --inline-code-bg: rgb(242 242 242);
     --hover-wash: rgb(127 127 127 / 0.1);
+    --copy-comments-accent: #c2620e;
+    --copy-comments-accent-hover: #a75409;
+    --copy-comments-accent-text: #ffffff;
+    --copy-comments-copied: #1f7a44;
+    --copy-comments-copied-text: #ffffff;
     --copy-icon: rgb(17 17 17 / 0.62);
     --muted: rgb(17 17 17 / 0.48);
     --sidebar-bg: rgb(255 255 255 / 0.58);
@@ -62,6 +67,11 @@
       --file-border: rgb(230 230 230 / 0.1);
       --inline-code-bg: rgb(39 39 39);
       --hover-wash: rgb(127 127 127 / 0.14);
+      --copy-comments-accent: #e8912f;
+      --copy-comments-accent-hover: #f4a244;
+      --copy-comments-accent-text: #1a1206;
+      --copy-comments-copied: #6fd094;
+      --copy-comments-copied-text: #0d2015;
       --copy-icon: rgb(230 230 230 / 0.68);
       --muted: rgb(230 230 230 / 0.48);
       --sidebar-bg: rgb(38 38 38 / 0.58);
@@ -91,6 +101,11 @@
     --file-border: rgb(17 17 17 / 0.09);
     --inline-code-bg: rgb(242 242 242);
     --hover-wash: rgb(127 127 127 / 0.1);
+    --copy-comments-accent: #c2620e;
+    --copy-comments-accent-hover: #a75409;
+    --copy-comments-accent-text: #ffffff;
+    --copy-comments-copied: #1f7a44;
+    --copy-comments-copied-text: #ffffff;
     --copy-icon: rgb(17 17 17 / 0.62);
     --muted: rgb(17 17 17 / 0.48);
     --sidebar-bg: rgb(255 255 255 / 0.58);
@@ -119,6 +134,11 @@
     --file-border: rgb(230 230 230 / 0.1);
     --inline-code-bg: rgb(39 39 39);
     --hover-wash: rgb(127 127 127 / 0.14);
+    --copy-comments-accent: #e8912f;
+    --copy-comments-accent-hover: #f4a244;
+    --copy-comments-accent-text: #1a1206;
+    --copy-comments-copied: #6fd094;
+    --copy-comments-copied-text: #0d2015;
     --copy-icon: rgb(230 230 230 / 0.68);
     --muted: rgb(230 230 230 / 0.48);
     --sidebar-bg: rgb(38 38 38 / 0.58);
@@ -3613,41 +3633,27 @@ diffs-container .review-comment-thread {
   word-break: break-word;
 }
 
-.review-action-bar {
+.copy-comments-button {
   -webkit-app-region: no-drag;
   align-items: center;
-  bottom: 16px;
-  display: inline-flex;
-  gap: 12px;
-  position: fixed;
-  right: 16px;
-  z-index: 12;
-}
-
-.copy-comments-button {
-  align-items: center;
-  backdrop-filter: blur(22px) saturate(1.35);
-  background: color-mix(in srgb, var(--code-bg) 78%, transparent);
-  border: 1px solid var(--file-border);
-  border-radius: 50%;
-  box-shadow:
-    0 0 0 1px rgb(255 255 255 / 0.16) inset,
-    0 0 0 1px var(--file-border),
-    0 18px 80px -54px rgb(0 0 0 / 0.8),
-    0 16px 46px -30px rgb(0 0 0 / 0.72),
-    0 12px 24px -18px rgb(0 0 0 / 0.9);
+  background: var(--copy-comments-accent);
+  border: 0;
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.16);
+  color: var(--copy-comments-accent-text);
+  corner-shape: squircle;
   cursor: pointer;
   display: inline-flex;
-  height: 46px;
+  flex: none;
+  font: 700 11px/1 var(--font-sans);
+  gap: 5px;
+  height: 26px;
   justify-content: center;
-  padding: 0;
-  transition: all 250ms cubic-bezier(0.34, 1.56, 0.64, 1);
-  transform: scale(1);
-  width: 46px;
-}
-
-.copy-comments-button {
-  color: var(--copy-icon);
+  padding: 0 10px;
+  transition:
+    background 150ms ease,
+    color 150ms ease,
+    transform 150ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .review-submit-button {
@@ -3800,16 +3806,11 @@ diffs-container .review-comment-thread {
 }
 
 .copy-comments-button:hover {
-  box-shadow:
-    0 0 0 1px var(--file-border),
-    0 26px 96px -48px rgb(0 0 0 / 0.92),
-    0 22px 62px -30px rgb(0 0 0 / 0.82),
-    0 16px 32px -18px rgb(0 0 0 / 0.96);
-  transform: scale(1.05);
+  background: var(--copy-comments-accent-hover);
 }
 
 .copy-comments-button:active {
-  transform: scale(0.95);
+  transform: scale(0.96);
 }
 
 .review-submit-button:disabled {
@@ -3817,9 +3818,14 @@ diffs-container .review-comment-thread {
   opacity: 0.58;
 }
 
-.copy-comments-button.copied {
-  background: color-mix(in srgb, var(--code-bg) 80%, var(--viewed) 14%);
-  color: var(--viewed);
+.copy-comments-button.copied,
+.copy-comments-button.copied:hover {
+  background: var(--copy-comments-copied);
+  color: var(--copy-comments-copied-text);
+}
+
+.copy-comments-count {
+  font: 700 11px/1 var(--font-mono);
 }
 
 .copy-comments-icon {
@@ -3829,7 +3835,7 @@ diffs-container .review-comment-thread {
 }
 
 .copy-comments-icon.check {
-  transform: translateY(-1px);
+  transform: none;
 }
 
 .review-submit-icon {

--- a/core/App.css
+++ b/core/App.css
@@ -721,6 +721,7 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   min-width: 0;
   padding: 0 14px 0 78px;
+  position: relative;
 }
 
 .share-shell .review-top-bar {
@@ -740,11 +741,26 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
 }
 
 .review-top-bar-left {
+  grid-column: 1;
   justify-content: flex-start;
 }
 
 .review-top-bar-right {
+  grid-column: 3;
   justify-content: flex-end;
+}
+
+.review-top-bar-center {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  left: 50%;
+  max-width: min(38%, 320px);
+  min-width: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .review-top-bar-repository-slot {
@@ -904,6 +920,40 @@ a.review-top-bar-source:focus-visible {
   background: var(--hover-wash);
   box-shadow: 0 1px 2px rgb(0 0 0 / 0.08);
   color: var(--sidebar-text);
+}
+
+.sidebar .review-mode-control {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--sidebar-border);
+  border-radius: 0;
+  corner-shape: initial;
+  display: flex;
+  gap: 4px;
+  height: 38px;
+  padding: 6px 8px;
+  width: 100%;
+}
+
+.sidebar .review-mode-control button {
+  flex: 1 1 0;
+  height: 26px;
+  overflow: hidden;
+  padding: 0 6px;
+}
+
+.sidebar .review-mode-control button > svg {
+  flex: none;
+}
+
+@container sidebar (max-width: 200px) {
+  .sidebar .review-mode-control button {
+    padding: 0 4px;
+  }
+
+  .sidebar .review-mode-label {
+    display: none;
+  }
 }
 
 .review-mode-label {
@@ -4256,11 +4306,11 @@ diffs-container .review-comment-thread {
 }
 
 @media (max-width: 480px) {
-  .review-mode-control button {
+  .review-top-bar .review-mode-control button {
     padding-inline: 7px;
   }
 
-  .review-mode-label {
+  .review-top-bar .review-mode-label {
     display: none;
   }
 }

--- a/core/App.css
+++ b/core/App.css
@@ -33,11 +33,6 @@
     --file-border: rgb(17 17 17 / 0.09);
     --inline-code-bg: rgb(242 242 242);
     --hover-wash: rgb(127 127 127 / 0.1);
-    --copy-comments-accent: #c2620e;
-    --copy-comments-accent-hover: #a75409;
-    --copy-comments-accent-text: #ffffff;
-    --copy-comments-copied: #1f7a44;
-    --copy-comments-copied-text: #ffffff;
     --copy-icon: rgb(17 17 17 / 0.62);
     --muted: rgb(17 17 17 / 0.48);
     --sidebar-bg: rgb(255 255 255 / 0.58);
@@ -67,11 +62,6 @@
       --file-border: rgb(230 230 230 / 0.1);
       --inline-code-bg: rgb(39 39 39);
       --hover-wash: rgb(127 127 127 / 0.14);
-      --copy-comments-accent: #e8912f;
-      --copy-comments-accent-hover: #f4a244;
-      --copy-comments-accent-text: #1a1206;
-      --copy-comments-copied: #6fd094;
-      --copy-comments-copied-text: #0d2015;
       --copy-icon: rgb(230 230 230 / 0.68);
       --muted: rgb(230 230 230 / 0.48);
       --sidebar-bg: rgb(38 38 38 / 0.58);
@@ -101,11 +91,6 @@
     --file-border: rgb(17 17 17 / 0.09);
     --inline-code-bg: rgb(242 242 242);
     --hover-wash: rgb(127 127 127 / 0.1);
-    --copy-comments-accent: #c2620e;
-    --copy-comments-accent-hover: #a75409;
-    --copy-comments-accent-text: #ffffff;
-    --copy-comments-copied: #1f7a44;
-    --copy-comments-copied-text: #ffffff;
     --copy-icon: rgb(17 17 17 / 0.62);
     --muted: rgb(17 17 17 / 0.48);
     --sidebar-bg: rgb(255 255 255 / 0.58);
@@ -134,11 +119,6 @@
     --file-border: rgb(230 230 230 / 0.1);
     --inline-code-bg: rgb(39 39 39);
     --hover-wash: rgb(127 127 127 / 0.14);
-    --copy-comments-accent: #e8912f;
-    --copy-comments-accent-hover: #f4a244;
-    --copy-comments-accent-text: #1a1206;
-    --copy-comments-copied: #6fd094;
-    --copy-comments-copied-text: #0d2015;
     --copy-icon: rgb(230 230 230 / 0.68);
     --muted: rgb(230 230 230 / 0.48);
     --sidebar-bg: rgb(38 38 38 / 0.58);
@@ -767,6 +747,9 @@ html[data-codiff-platform='darwin'] .workspace-top-bar {
 
 .review-top-bar-right {
   grid-column: 3;
+  /* Wider than the left group so the copy button reads as its own control
+     rather than as part of the source label it sits beside. */
+  gap: 16px;
   justify-content: flex-end;
 }
 
@@ -3636,11 +3619,10 @@ diffs-container .review-comment-thread {
 .copy-comments-button {
   -webkit-app-region: no-drag;
   align-items: center;
-  background: var(--copy-comments-accent);
-  border: 0;
+  background: color-mix(in srgb, var(--sidebar-ref) 12%, var(--code-bg));
+  border: 1px solid color-mix(in srgb, var(--sidebar-ref) 38%, transparent);
   border-radius: 14px;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 0.16);
-  color: var(--copy-comments-accent-text);
+  color: var(--sidebar-ref);
   corner-shape: squircle;
   cursor: pointer;
   display: inline-flex;
@@ -3652,7 +3634,7 @@ diffs-container .review-comment-thread {
   padding: 0 10px;
   transition:
     background 150ms ease,
-    color 150ms ease,
+    border-color 150ms ease,
     transform 150ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
@@ -3806,7 +3788,8 @@ diffs-container .review-comment-thread {
 }
 
 .copy-comments-button:hover {
-  background: var(--copy-comments-accent-hover);
+  background: color-mix(in srgb, var(--sidebar-ref) 20%, var(--code-bg));
+  border-color: color-mix(in srgb, var(--sidebar-ref) 52%, transparent);
 }
 
 .copy-comments-button:active {
@@ -3816,12 +3799,6 @@ diffs-container .review-comment-thread {
 .review-submit-button:disabled {
   cursor: default;
   opacity: 0.58;
-}
-
-.copy-comments-button.copied,
-.copy-comments-button.copied:hover {
-  background: var(--copy-comments-copied);
-  color: var(--copy-comments-copied-text);
 }
 
 .copy-comments-count {

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -23,7 +23,8 @@ import {
 } from './app/components/Panels.tsx';
 import { PlanEditorView } from './app/components/PlanEditorView.tsx';
 import { ReviewCodeView, type ReviewDiffBlock } from './app/components/ReviewCodeView.tsx';
-import { ReviewTopBar, type ReviewModeItem } from './app/components/ReviewTopBar.tsx';
+import type { ReviewModeItem } from './app/components/ReviewModeControl.tsx';
+import { ReviewTopBar } from './app/components/ReviewTopBar.tsx';
 import { Sidebar } from './app/components/Sidebar.tsx';
 import { CommitView } from './app/components/walkthrough/CommitView.tsx';
 import {
@@ -1826,9 +1827,6 @@ export default function App() {
             ) : null}
           </>
         }
-        mode={sidebarMode}
-        modes={reviewModes}
-        onModeChange={changeSidebarMode}
         onToggleSidebar={toggleSidebar}
         repository={
           <span className="review-top-bar-repository review-top-bar-repository-path">
@@ -1922,10 +1920,12 @@ export default function App() {
           historyLoading={historyLoading}
           keymap={codiffConfig.keymap}
           mode={sidebarMode}
+          modes={reviewModes}
           narrativeNavigation={narrativeNavigation}
           narrativeWalkthrough={narrativeWalkthrough}
           onActivatePath={activatePath}
           onLoadMoreHistory={loadMoreHistory}
+          onModeChange={changeSidebarMode}
           onSearchQueryChange={
             sidebarMode === 'history' ? setHistorySearchQuery : setFileSearchQuery
           }

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -58,6 +58,7 @@ import {
 import {
   type CodeViewInstance,
   type RepositoryLoadError,
+  type ReviewComment,
   type ReviewIdentity,
   type ReviewScrollBehavior,
   type ReviewScrollTarget,
@@ -123,6 +124,7 @@ import type {
   DiffSection,
 } from './types.ts';
 
+const emptyReviewComments: ReadonlyArray<ReviewComment> = [];
 const emptyWalkthroughNotes = new Map<string, WalkthroughNote>();
 const disableCodeViewWorkerPool = process.env.NODE_ENV === 'test';
 
@@ -1804,14 +1806,12 @@ export default function App() {
       <div aria-hidden className="window-drag-region" />
       <ReviewTopBar
         actions={
-          isSwitchingSource ? undefined : (
-            <CopyCommentsButton
-              comments={reviewComments}
-              files={orderedFiles}
-              reviewCommentsPrefix={preferences.reviewCommentsPrefix}
-              showWhitespace={showWhitespace}
-            />
-          )
+          <CopyCommentsButton
+            comments={isSwitchingSource ? emptyReviewComments : reviewComments}
+            files={orderedFiles}
+            reviewCommentsPrefix={preferences.reviewCommentsPrefix}
+            showWhitespace={showWhitespace}
+          />
         }
         center={
           state.branch ? (

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -1803,29 +1803,29 @@ export default function App() {
     >
       <div aria-hidden className="window-drag-region" />
       <ReviewTopBar
+        center={
+          state.branch ? (
+            <span className="review-top-bar-branch" title={state.branch}>
+              {state.branch}
+            </span>
+          ) : null
+        }
         context={
-          <>
-            {state.branch ? (
-              <span className="review-top-bar-branch" title={state.branch}>
-                {state.branch}
-              </span>
-            ) : null}
-            {sidebarSourceLabel ? (
-              pullRequestUrl ? (
-                <a
-                  className="review-top-bar-source"
-                  href={pullRequestUrl}
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  <span>{sidebarSourceLabel}</span>
-                  <ArrowSquareOut aria-hidden size={14} weight="bold" />
-                </a>
-              ) : (
-                <span className="review-top-bar-source">{sidebarSourceLabel}</span>
-              )
-            ) : null}
-          </>
+          sidebarSourceLabel ? (
+            pullRequestUrl ? (
+              <a
+                className="review-top-bar-source"
+                href={pullRequestUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <span>{sidebarSourceLabel}</span>
+                <ArrowSquareOut aria-hidden size={14} weight="bold" />
+              </a>
+            ) : (
+              <span className="review-top-bar-source">{sidebarSourceLabel}</span>
+            )
+          ) : null
         }
         onToggleSidebar={toggleSidebar}
         repository={

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -1803,6 +1803,16 @@ export default function App() {
     >
       <div aria-hidden className="window-drag-region" />
       <ReviewTopBar
+        actions={
+          isSwitchingSource ? undefined : (
+            <CopyCommentsButton
+              comments={reviewComments}
+              files={orderedFiles}
+              reviewCommentsPrefix={preferences.reviewCommentsPrefix}
+              showWhitespace={showWhitespace}
+            />
+          )
+        }
         center={
           state.branch ? (
             <span className="review-top-bar-branch" title={state.branch}>
@@ -1885,16 +1895,6 @@ export default function App() {
         />
       ) : null}
       <KeyboardShortcutsHelp keymap={codiffConfig.keymap} visible={shortcutsHelpVisible} />
-      {!isSwitchingSource ? (
-        <div className="review-action-bar">
-          <CopyCommentsButton
-            comments={reviewComments}
-            files={orderedFiles}
-            reviewCommentsPrefix={preferences.reviewCommentsPrefix}
-            showWhitespace={showWhitespace}
-          />
-        </div>
-      ) : null}
       <aside className="squircle sidebar">
         <Sidebar
           branchSource={

--- a/core/SharedWalkthroughApp.tsx
+++ b/core/SharedWalkthroughApp.tsx
@@ -23,7 +23,8 @@ import {
   ReviewCodeView,
   type ReviewDiffBlock,
 } from './app/components/ReviewCodeView.tsx';
-import { ReviewTopBar, type ReviewModeItem } from './app/components/ReviewTopBar.tsx';
+import type { ReviewModeItem } from './app/components/ReviewModeControl.tsx';
+import { ReviewTopBar } from './app/components/ReviewTopBar.tsx';
 import { DiffLineCountBadge } from './app/components/Sidebar.tsx';
 import { NarrativeSidebar } from './app/components/walkthrough/NarrativeSidebar.tsx';
 import {

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -438,11 +438,14 @@ test('stale persisted collapsed sidebar state does not hide the sidebar on launc
       false,
     );
     expect(app.container.querySelector('.sidebar')).not.toBeNull();
-    expect(app.container.querySelector('.sidebar [role="tablist"]')).toBeNull();
+    expect(app.container.querySelector('.sidebar [role="tablist"]')).not.toBeNull();
   });
 
   const topBar = app.container.querySelector('.review-top-bar');
-  const modes = topBar?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [];
+  expect(topBar?.querySelector('[role="tablist"]')).toBeNull();
+  const modeControl = app.container.querySelector('.sidebar .review-mode-control');
+  expect(modeControl?.nextElementSibling?.className).toBe('sidebar-search-row');
+  const modes = modeControl?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [];
   expect([...modes].map((mode) => mode.textContent)).toEqual(['Walkthrough', 'Tree', 'History']);
   const sidebarToggle = topBar?.querySelector<HTMLButtonElement>('.sidebar-toggle-button');
   await act(async () => sidebarToggle?.click());

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -552,6 +552,19 @@ test('repository label is plain text and clicking it does nothing', async () => 
   expect(openRepositoryFolder).not.toHaveBeenCalled();
 });
 
+test('the branch name renders in the center of the top bar', async () => {
+  window.codiff = createCodiffMock();
+
+  await using app = await renderReact(<App />);
+  await waitFor(() => expect(app.container.querySelector('.app-shell')).not.toBeNull());
+
+  const branch = app.container.querySelector<HTMLElement>('.review-top-bar-branch');
+  expect(branch?.textContent).toBe('main');
+  expect(branch?.getAttribute('title')).toBe('main');
+  expect(branch?.parentElement?.className).toBe('review-top-bar-center');
+  expect(app.container.querySelector('.review-top-bar-context .review-top-bar-branch')).toBeNull();
+});
+
 test('empty repository state fills the review pane for centered layout', async () => {
   window.codiff = createCodiffMock();
 

--- a/core/__tests__/CopyCommentsButton.test.tsx
+++ b/core/__tests__/CopyCommentsButton.test.tsx
@@ -21,7 +21,7 @@ const createReviewComment = (comment: Partial<ReviewComment>) =>
     ...comment,
   }) satisfies ReviewComment;
 
-test('stays hidden until a comment with a body exists', async () => {
+test('stays visible but disabled until a comment with a body exists', async () => {
   await using app = await renderReact(
     <CopyCommentsButton
       comments={[
@@ -34,7 +34,28 @@ test('stays hidden until a comment with a body exists', async () => {
     />,
   );
 
-  expect(app.container.querySelector('.copy-comments-button')).toBeNull();
+  const button = app.container.querySelector<HTMLButtonElement>('.copy-comments-button');
+  expect(button).not.toBeNull();
+  expect(button?.disabled).toBe(true);
+  expect(button?.getAttribute('aria-label')).toBe(
+    'Copy review comments as markdown, no comments yet',
+  );
+  expect(button?.querySelector('.copy-comments-count')?.textContent).toBe('0');
+});
+
+test('enables itself once a comment has a body', async () => {
+  await using app = await renderReact(
+    <CopyCommentsButton
+      comments={[createReviewComment({})]}
+      files={[file]}
+      reviewCommentsPrefix=""
+      showWhitespace={false}
+    />,
+  );
+
+  const button = app.container.querySelector<HTMLButtonElement>('.copy-comments-button');
+  expect(button?.disabled).toBe(false);
+  expect(button?.getAttribute('aria-label')).toBe('Copy 1 review comment');
 });
 
 test('shows the pending comment count next to the copy icon', async () => {

--- a/core/__tests__/CopyCommentsButton.test.tsx
+++ b/core/__tests__/CopyCommentsButton.test.tsx
@@ -49,7 +49,7 @@ test('shows the pending comment count next to the copy icon', async () => {
 
   const button = app.container.querySelector<HTMLButtonElement>('.copy-comments-button');
   expect(button?.getAttribute('aria-label')).toBe('Copy 2 review comments');
-  expect(button?.getAttribute('title')).toBe('Copy review comments');
+  expect(button?.getAttribute('title')).toBe('Copy review comments as markdown');
   expect(button?.querySelector('.copy-comments-count')?.textContent).toBe('2');
   expect(button?.querySelector('.copy-comments-icon')).not.toBeNull();
 });

--- a/core/__tests__/CopyCommentsButton.test.tsx
+++ b/core/__tests__/CopyCommentsButton.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { expect, test } from 'vite-plus/test';
+import { CopyCommentsButton } from '../app/components/Panels.tsx';
+import type { ReviewComment } from '../lib/app-types.ts';
+import { createChangedFile } from './helpers/fixtures.ts';
+import { renderReact } from './helpers/react.tsx';
+
+const file = createChangedFile('src/app.ts');
+
+const createReviewComment = (comment: Partial<ReviewComment>) =>
+  ({
+    body: 'Rename this helper.',
+    filePath: file.path,
+    id: 'comment-1',
+    lineNumber: 1,
+    sectionId: file.sections[0].id,
+    side: 'additions',
+    ...comment,
+  }) satisfies ReviewComment;
+
+test('stays hidden until a comment with a body exists', async () => {
+  await using app = await renderReact(
+    <CopyCommentsButton
+      comments={[
+        createReviewComment({ body: '   ' }),
+        createReviewComment({ id: 'comment-2', isReadOnly: true }),
+      ]}
+      files={[file]}
+      reviewCommentsPrefix=""
+      showWhitespace={false}
+    />,
+  );
+
+  expect(app.container.querySelector('.copy-comments-button')).toBeNull();
+});
+
+test('shows the pending comment count next to the copy icon', async () => {
+  await using app = await renderReact(
+    <CopyCommentsButton
+      comments={[createReviewComment({}), createReviewComment({ id: 'comment-2' })]}
+      files={[file]}
+      reviewCommentsPrefix=""
+      showWhitespace={false}
+    />,
+  );
+
+  const button = app.container.querySelector<HTMLButtonElement>('.copy-comments-button');
+  expect(button?.getAttribute('aria-label')).toBe('Copy 2 review comments');
+  expect(button?.getAttribute('title')).toBe('Copy review comments');
+  expect(button?.querySelector('.copy-comments-count')?.textContent).toBe('2');
+  expect(button?.querySelector('.copy-comments-icon')).not.toBeNull();
+});

--- a/core/app/components/Panels.tsx
+++ b/core/app/components/Panels.tsx
@@ -423,7 +423,7 @@ export function CopyCommentsButton({
       }`}
       className={`copy-comments-button${copied ? ' copied' : ''}`}
       onClick={() => void copyComments()}
-      title="Copy review comments"
+      title="Copy review comments as markdown"
       type="button"
     >
       {copied ? (

--- a/core/app/components/Panels.tsx
+++ b/core/app/components/Panels.tsx
@@ -412,16 +412,17 @@ export function CopyCommentsButton({
     markCopied();
   }, [comments, files, markCopied, reviewCommentsPrefix, showWhitespace]);
 
-  if (pendingCommentCount === 0) {
-    return null;
-  }
-
   return (
     <button
-      aria-label={`Copy ${pendingCommentCount} review ${
-        pendingCommentCount === 1 ? 'comment' : 'comments'
-      }`}
+      aria-label={
+        pendingCommentCount === 0
+          ? 'Copy review comments as markdown, no comments yet'
+          : `Copy ${pendingCommentCount} review ${
+              pendingCommentCount === 1 ? 'comment' : 'comments'
+            }`
+      }
       className={`copy-comments-button${copied ? ' copied' : ''}`}
+      disabled={pendingCommentCount === 0}
       onClick={() => void copyComments()}
       title="Copy review comments as markdown"
       type="button"

--- a/core/app/components/Panels.tsx
+++ b/core/app/components/Panels.tsx
@@ -427,10 +427,11 @@ export function CopyCommentsButton({
       type="button"
     >
       {copied ? (
-        <Check aria-hidden className="copy-comments-icon check" size={22} weight="bold" />
+        <Check aria-hidden className="copy-comments-icon check" size={15} weight="bold" />
       ) : (
-        <LucideCopy aria-hidden className="copy-comments-icon" size={21} strokeWidth={2.25} />
+        <LucideCopy aria-hidden className="copy-comments-icon" size={14} strokeWidth={2.25} />
       )}
+      <span className="copy-comments-count">{pendingCommentCount}</span>
     </button>
   );
 }

--- a/core/app/components/ReviewModeControl.tsx
+++ b/core/app/components/ReviewModeControl.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+export type ReviewModeItem<Mode extends string> = {
+  ariaLabel?: string;
+  icon: ReactNode;
+  indicator?: ReactNode;
+  label: string;
+  title?: string;
+  value: Mode;
+};
+
+export function ReviewModeControl<Mode extends string>({
+  mode,
+  modes,
+  onModeChange,
+}: {
+  mode: Mode;
+  modes: ReadonlyArray<ReviewModeItem<Mode>>;
+  onModeChange: (mode: Mode) => void;
+}) {
+  return (
+    <div aria-label="Review mode" className="review-mode-control" role="tablist">
+      {modes.map((item) => (
+        <button
+          aria-label={item.ariaLabel}
+          aria-selected={mode === item.value}
+          key={item.value}
+          onClick={() => onModeChange(item.value)}
+          role="tab"
+          title={item.title}
+          type="button"
+        >
+          {item.icon}
+          <span className="review-mode-label">{item.label}</span>
+          {item.indicator}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/core/app/components/ReviewTopBar.tsx
+++ b/core/app/components/ReviewTopBar.tsx
@@ -1,17 +1,10 @@
 import { SidebarSimpleIcon as SidebarSimple } from '@phosphor-icons/react/SidebarSimple';
 import type { ReactNode } from 'react';
-
-export type ReviewModeItem<Mode extends string> = {
-  ariaLabel?: string;
-  icon: ReactNode;
-  indicator?: ReactNode;
-  label: string;
-  title?: string;
-  value: Mode;
-};
+import { ReviewModeControl, type ReviewModeItem } from './ReviewModeControl.tsx';
 
 export function ReviewTopBar<Mode extends string>({
   actions,
+  center,
   context,
   leading,
   mode,
@@ -25,18 +18,23 @@ export function ReviewTopBar<Mode extends string>({
   toggleTitle,
 }: {
   actions?: ReactNode;
+  center?: ReactNode;
   context?: ReactNode;
   leading?: ReactNode;
-  mode: Mode;
-  modes: ReadonlyArray<ReviewModeItem<Mode>>;
-  onModeChange: (mode: Mode) => void;
   onToggleSidebar: () => void;
   repository: ReactNode;
   repositoryTooltip?: string;
   sidebarCollapsed: boolean;
   sourceMenu?: ReactNode;
   toggleTitle: string;
-}) {
+} & (
+  | {
+      mode: Mode;
+      modes: ReadonlyArray<ReviewModeItem<Mode>>;
+      onModeChange: (mode: Mode) => void;
+    }
+  | { mode?: undefined; modes?: undefined; onModeChange?: undefined }
+)) {
   return (
     <header className="review-top-bar workspace-top-bar">
       <div className="review-top-bar-left">
@@ -55,23 +53,11 @@ export function ReviewTopBar<Mode extends string>({
           {repository}
         </div>
       </div>
-      <div aria-label="Review mode" className="review-mode-control" role="tablist">
-        {modes.map((item) => (
-          <button
-            aria-label={item.ariaLabel}
-            aria-selected={mode === item.value}
-            key={item.value}
-            onClick={() => onModeChange(item.value)}
-            role="tab"
-            title={item.title}
-            type="button"
-          >
-            {item.icon}
-            <span className="review-mode-label">{item.label}</span>
-            {item.indicator}
-          </button>
-        ))}
-      </div>
+      {modes ? (
+        <ReviewModeControl mode={mode} modes={modes} onModeChange={onModeChange} />
+      ) : (
+        <div className="review-top-bar-center">{center}</div>
+      )}
       <div className="review-top-bar-right">
         {context ? <div className="review-top-bar-context">{context}</div> : null}
         {actions ? <div className="review-top-bar-actions">{actions}</div> : null}

--- a/core/app/components/Sidebar.tsx
+++ b/core/app/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import type { ChangedFile, HistoryEntry, NarrativeWalkthrough, ReviewSource } fr
 import { Avatar } from './Avatar.tsx';
 import { Button } from './Button.tsx';
 import { ReviewFileTree } from './FileTree.tsx';
+import { ReviewModeControl, type ReviewModeItem } from './ReviewModeControl.tsx';
 import { NarrativeSidebar } from './walkthrough/NarrativeSidebar.tsx';
 import type { NarrativeNavigation } from './walkthrough/useNarrativeNavigation.ts';
 import { WalkthroughProgress } from './walkthrough/WalkthroughProgress.tsx';
@@ -34,10 +35,12 @@ export function Sidebar({
   historyLoading,
   keymap,
   mode,
+  modes,
   narrativeNavigation,
   narrativeWalkthrough,
   onActivatePath,
   onLoadMoreHistory,
+  onModeChange,
   onSearchQueryChange,
   onSelectSource,
   onShareWalkthrough,
@@ -63,10 +66,12 @@ export function Sidebar({
   historyLoading: boolean;
   keymap: CodiffKeymap;
   mode: SidebarMode;
+  modes: ReadonlyArray<ReviewModeItem<SidebarMode>>;
   narrativeNavigation: NarrativeNavigation;
   narrativeWalkthrough: NarrativeWalkthrough | null;
   onActivatePath: (path: string) => void;
   onLoadMoreHistory: () => void;
+  onModeChange: (mode: SidebarMode) => void;
   onSearchQueryChange: (query: string) => void;
   onSelectSource: (source: ReviewSource) => void;
   onShareWalkthrough?: () => void;
@@ -115,6 +120,7 @@ export function Sidebar({
 
   return (
     <>
+      <ReviewModeControl mode={mode} modes={modes} onModeChange={onModeChange} />
       <div className="sidebar-search-row">
         <input
           aria-label="Filter changed files"


### PR DESCRIPTION
# Show the copy review comments button in the title bar

> **Stacked on the centered-branch PR, which is itself stacked on the review-mode-tabs PR.** Until those merge this diff also shows their commits. Review it last; the diff narrows to just the change below once the parents land.

## Problem

- The copy-comments control was a floating circular button pinned to the bottom-right of the window.
- It overlapped diff content, sat far from everything else actionable, and gave no indication of how many comments it would copy.
- It also only existed once a comment did, so there was nothing to discover before you had written one and nothing to explain why it came and went.

## What changed

- Moved into the title bar's right-hand action area, sized like the other title-bar controls, showing the pending comment count.
- Always present, and disabled while the count is zero, so the control is discoverable before the first comment and never appears or disappears under the cursor.
- Reuses the sidebar toggle's own treatment — transparent at rest, muted text, grey wash on hover — so the two read as siblings. The disabled state follows the muted-plus-reduced-opacity convention used by the other disabled buttons. No new color tokens.
- Copying no longer changes the button's color — only the icon swaps to a checkmark.
- Tooltip now says what the button actually produces: *Copy review comments as markdown*.
- Spacing in the right-hand group matches the left group, so the gap between the source label and the copy button is the same 8px that separates the sidebar toggle from the open-source menu.
- The old floating action bar and its styles are gone; nothing else referenced them.

## Risks

- The count renders as `0` rather than being hidden, which keeps the button's width fixed so the title bar doesn't shift when the first comment lands.
- A permanently visible control is one more thing in the title bar; on narrow windows the source label and the button compete for the right group.
- While a review source is switching the button reads as empty and disabled rather than vanishing, so the layout holds still through the switch.

## Omissions / not verified

- The accessible label still carries the count (*Copy 3 review comments*), which is what a screen reader should hear; the visible tooltip describes the output format instead.

## Screen recording

https://github.com/user-attachments/assets/30d4b2ad-195b-42ee-90dc-b57d82410890

## Test plan

1. Open a repository with no comments. **Expected:** the button is in the title bar showing `0`, greyed out and not clickable.
2. Click it while disabled. **Expected:** nothing happens and the clipboard is untouched.
3. Add a review comment with a body. **Expected:** the button enables and reads `1`, without changing width or shifting the title bar.
4. Add two more. **Expected:** the count reads `3` and the tooltip reads *Copy review comments as markdown*.
5. Click it. **Expected:** the icon becomes a checkmark for ~2s, the color does **not** change, and the clipboard holds the rendered markdown.
6. Delete every comment. **Expected:** the button returns to `0` and disabled, still in place.
7. Create a comment and leave it empty. **Expected:** the button stays disabled — empty drafts don't count.
8. Switch review source while comments exist. **Expected:** the button reads `0` and disabled during the switch, then returns to the real count. No layout jump either way.
9. Hover and press the button next to the sidebar toggle. **Expected:** identical hover and active feedback on both.
10. Compare the gap either side of the title bar. **Expected:** the source label to copy button spacing matches the sidebar toggle to open-source menu spacing.
11. Toggle light and dark themes. **Expected:** enabled and disabled states both stay legible against the title bar.
12. Narrow the window until the source label and button crowd. **Expected:** neither overlaps the centered branch.

---

This PR was written primarily with Claude Code.
