### PR TITLE
Add review comments with Mod+Enter instead of asking the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ counts; when it is `false`, Codiff hides those changes from the working-tree rev
     "prevSearchMatch": "Shift+Enter",
     "closeSearch": "Escape",
     "submitComment": "Mod+Enter",
+    "askAgent": "Mod+Alt+Enter",
     "discardComment": "Escape",
     "toggleSidebar": "Mod+Shift+b",
   },

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -20,6 +20,7 @@
     "wordWrap": false
   },
   "keymap": {
+    "askAgent": "Mod+Alt+Enter",
     "closeSearch": "Escape",
     "commandBar": "Mod+Shift+p",
     "diffSearch": "Mod+f",

--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -1249,6 +1249,138 @@ test('review comment typing stays local until a comment action commits it', asyn
   expect(onAskCodex).toHaveBeenCalledWith('comment-1');
 });
 
+const renderLocalReviewComment = async ({
+  body,
+  onAskCodex,
+  onCommentDraftChange,
+  onDeleteComment,
+  onUpdateComment,
+}: {
+  body: string;
+  onAskCodex: () => void;
+  onCommentDraftChange?: () => void;
+  onDeleteComment?: () => void;
+  onUpdateComment: () => void;
+}) => {
+  const file = createChangedFile('src/comment.ts');
+  const comment = {
+    body,
+    filePath: file.path,
+    id: 'comment-1',
+    lineNumber: 1,
+    sectionId: file.sections[0].id,
+    side: 'additions',
+  } satisfies ReviewComment;
+  const view = await renderReact(
+    <ReviewCodeViewHarness
+      comments={[comment]}
+      files={[file]}
+      onAskCodex={onAskCodex}
+      onCommentDraftChange={onCommentDraftChange}
+      onDeleteComment={onDeleteComment}
+      onUpdateComment={onUpdateComment}
+    />,
+  );
+  const textarea = view.container.querySelector<HTMLTextAreaElement>('.review-comment-input');
+  if (!textarea) {
+    throw new Error('Expected review comment textarea.');
+  }
+
+  textarea.focus();
+  return { textarea, view };
+};
+
+const pressCommentShortcut = async (textarea: HTMLTextAreaElement, altKey: boolean) => {
+  await act(async () => {
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        altKey,
+        bubbles: true,
+        cancelable: true,
+        key: 'Enter',
+        metaKey: true,
+      }),
+    );
+  });
+};
+
+test('local review comments are added with Mod+Enter instead of asking the agent', async () => {
+  const platform = vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel');
+  const onAskCodex = vi.fn();
+  const onCommentDraftChange = vi.fn();
+  const onUpdateComment = vi.fn();
+  const { textarea, view } = await renderLocalReviewComment({
+    body: '',
+    onAskCodex,
+    onCommentDraftChange,
+    onUpdateComment,
+  });
+
+  await using _view = view;
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      platform.mockRestore();
+    },
+  };
+  await setInputValue(textarea, 'Please check this.');
+  await pressCommentShortcut(textarea, false);
+  expect(onUpdateComment).toHaveBeenCalledWith('comment-1', 'Please check this.');
+  expect(onAskCodex).not.toHaveBeenCalled();
+  expect(document.activeElement).not.toBe(textarea);
+  expect(onCommentDraftChange).toHaveBeenLastCalledWith(null);
+});
+
+test('local review comments ask the agent with Mod+Alt+Enter', async () => {
+  const platform = vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel');
+  const onAskCodex = vi.fn();
+  const onUpdateComment = vi.fn();
+  const { textarea, view } = await renderLocalReviewComment({
+    body: '',
+    onAskCodex,
+    onUpdateComment,
+  });
+
+  await using _view = view;
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      platform.mockRestore();
+    },
+  };
+  await setInputValue(textarea, 'Explain this change.');
+  await pressCommentShortcut(textarea, true);
+  expect(onAskCodex).toHaveBeenCalledWith('comment-1');
+  expect(onUpdateComment).toHaveBeenCalledWith('comment-1', 'Explain this change.');
+  expect(document.activeElement).toBe(textarea);
+});
+
+test('adding an empty local review comment with Mod+Enter discards it', async () => {
+  const platform = vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel');
+  const onAskCodex = vi.fn();
+  const onDeleteComment = vi.fn();
+  const onUpdateComment = vi.fn();
+  const { textarea, view } = await renderLocalReviewComment({
+    body: '',
+    onAskCodex,
+    onDeleteComment,
+    onUpdateComment,
+  });
+
+  await using _view = view;
+  await using _resource = {
+    async [Symbol.asyncDispose]() {
+      platform.mockRestore();
+    },
+  };
+  await pressCommentShortcut(textarea, false);
+  expect(onUpdateComment).not.toHaveBeenCalled();
+  expect(onAskCodex).not.toHaveBeenCalled();
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  });
+  expect(onDeleteComment).toHaveBeenCalledTimes(1);
+  expect(onDeleteComment).toHaveBeenCalledWith('comment-1');
+});
+
 test('a Codex reply does not repeatedly invalidate the diff item layout', async () => {
   const file = createChangedFile('src/comment.ts');
   const comment = {

--- a/core/__tests__/keymap.test.ts
+++ b/core/__tests__/keymap.test.ts
@@ -948,6 +948,7 @@ function createTestContext({
   vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue(platform);
 
   const keymap = {
+    askAgent: 'Mod+Alt+Enter',
     closeSearch: 'Escape',
     commandBar: 'Mod+Shift+p',
     diffSearch: 'Mod+f',

--- a/core/app/components/KeyboardShortcutsHelp.tsx
+++ b/core/app/components/KeyboardShortcutsHelp.tsx
@@ -36,7 +36,8 @@ const SHORTCUT_GROUPS: ReadonlyArray<ShortcutGroup> = [
   },
   {
     shortcuts: [
-      { action: 'submitComment', label: 'Submit comment' },
+      { action: 'submitComment', label: 'Add comment' },
+      { action: 'askAgent', label: 'Ask the agent' },
       { action: 'discardComment', label: 'Discard comment' },
     ],
     title: 'Comments',

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -43,7 +43,7 @@ import claudeIconUrl from '../../assets/claude.svg';
 import codexIconUrl from '../../assets/codex.svg';
 import opencodeIconUrl from '../../assets/opencode.svg';
 import piIconUrl from '../../assets/pi.svg';
-import { matchesShortcut } from '../../config/keymap.ts';
+import { getShortcutLabel, matchesShortcut } from '../../config/keymap.ts';
 import type { CodiffDiffStyle, CodiffKeymap } from '../../config/types.ts';
 import type {
   CodeViewInstance,
@@ -1521,6 +1521,14 @@ function ReviewCommentEditor({
     onCommentBlur(flushDraft(), draft);
   }, [draft, flushDraft, onCommentBlur]);
 
+  // Local reviews have nothing to submit a comment to, so adding one means
+  // finishing it the way clicking away does. `MarkdownEditorHandle` exposes no
+  // blur, so focus leaves through the focused element and the editor's own blur
+  // handler flushes the draft and closes the comment.
+  const handleAddComment = useCallback(() => {
+    (document.activeElement as HTMLElement | null)?.blur();
+  }, []);
+
   const handleFocus = useCallback(() => {
     onCommentFocus(draftComment);
   }, [draftComment, onCommentFocus]);
@@ -1541,14 +1549,23 @@ function ReviewCommentEditor({
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
       if (matchesShortcut(event, keymap, 'submitComment')) {
-        if (supportsReviewCommentActions && commentCanSubmit) {
-          event.preventDefault();
-          event.stopPropagation();
-          handleSubmitComment();
+        if (supportsReviewCommentActions) {
+          if (commentCanSubmit) {
+            event.preventDefault();
+            event.stopPropagation();
+            handleSubmitComment();
+          }
           return;
         }
 
-        if (!supportsReviewCommentActions && canAskCodex) {
+        event.preventDefault();
+        event.stopPropagation();
+        handleAddComment();
+        return;
+      }
+
+      if (matchesShortcut(event, keymap, 'askAgent')) {
+        if (canAskCodex) {
           event.preventDefault();
           event.stopPropagation();
           handleAskCodex();
@@ -1577,6 +1594,7 @@ function ReviewCommentEditor({
       comment.id,
       comment.isReadOnly,
       draft,
+      handleAddComment,
       handleAskCodex,
       handleSubmitComment,
       keymap,
@@ -1651,7 +1669,9 @@ function ReviewCommentEditor({
                 disabled={!canAskCodex}
                 onClick={handleAskCodex}
                 title={
-                  canAskCodex ? `Ask ${agentLabel}` : `Write a note before asking ${agentLabel}`
+                  canAskCodex
+                    ? `Ask ${agentLabel} (${getShortcutLabel(keymap, 'askAgent')})`
+                    : `Write a note before asking ${agentLabel}`
                 }
                 type="button"
               >

--- a/core/config/codiff-config.schema.json
+++ b/core/config/codiff-config.schema.json
@@ -169,7 +169,12 @@
         "submitComment": {
           "type": "string",
           "default": "Mod+Enter",
-          "description": "Submit a remote review comment or ask Codex."
+          "description": "Add the review comment being written, submitting it remotely when the review source supports it."
+        },
+        "askAgent": {
+          "type": "string",
+          "default": "Mod+Alt+Enter",
+          "description": "Ask the configured agent about the review comment being written."
         },
         "discardComment": {
           "type": "string",

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -29,6 +29,7 @@ export type KeyCombo = string;
 export type KeyComboBinding = KeyCombo | ReadonlyArray<KeyCombo>;
 
 export type CodiffKeymap = {
+  askAgent: KeyCombo;
   closeSearch: KeyCombo;
   commandBar: KeyCombo;
   diffSearch: KeyCombo;

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -219,6 +219,8 @@ const mergeConfig = (raw) => {
 
   return {
     keymap: {
+      askAgent:
+        typeof rawKeymap.askAgent === 'string' ? rawKeymap.askAgent : defaults.keymap.askAgent,
       closeSearch:
         typeof rawKeymap.closeSearch === 'string'
           ? rawKeymap.closeSearch


### PR DESCRIPTION
# Add review comments with Mod+Enter instead of asking the agent

> Independent of the title-bar stack — branches straight off `main` and shares no files with those PRs.

## Problem

- In a local review, `Mod+Enter` in a comment editor asked the agent. In a pull-request review the same chord submitted the comment.
- `Mod+Enter` is GitHub's "submit a comment" everywhere, so the local behaviour sends a comment to an LLM when the muscle memory says "post this".
- Asking the agent is the more expensive and less reversible of the two actions, which is the wrong way round for an accidental keypress.

## What changed

- `Mod+Enter` now always means *add this comment*. Pull-request mode submits as before; local mode finishes the comment the way clicking away does, so the draft is flushed and the editor closes.
- Asking the agent moved to a new configurable `askAgent` action, default `Mod+Alt+Enter`, and now works in pull-request mode too — previously the keyboard path existed only locally.
- The Ask button's tooltip shows the shortcut, and the shortcuts help panel lists the new action. `submitComment` is relabelled *Add comment*, since it no longer means "submit" in a local review.

## Risks

- **Behaviour change for existing muscle memory:** anyone who learned `Mod+Enter` to ask the agent now adds a comment instead. Both actions are rebindable in `codiff.jsonc` for anyone who wants the old mapping back.
- **Why not `Mod+Shift+Enter`:** GitHub already binds it in the Files changed tab, to *Submit a review comment*. Reusing it for "ask the AI" would recreate the same class of surprise this PR removes. `Mod+Alt+Enter` collides with nothing in the keymap, nothing GitHub binds, and nothing in the markdown editor (which claims `Mod+Alt+Digit0–6` for headings).
- The local add path blurs the focused element, because the editor handle exposes `focus` but no `blur`. Lexical turns that native blur into its own blur command, so the existing flush-and-cleanup path runs once, not twice.

## Omissions / not verified

- Saving an edit to an existing comment, and the general-comments composer, still use `Mod+Enter` and are untouched.
- The shared walkthrough and shared plan apps are untouched — neither has an ask-the-agent path.

## Screen recording

https://github.com/user-attachments/assets/95d08bcb-7700-4641-a61f-ecbb24fbcfaf

## Test plan

1. In a local review, start a comment, type a note, press `Mod+Enter`. **Expected:** the comment is kept and the editor closes. The agent is **not** asked.
2. Same, but press `Mod+Alt+Enter`. **Expected:** the agent is asked and focus stays in the editor.
3. Start a comment, type nothing, press `Mod+Enter`. **Expected:** the empty draft is discarded, exactly as clicking away does.
4. Press `Mod+Alt+Enter` on an empty draft. **Expected:** nothing happens — there is no note to ask about.
5. In a pull-request review, type a comment and press `Mod+Enter`. **Expected:** it submits, unchanged from before.
6. In a pull-request review, press `Mod+Alt+Enter`. **Expected:** the agent is asked — this is new.
7. Edit an existing comment and press `Mod+Enter`. **Expected:** the edit saves, unchanged.
8. Open the shortcuts help. **Expected:** *Add comment* on `Mod+Enter` and *Ask the agent* on `Mod+Alt+Enter`.
9. Rebind `askAgent` in `codiff.jsonc` and restart. **Expected:** the new binding applies and the Ask tooltip shows it.

---

This PR was written primarily with Claude Code.
