### PR TITLE
Add button to copy code from collapsible markdown blocks

### DIFF
--- a/core/App.css
+++ b/core/App.css
@@ -2180,11 +2180,30 @@ html[data-codiff-platform='darwin'] .sidebar {
 }
 
 .codiff-markdown-details > summary {
+  align-items: center;
   color: var(--text);
   cursor: pointer;
+  display: flex;
   font: 600 13px/1.4 var(--font-sans);
+  gap: 8px;
   list-style: none;
   padding: 8px 10px;
+}
+
+.codiff-markdown-details-summary-label {
+  flex: 1;
+  min-width: 0;
+}
+
+.codiff-markdown-details > summary .codiff-copy-code-button {
+  height: 24px;
+  margin: -4px 0;
+  width: 24px;
+}
+
+.codiff-markdown-details > summary:hover .codiff-copy-code-button,
+.codiff-markdown-details > summary:focus-within .codiff-copy-code-button {
+  opacity: 1;
 }
 
 .codiff-markdown-details > summary::-webkit-details-marker {
@@ -2194,9 +2213,9 @@ html[data-codiff-platform='darwin'] .sidebar {
 .codiff-markdown-details > summary::before {
   content: '\25B8';
   display: inline-block;
+  flex: none;
   font-size: 20px;
   line-height: 0.5;
-  margin-right: 8px;
 }
 
 .codiff-markdown-details > summary:hover {

--- a/core/__tests__/ReadOnlyMarkdownView.test.tsx
+++ b/core/__tests__/ReadOnlyMarkdownView.test.tsx
@@ -2,8 +2,9 @@
  * @vitest-environment jsdom
  */
 
-import { expect, test } from 'vite-plus/test';
+import { expect, test, vi } from 'vite-plus/test';
 import {
+  extractFencedCodeBlocks,
   normalizeReadOnlyMarkdownValue,
   ReadOnlyMarkdownView,
 } from '../app/components/ReadOnlyMarkdownView.tsx';
@@ -20,6 +21,59 @@ test('normalizeReadOnlyMarkdownValue collapses repeated blank lines outside fenc
   ).toBe(
     'First paragraph.\n\nSecond paragraph.\n\n```ts\nconst a = 1;\n\nconst b = 2;\n```\n\nThird paragraph.',
   );
+});
+
+test('extractFencedCodeBlocks returns the contents of each fenced block', () => {
+  expect(
+    extractFencedCodeBlocks('Intro.\n\n```sh\nnpm install\n```\n\nOutro.\n\n~~~\nplain\n~~~\n'),
+  ).toEqual(['npm install', 'plain']);
+  expect(extractFencedCodeBlocks('No code here, only `inline`.')).toEqual([]);
+  expect(extractFencedCodeBlocks('````\n```\nnested fence\n```\n````')).toEqual([
+    '```\nnested fence\n```',
+  ]);
+  expect(extractFencedCodeBlocks('```ts\nconst a = 1;\n')).toEqual(['const a = 1;']);
+  expect(extractFencedCodeBlocks('```\n\n```')).toEqual([]);
+});
+
+test('ReadOnlyMarkdownView copies the code inside a collapsible block', async () => {
+  const writeText = vi.fn(async () => {});
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+
+  await using view = await renderReact(
+    <ReadOnlyMarkdownView
+      ariaLabel="Markdown preview"
+      className="markdown-preview"
+      value={
+        '<details><summary>Fix in your Agent</summary>\n\nPaste this:\n\n```\nFix the issues.\n```\n\n</details>'
+      }
+      variant="embedded"
+    />,
+  );
+
+  const button = view.container.querySelector<HTMLButtonElement>('.codiff-copy-code-button');
+  expect(button).not.toBe(null);
+
+  button?.click();
+
+  await waitFor(() => {
+    expect(writeText).toHaveBeenCalledWith('Fix the issues.');
+  });
+});
+
+test('ReadOnlyMarkdownView omits the copy button for collapsibles without code', async () => {
+  await using view = await renderReact(
+    <ReadOnlyMarkdownView
+      ariaLabel="Markdown preview"
+      className="markdown-preview"
+      value={'<details><summary>Notes</summary>\n\nJust prose.\n\n</details>'}
+      variant="embedded"
+    />,
+  );
+
+  expect(view.container.querySelector('.codiff-copy-code-button')).toBe(null);
 });
 
 test('ReadOnlyMarkdownView does not render empty paragraph break blocks', async () => {

--- a/core/app/components/ReadOnlyMarkdownView.tsx
+++ b/core/app/components/ReadOnlyMarkdownView.tsx
@@ -1,7 +1,10 @@
 import { MarkdownEditor } from '@nkzw/mdx-editor';
-import type { ComponentProps, ReactNode } from 'react';
-import { Suspense, useMemo } from 'react';
+import { CheckIcon as Check } from '@phosphor-icons/react/Check';
+import { Copy as LucideCopy } from 'lucide-react';
+import type { ComponentProps, MouseEvent as ReactMouseEvent, ReactNode } from 'react';
+import { Suspense, useCallback, useMemo } from 'react';
 import { renderInlineMarkdown } from '../../lib/markdown.tsx';
+import { useCopiedState } from './useCopiedState.ts';
 
 type MarkdownEditorProps = ComponentProps<typeof MarkdownEditor>;
 
@@ -76,6 +79,45 @@ export const normalizeReadOnlyMarkdownValue = (value: string) => {
     : normalizedValue;
 };
 
+const isClosingFence = (marker: string, candidate: string | null) =>
+  candidate != null && candidate[0] === marker[0] && candidate.length >= marker.length;
+
+export const extractFencedCodeBlocks = (value: string): Array<string> => {
+  const blocks: Array<string> = [];
+  let fenceMarker: string | null = null;
+  let currentBlock: Array<string> = [];
+
+  for (const line of value.replaceAll('\r\n', '\n').replaceAll('\r', '\n').split('\n')) {
+    const currentFenceMarker = getFenceMarker(line);
+
+    if (fenceMarker) {
+      if (isClosingFence(fenceMarker, currentFenceMarker)) {
+        blocks.push(currentBlock.join('\n'));
+        currentBlock = [];
+        fenceMarker = null;
+        continue;
+      }
+      currentBlock.push(line);
+      continue;
+    }
+
+    if (currentFenceMarker) {
+      fenceMarker = currentFenceMarker;
+    }
+  }
+
+  // An unterminated fence still renders as a code block, so it stays copyable.
+  // Its trailing newline has no closing fence to belong to, so it is dropped.
+  while (fenceMarker && currentBlock.at(-1) === '') {
+    currentBlock.pop();
+  }
+  if (fenceMarker && currentBlock.length > 0) {
+    blocks.push(currentBlock.join('\n'));
+  }
+
+  return blocks.filter((block) => block.trim().length > 0);
+};
+
 const parseMarkdownDetails = (value: string): Array<MarkdownPart> => {
   const parts: Array<MarkdownPart> = [];
   let lastIndex = 0;
@@ -104,6 +146,55 @@ const parseMarkdownDetails = (value: string): Array<MarkdownPart> => {
 
 const hasDetailsBlock = (parts: ReadonlyArray<MarkdownPart>) =>
   parts.some((part) => part.type === 'details');
+
+// Nested `<details>` render their own button, so only this level's code is copied.
+const getOwnFencedCode = (parts: ReadonlyArray<MarkdownPart>) =>
+  parts
+    .filter((part) => part.type === 'markdown')
+    .flatMap((part) => extractFencedCodeBlocks(part.value))
+    .join('\n\n');
+
+function CopyCodeButton({ code }: { code: string }) {
+  const [copied, markCopied] = useCopiedState(1600);
+
+  const handleClick = useCallback(
+    async (event: ReactMouseEvent<HTMLButtonElement>) => {
+      // The button lives inside `<summary>`, which would otherwise toggle.
+      event.preventDefault();
+      event.stopPropagation();
+      try {
+        await navigator.clipboard.writeText(code);
+      } catch {
+        return;
+      }
+      markCopied();
+    },
+    [code, markCopied],
+  );
+
+  const label = copied ? 'Code copied' : 'Copy code';
+
+  return (
+    <button
+      aria-label={label}
+      className={`codiff-copy-path-button codiff-copy-code-button${copied ? ' copied' : ''}`}
+      onClick={(event) => void handleClick(event)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.stopPropagation();
+        }
+      }}
+      title={label}
+      type="button"
+    >
+      {copied ? (
+        <Check aria-hidden className="codiff-copy-path-icon check" size={16} weight="bold" />
+      ) : (
+        <LucideCopy aria-hidden className="codiff-copy-path-icon" size={16} strokeWidth={2.25} />
+      )}
+    </button>
+  );
+}
 
 function MarkdownSegment({
   additionalPlugins,
@@ -175,6 +266,9 @@ function MarkdownParts({
       );
     }
 
+    const bodyParts = parseMarkdownDetails(part.body);
+    const code = getOwnFencedCode(bodyParts);
+
     return (
       <details
         className="codiff-markdown-details"
@@ -182,14 +276,19 @@ function MarkdownParts({
         onToggle={(event) => onHeightChange?.(event.currentTarget.getBoundingClientRect().height)}
         open={part.open}
       >
-        <summary>{renderInlineMarkdown(part.summary || 'Details')}</summary>
+        <summary>
+          <span className="codiff-markdown-details-summary-label">
+            {renderInlineMarkdown(part.summary || 'Details')}
+          </span>
+          {code ? <CopyCodeButton code={code} /> : null}
+        </summary>
         <MarkdownParts
           additionalPlugins={additionalPlugins}
           ariaLabel={`${ariaLabel} details`}
           contentClassName={contentClassName}
           editorClassName={editorClassName}
           onHeightChange={onHeightChange}
-          parts={parseMarkdownDetails(part.body)}
+          parts={bodyParts}
         />
       </details>
     );


### PR DESCRIPTION
Agent-authored review comments put the prompt to paste into your agent inside a collapsed `<details>`, where the only way to get it out was to expand the section and hand-select the text. Code blocks render as read-only CodeMirror instances rather than `<pre>`, so there was nothing to copy from either.

The button copies only the fences belonging to its own level, since nested collapsibles render their own.

Written by Claude Opus 5, reviewed and validated locally by your friendly neighborhood human being.

Before: 
<img width="1846" height="594" alt="image" src="https://github.com/user-attachments/assets/39842cb4-01c9-4ab9-8a4f-fc98c08d23b4" />

After:
<img width="1920" height="610" alt="image" src="https://github.com/user-attachments/assets/14509bb8-275b-4191-b86e-e294164b8689" />
