### PR TITLE
Wrap prose in React-slotted diff annotations

### DIFF
--- a/core/lib/code-view-options.ts
+++ b/core/lib/code-view-options.ts
@@ -189,4 +189,11 @@ export const codeViewUnsafeCSS = `
   [data-selected-line] [data-gutter-utility-slot] {
     display: none;
   }
+
+  /* The imperative API wraps annotations in a node that resets white-space, but
+     the React API slots them in bare, so they inherit "pre" from the shadow
+     <pre> and prose never wraps. */
+  [data-annotation-content] slot::slotted(*) {
+    white-space: normal;
+  }
 `;


### PR DESCRIPTION
@pierre/diffs resets white-space only on the imperative annotation path via createAnnotationWrapperNode. The React path slots content in bare, so it inherits "pre" from the shadow \<pre> and walkthrough narration renders as one unwrapped line that overflows its container.

The bug:
<img width="906" height="84" alt="Screenshot 2026-08-11 at 3 05 47 PM" src="https://github.com/user-attachments/assets/5c465dec-b342-48b4-a10d-4bfae0a149b7" />

Fix written by Claude Opus 5 and reviewed by me, a human.