### PR TITLE
Copy an absolute file:line reference on Mod+Click

### DIFF
--- a/core/App.tsx
+++ b/core/App.tsx
@@ -1740,6 +1740,7 @@ export default function App() {
     onToggleCollapsed: toggleCollapsed,
     onToggleViewed: toggleViewed,
     onUpdateComment: updateComment,
+    repositoryRoot: state.root,
     searchQuery: diffSearchQuery,
     showWhitespace,
     source: state.source,

--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -1820,3 +1820,69 @@ test('line content clicks create review comments unless text is selected', async
   });
   expect(onCreateComment).toHaveBeenCalledTimes(3);
 });
+
+test('mod-clicking a line copies its absolute path and line number', async () => {
+  const writeText = vi.fn(async () => {});
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+  const onCreateComment = vi.fn();
+  const file = createChangedFileWithPatch(
+    'src/click.ts',
+    'diff --git a/src/click.ts b/src/click.ts\n@@ -1 +1 @@\n-old\n+new\n',
+  );
+  await using view = await renderReact(
+    <ReviewCodeViewHarness
+      files={[file]}
+      onCreateComment={onCreateComment}
+      repositoryRoot="/home/reviewer/project"
+    />,
+  );
+
+  expect(view.container).not.toBeNull();
+  const { item, onLineClick } = getReviewCodeViewHandlers();
+  await act(async () => {
+    onLineClick(
+      {
+        annotationSide: 'additions',
+        event: { composedPath: () => [], metaKey: true },
+        lineNumber: 1,
+      },
+      { item },
+    );
+  });
+  expect(writeText).toHaveBeenCalledWith('/home/reviewer/project/src/click.ts:1');
+  expect(onCreateComment).not.toHaveBeenCalled();
+});
+
+test('mod-clicking a line without a repository root neither copies nor comments', async () => {
+  const writeText = vi.fn(async () => {});
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+  const onCreateComment = vi.fn();
+  const file = createChangedFileWithPatch(
+    'src/click.ts',
+    'diff --git a/src/click.ts b/src/click.ts\n@@ -1 +1 @@\n-old\n+new\n',
+  );
+  await using view = await renderReact(
+    <ReviewCodeViewHarness files={[file]} onCreateComment={onCreateComment} />,
+  );
+
+  expect(view.container).not.toBeNull();
+  const { item, onLineClick } = getReviewCodeViewHandlers();
+  await act(async () => {
+    onLineClick(
+      {
+        annotationSide: 'additions',
+        event: { composedPath: () => [], ctrlKey: true },
+        lineNumber: 1,
+      },
+      { item },
+    );
+  });
+  expect(writeText).not.toHaveBeenCalled();
+  expect(onCreateComment).not.toHaveBeenCalled();
+});

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -153,6 +153,16 @@ const isEditableWorkingTreeSection = (
   file.sections.at(-1)?.id === section.id &&
   (section.kind === 'staged' || section.kind === 'unstaged');
 
+// The repository root carries platform separators while Git file paths always
+// use forward slashes, so join with the root's own separator style.
+const copyLineReference = (repositoryRoot: string, filePath: string, lineNumber: number) => {
+  const separator = repositoryRoot.includes('\\') ? '\\' : '/';
+  const root = repositoryRoot.endsWith(separator) ? repositoryRoot.slice(0, -1) : repositoryRoot;
+  void navigator.clipboard
+    .writeText(`${root}${separator}${filePath}:${lineNumber}`)
+    .catch(() => {});
+};
+
 function CopyFilePathButton({ path }: { path: string }) {
   const [copied, markCopied] = useCopiedState(1600);
 
@@ -2497,6 +2507,7 @@ export function ReviewCodeView({
   onUpdateSourceDescription,
   onUpdateSourceTitle,
   onUploadSourceDescriptionAsset,
+  repositoryRoot,
   reviewIdentityByPath,
   scrollTarget,
   searchQuery,
@@ -2557,6 +2568,7 @@ export function ReviewCodeView({
   onUpdateSourceDescription?: (body: string) => Promise<void> | void;
   onUpdateSourceTitle?: (title: string) => Promise<void> | void;
   onUploadSourceDescriptionAsset?: (file: File) => Promise<string> | string;
+  repositoryRoot?: string;
   reviewIdentityByPath?: ReadonlyMap<string, ReviewIdentity>;
   scrollTarget: ReviewScrollTarget | null;
   searchQuery: string;
@@ -3221,6 +3233,13 @@ export function ReviewCodeView({
             return;
           }
 
+          if (line.event.metaKey || line.event.ctrlKey) {
+            if (repositoryRoot != null) {
+              copyLineReference(repositoryRoot, meta.file.path, line.lineNumber);
+            }
+            return;
+          }
+
           const side = 'annotationSide' in line ? line.annotationSide : null;
           if (!side) {
             return;
@@ -3293,6 +3312,7 @@ export function ReviewCodeView({
       loadingSectionIds,
       onCreateComment,
       onLoadSection,
+      repositoryRoot,
       theme,
       wordWrap,
     ],


### PR DESCRIPTION
## TL;DR

Cmd+Click (macOS) or Ctrl+Click (Windows/Linux) on a diff line now copies `{absolute path}:{line number}` to the clipboard. This gives reviewers a pasteable location for an editor or a coding agent, while a plain click keeps creating a review comment.

**Risk:** Low
**Change type:** Additive

## Architecture

<details><summary>Why Meta/Ctrl, and how the repository root reaches the diff view</summary>

- **Modifier choice.** A plain click already creates a review comment, and Shift is claimed by the diff library for extending selections and expanding hunks. Meta and Ctrl were unclaimed. On macOS, Chromium remaps Ctrl+Click to a secondary click that fires `contextmenu` and never reaches the `click` handler, so the effective binding is Cmd+Click there and Ctrl+Click on Windows and Linux.
- **Precedence.** The modifier check sits in `onLineClick` after the existing interactive-element, collapsed-section, and text-selection guards, and it returns before comment creation. A modifier click never opens a comment editor, even when no repository root is available.
- **Prop threading.** The repository root reaches `ReviewCodeView` as a new optional `repositoryRoot` prop, fed from `RepositoryState.root` in the app's shared review props. The shared-walkthrough page never passes the prop, so Mod+Click stays inert there, since a reference relative to the author's checkout would mislead a web viewer.
- **Path joining.** The repository root carries the platform's separators while Git file paths always use forward slashes, so the copied reference joins with the root's own separator style.

</details>

## Testing

<details><summary>Unit tests drive the click handler directly, plus the full suite and build</summary>

Two new tests in `core/__tests__/ReviewCodeView-scroll.test.tsx` drive the `CodeView` `onLineClick` handler the same way the existing line-click test does:

- A meta-click with a `repositoryRoot` copies `{root}/{path}:{line}` to the clipboard and creates no comment.
- A ctrl-click without a `repositoryRoot` copies nothing and creates no comment.

`vp check --fix`, the full `vp test` run (99 files), and `vp run build` all pass locally. I did not manually exercise the gesture in the desktop app.

</details>

## AI Assistance

This PR was researched, implemented, and tested with Claude Code, per the contribution guidelines' disclosure policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

banana banana banana
