### PR TITLE
fix: keep walkthrough scrolling stable across stop boundaries

### DIFF
--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -119,6 +119,14 @@ const getCodeViewItemVersion = (id: string) =>
   (codeViewMock.lastItems.find((item) => item.id === id) as { version?: number } | undefined)
     ?.version;
 
+const getWalkthroughHeaderNode = (blockId: string) => {
+  const index = codeViewMock.lastItems.findIndex(
+    (item) => item.id === `${blockId}:walkthrough-header`,
+  );
+  expect(index).toBeGreaterThanOrEqual(0);
+  return codeViewMock.postRenderNodes[index];
+};
+
 const createLoadedMarkdownFile = (contents: string, fingerprint: string) => {
   const file = createChangedFileWithPatch(
     'plan.md',
@@ -483,6 +491,44 @@ test('scroll selection updates do not publish new item versions', async () => {
   expect(codeViewMock.lastItems.map((item) => item.version)).toEqual(firstVersions);
   expect(codeViewMock.postRenderNodes[0]?.classList.contains('codiff-selected-item')).toBe(false);
   expect(codeViewMock.postRenderNodes[1]?.classList.contains('codiff-selected-item')).toBe(true);
+});
+
+test('walkthrough stop selection updates do not publish new header item versions', async () => {
+  const firstFile = createChangedFile('src/first.ts');
+  const secondFile = createChangedFile('src/second.ts');
+  const blocks = (currentIndex: number): ReadonlyArray<ReviewDiffBlock> => [
+    {
+      file: firstFile,
+      header: <div>Stop one</div>,
+      headerSelected: currentIndex === 0,
+      id: 'walkthrough:s1',
+      itemIdPrefix: 'walkthrough:s1',
+    },
+    {
+      file: secondFile,
+      header: <div>Stop two</div>,
+      headerSelected: currentIndex === 1,
+      id: 'walkthrough:s2',
+      itemIdPrefix: 'walkthrough:s2',
+    },
+  ];
+  await using view = await renderReact(<ReviewCodeViewHarness blocks={blocks(0)} files={[]} />);
+
+  const firstVersions = codeViewMock.lastItems.map((item) => item.version);
+  expect(
+    getWalkthroughHeaderNode('walkthrough:s1')?.classList.contains('codiff-selected-item'),
+  ).toBe(true);
+  expect(
+    getWalkthroughHeaderNode('walkthrough:s2')?.classList.contains('codiff-selected-item'),
+  ).toBe(false);
+  await view.rerender(<ReviewCodeViewHarness blocks={blocks(1)} files={[]} />);
+  expect(codeViewMock.lastItems.map((item) => item.version)).toEqual(firstVersions);
+  expect(
+    getWalkthroughHeaderNode('walkthrough:s1')?.classList.contains('codiff-selected-item'),
+  ).toBe(false);
+  expect(
+    getWalkthroughHeaderNode('walkthrough:s2')?.classList.contains('codiff-selected-item'),
+  ).toBe(true);
 });
 
 test('walkthrough header chrome does not leak inline styles onto reused diff nodes', async () => {

--- a/core/__tests__/narrative-walkthrough-view.test.ts
+++ b/core/__tests__/narrative-walkthrough-view.test.ts
@@ -222,18 +222,14 @@ test('walkthrough scrolling skips the initial stop but keeps explicit navigation
     getWalkthroughBlockScrollTarget({
       activeBlockId: 'walkthrough:first',
       firstSupportBlockId: null,
-      mode: 'stop',
-      stopScrollRequest: 0,
-      supportScrollRequest: 0,
+      scrollTarget: { index: 0, kind: 'stop', nonce: 0 },
     }),
   ).toBeNull();
   expect(
     getWalkthroughBlockScrollTarget({
       activeBlockId: 'walkthrough:first',
       firstSupportBlockId: null,
-      mode: 'stop',
-      stopScrollRequest: 1,
-      supportScrollRequest: 0,
+      scrollTarget: { index: 0, kind: 'stop', nonce: 1 },
     }),
   ).toEqual({
     behavior: 'smooth',
@@ -244,14 +240,38 @@ test('walkthrough scrolling skips the initial stop but keeps explicit navigation
     getWalkthroughBlockScrollTarget({
       activeBlockId: 'walkthrough:first',
       firstSupportBlockId: 'walkthrough:support',
-      mode: 'support',
-      stopScrollRequest: 0,
-      supportScrollRequest: 1,
+      scrollTarget: { index: 0, kind: 'support', nonce: 2 },
     }),
   ).toEqual({
     behavior: 'smooth',
     blockId: 'walkthrough:support',
-    request: 1,
+    request: 2,
+  });
+});
+
+test('walkthrough scroll targets track explicit navigation, not scroll-derived mode', () => {
+  // A stop was clicked (nonce 3); scrolling into the support region flips the
+  // mode but must not surface a support target with a fresh request.
+  const stopTarget = getWalkthroughBlockScrollTarget({
+    activeBlockId: 'walkthrough:first',
+    firstSupportBlockId: 'walkthrough:support',
+    scrollTarget: { index: 0, kind: 'stop', nonce: 3 },
+  });
+  expect(stopTarget).toEqual({
+    behavior: 'smooth',
+    blockId: 'walkthrough:first',
+    request: 3,
+  });
+  expect(
+    getWalkthroughBlockScrollTarget({
+      activeBlockId: null,
+      firstSupportBlockId: 'walkthrough:support',
+      scrollTarget: { index: 0, kind: 'support', nonce: 4 },
+    }),
+  ).toEqual({
+    behavior: 'smooth',
+    blockId: 'walkthrough:support',
+    request: 4,
   });
 });
 

--- a/core/__tests__/useNarrativeNavigation.test.tsx
+++ b/core/__tests__/useNarrativeNavigation.test.tsx
@@ -134,3 +134,66 @@ test('support navigation holds support mode until the support block is reached',
   expect(getNavigation().mode).toBe('stop');
   expect(getNavigation().index).toBe(1);
 });
+
+test('scrolling across support blocks does not hijack a pending stop scroll', async () => {
+  const navigationRef: { current: NarrativeNavigation | null } = {
+    current: null,
+  };
+  const getNavigation = () => {
+    if (!navigationRef.current) {
+      throw new Error('Navigation did not render.');
+    }
+    return navigationRef.current;
+  };
+
+  await using _view = await renderReact(
+    <NavigationHarness onNavigation={(next) => (navigationRef.current = next)} />,
+  );
+
+  await act(async () => {
+    getNavigation().goStop(1);
+  });
+  expect(getNavigation().mode).toBe('stop');
+  await act(async () => {
+    getNavigation().syncSupportFromScroll();
+  });
+  expect(getNavigation().mode).toBe('stop');
+  expect(getNavigation().index).toBe(1);
+  await act(async () => {
+    getNavigation().syncIndexFromScroll(1);
+  });
+  await act(async () => {
+    getNavigation().syncSupportFromScroll();
+  });
+  expect(getNavigation().mode).toBe('support');
+});
+
+test('stop and support scroll requests share one monotonic nonce sequence', async () => {
+  const navigationRef: { current: NarrativeNavigation | null } = {
+    current: null,
+  };
+  const getNavigation = () => {
+    if (!navigationRef.current) {
+      throw new Error('Navigation did not render.');
+    }
+    return navigationRef.current;
+  };
+
+  await using _view = await renderReact(
+    <NavigationHarness onNavigation={(next) => (navigationRef.current = next)} />,
+  );
+
+  expect(getNavigation().scrollTarget).toEqual({ index: 0, kind: 'stop', nonce: 0 });
+  await act(async () => {
+    getNavigation().goStop(2);
+  });
+  expect(getNavigation().scrollTarget).toEqual({ index: 2, kind: 'stop', nonce: 1 });
+  await act(async () => {
+    getNavigation().openSupport();
+  });
+  expect(getNavigation().scrollTarget).toMatchObject({ kind: 'support', nonce: 2 });
+  await act(async () => {
+    getNavigation().goStop(0);
+  });
+  expect(getNavigation().scrollTarget).toEqual({ index: 0, kind: 'stop', nonce: 3 });
+});

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -2743,6 +2743,7 @@ export function ReviewCodeView({
     itemMetadata,
     items,
     searchTargetsByBaseItemId,
+    selectedHeaderItemIds,
   } = useMemo(() => {
     const nextItems: Array<CodeViewItem<ReviewAnnotationMetadata>> = [];
     const nextFirstItemByBlockId = new Map<string, string>();
@@ -2750,6 +2751,7 @@ export function ReviewCodeView({
     const nextItemBlockId = new Map<string, string>();
     const nextItemMetadata = new Map<string, CodeViewItemMetadata>();
     const nextSearchTargetsByBaseItemId = new Map<string, Array<RenderedSearchTarget>>();
+    const nextSelectedHeaderItemIds = new Set<string>();
     const fontLayoutKey = `line-height:${diffLineHeight}`;
 
     for (const block of reviewBlocks) {
@@ -2757,6 +2759,9 @@ export function ReviewCodeView({
         const headerId = getBlockHeaderItemId(block);
         nextFirstItemByBlockId.set(block.id, nextFirstItemByBlockId.get(block.id) ?? headerId);
         nextItemBlockId.set(headerId, block.id);
+        if ((block.headerSelected ?? block.selected) === true) {
+          nextSelectedHeaderItemIds.add(headerId);
+        }
         nextItems.push({
           annotations: [
             {
@@ -2776,11 +2781,11 @@ export function ReviewCodeView({
           },
           id: headerId,
           type: 'file',
-          version: getItemVersion(
-            `${block.id}:walkthrough-header:${
-              (block.headerSelected ?? block.selected) === true ? 'selected' : 'idle'
-            }`,
-          ),
+          // Selection stays out of the version: a scroll-driven current-stop
+          // change must not re-measure the header item, or the viewer's scroll
+          // anchoring yanks the scroll position at every stop boundary. The
+          // accent is applied through `codiff-selected-item` in onPostRender.
+          version: getItemVersion(`${block.id}:walkthrough-header`),
         });
       }
 
@@ -3000,6 +3005,7 @@ export function ReviewCodeView({
       itemMetadata: nextItemMetadata,
       items: nextItems,
       searchTargetsByBaseItemId: nextSearchTargetsByBaseItemId,
+      selectedHeaderItemIds: nextSelectedHeaderItemIds,
     };
   }, [
     collapsed,
@@ -3359,7 +3365,10 @@ export function ReviewCodeView({
           const metadata = itemMetadata.get(context.item.id);
           const isWalkthroughHeaderItem = context.item.id.endsWith(':walkthrough-header');
           node.classList.toggle('codiff-walkthrough-header-item', isWalkthroughHeaderItem);
-          node.classList.toggle('codiff-selected-item', metadata?.isSelected === true);
+          node.classList.toggle(
+            'codiff-selected-item',
+            metadata?.isSelected === true || selectedHeaderItemIds.has(context.item.id),
+          );
           node.classList.toggle(
             'codiff-markdown-preview-item',
             metadata?.isMarkdownPreview === true,
@@ -3407,6 +3416,7 @@ export function ReviewCodeView({
       onCreateComment,
       onFindDefinitions,
       onLoadSection,
+      selectedHeaderItemIds,
       source,
       sourceKey,
       theme,

--- a/core/app/components/walkthrough/NarrativeWalkthroughView.tsx
+++ b/core/app/components/walkthrough/NarrativeWalkthroughView.tsx
@@ -51,30 +51,29 @@ export type WalkthroughBlockScrollTarget = {
   request: number;
 };
 
+// The target derives from the last explicit navigation action (goStop or
+// openSupport), never from the scroll-derived mode: a mode change caused by
+// scrolling must not issue a competing scroll command mid-flight.
 export const getWalkthroughBlockScrollTarget = ({
   activeBlockId,
   firstSupportBlockId,
-  mode,
-  stopScrollRequest,
-  supportScrollRequest,
+  scrollTarget,
 }: {
   activeBlockId: string | null | undefined;
   firstSupportBlockId: string | null;
-  mode: NarrativeNavigation['mode'];
-  stopScrollRequest: number;
-  supportScrollRequest: number;
+  scrollTarget: NarrativeNavigation['scrollTarget'];
 }): WalkthroughBlockScrollTarget | null =>
-  mode === 'support' && firstSupportBlockId
+  scrollTarget.kind === 'support' && firstSupportBlockId
     ? {
         behavior: 'smooth',
         blockId: firstSupportBlockId,
-        request: supportScrollRequest,
+        request: scrollTarget.nonce,
       }
-    : mode === 'stop' && activeBlockId && stopScrollRequest > 0
+    : scrollTarget.kind === 'stop' && activeBlockId && scrollTarget.nonce > 0
       ? {
           behavior: 'smooth',
           blockId: activeBlockId,
-          request: stopScrollRequest,
+          request: scrollTarget.nonce,
         }
       : null;
 
@@ -145,9 +144,12 @@ const emptyWalkthroughBlockSet: WalkthroughBlockSet = {
   stopIndexByBlockId: new Map(),
 };
 
-function StopHeader({ current, stop }: { current: boolean; stop: WalkthroughStopView }) {
+// The current-stop accent is not rendered here: it is applied through the
+// `codiff-selected-item` class on the virtualized item container, so the header
+// item's content and version stay stable while scrolling moves the selection.
+function StopHeader({ stop }: { stop: WalkthroughStopView }) {
   return (
-    <div className={`wt-stop-block wt-stop-block-header${current ? ' current' : ''}`}>
+    <div className="wt-stop-block wt-stop-block-header">
       <div className="wt-stage-title-row">
         <h2 className="wt-stage-title">{stop.title ?? walkthroughItemTitleFallback(stop)}</h2>
         <ImportancePill importance={stop.importance} />
@@ -157,9 +159,9 @@ function StopHeader({ current, stop }: { current: boolean; stop: WalkthroughStop
   );
 }
 
-function SupportHeader({ current }: { current: boolean }) {
+function SupportHeader() {
   return (
-    <div className={`wt-stop-block wt-stop-block-header${current ? ' current' : ''}`}>
+    <div className="wt-stop-block wt-stop-block-header">
       <div className="wt-stage-title-row">
         <h2 className="wt-stage-title">Support</h2>
         <ImportancePill importance="normal" />
@@ -185,7 +187,7 @@ const createWalkthroughBlocks = (
       firstBlockIdByStop[stop.index] = blockId;
       stopIndexByBlockId.set(blockId, stop.index);
       blocks.push({
-        header: <StopHeader current={stop.index === currentIndex} stop={stop} />,
+        header: <StopHeader stop={stop} />,
         headerSelected: stop.index === currentIndex,
         id: blockId,
       });
@@ -199,8 +201,7 @@ const createWalkthroughBlocks = (
       stopIndexByBlockId.set(blockId, stop.index);
       blocks.push({
         file,
-        header:
-          runIndex === 0 ? <StopHeader current={stop.index === currentIndex} stop={stop} /> : null,
+        header: runIndex === 0 ? <StopHeader stop={stop} /> : null,
         headerSelected: stop.index === currentIndex,
         id: blockId,
         itemIdPrefix: blockId,
@@ -240,7 +241,7 @@ const createSupportBlocks = (
         const isFirstBlock = blocks.length === 0;
         blocks.push({
           file,
-          header: isFirstBlock ? <SupportHeader current={selected} /> : null,
+          header: isFirstBlock ? <SupportHeader /> : null,
           headerSelected: selected,
           id: blockId,
           itemIdPrefix: blockId,
@@ -257,7 +258,7 @@ const createSupportBlocks = (
     const isFirstBlock = blocks.length === 0;
     blocks.push({
       file,
-      header: isFirstBlock ? <SupportHeader current={selected} /> : null,
+      header: isFirstBlock ? <SupportHeader /> : null,
       headerSelected: selected,
       id: blockId,
       itemIdPrefix: blockId,
@@ -552,9 +553,7 @@ export function NarrativeWalkthroughView({
   const reviewBlockScrollTarget = getWalkthroughBlockScrollTarget({
     activeBlockId,
     firstSupportBlockId,
-    mode: navigation.mode,
-    stopScrollRequest: navigation.scrollTarget.nonce,
-    supportScrollRequest: navigation.supportScrollRequest,
+    scrollTarget: navigation.scrollTarget,
   });
   const handleActiveBlockChange = useCallback(
     (blockId: string) => {

--- a/core/app/components/walkthrough/useNarrativeNavigation.ts
+++ b/core/app/components/walkthrough/useNarrativeNavigation.ts
@@ -31,11 +31,19 @@ export const useNarrativeNavigation = (
   );
   const [mode, setMode] = useState<NarrativeViewMode>('stop');
   const [index, setIndex] = useState(0);
-  const [scrollTarget, setScrollTarget] = useState<{ index: number; nonce: number }>({
+  // One shared nonce sequence covers both stop and support scroll requests, so
+  // a scroll command is identified by a single monotonically increasing number
+  // and a mode change derived from scrolling can never resurface an
+  // already-handled request as a new one.
+  const [scrollTarget, setScrollTarget] = useState<{
+    index: number;
+    kind: 'stop' | 'support';
+    nonce: number;
+  }>({
     index: 0,
+    kind: 'stop',
     nonce: 0,
   });
-  const [supportScrollRequest, setSupportScrollRequest] = useState(0);
   const [supportVisited, setSupportVisited] = useState(false);
   const [visited, setVisited] = useState<ReadonlySet<string>>(() => {
     const stopId = firstStopId(walkthrough);
@@ -85,8 +93,7 @@ export const useNarrativeNavigation = (
     if (mode !== 'commit') {
       setMode('stop');
       setIndex(0);
-      setScrollTarget({ index: 0, nonce: 0 });
-      setSupportScrollRequest(0);
+      setScrollTarget({ index: 0, kind: 'stop', nonce: 0 });
       setSupportVisited(false);
       const stopId = firstStopId(walkthrough);
       setVisited(new Set(stopId ? [stopId] : []));
@@ -163,7 +170,7 @@ export const useNarrativeNavigation = (
       markVisited(walkthroughView.sequence[clamped]?.id);
       pendingStopScrollRef.current = { index: clamped, walkthrough };
       pendingSupportScrollRef.current = null;
-      setScrollTarget((current) => ({ index: clamped, nonce: current.nonce + 1 }));
+      setScrollTarget((current) => ({ index: clamped, kind: 'stop', nonce: current.nonce + 1 }));
     },
     [walkthrough, walkthroughView, markVisited],
   );
@@ -217,16 +224,25 @@ export const useNarrativeNavigation = (
     }
     setMode('support');
     pendingSupportScrollRef.current = { walkthrough };
-    setSupportScrollRequest((current) => current + 1);
+    setScrollTarget((current) => ({ ...current, kind: 'support', nonce: current.nonce + 1 }));
     setSupportVisited(true);
   }, [walkthrough, walkthroughView, leaveStopMode]);
 
+  // Scrolling across a support block while a clicked stop is still being
+  // scrolled to must not hijack the flight into support mode; the lock is
+  // released when the target stop is reached or by direct user scroll input.
   const syncSupportFromScroll = useCallback(() => {
+    const pendingStop = pendingStopScrollRef.current;
+    if (pendingStop) {
+      if (pendingStop.walkthrough === walkthrough) {
+        return;
+      }
+      pendingStopScrollRef.current = null;
+    }
     pendingSupportScrollRef.current = null;
-    pendingStopScrollRef.current = null;
     setMode('support');
     setSupportVisited(true);
-  }, []);
+  }, [walkthrough]);
 
   const enterCommit = useCallback(() => {
     leaveStopMode();
@@ -275,7 +291,6 @@ export const useNarrativeNavigation = (
     scrollTarget,
     setCommitBody,
     setCommitSubject,
-    supportScrollRequest,
     supportVisited,
     syncIndexFromScroll,
     syncSupportFromScroll,

--- a/core/walkthrough.css
+++ b/core/walkthrough.css
@@ -558,7 +558,10 @@
   transition: box-shadow 220ms ease;
   width: 100%;
 }
-.wt-stop-block-header.current {
+/* The current-stop accent comes from the virtualized item container so the
+   header's own content never re-renders (and never re-measures) when scrolling
+   moves the selection. */
+.codiff-selected-item .wt-stop-block-header {
   box-shadow: inset 3px 0 0 var(--tree-selection-focus);
 }
 


### PR DESCRIPTION
Scrolling through a narrative walkthrough gets yanked backwards at every stop boundary, and clicking a stop in the table of contents can send the view scrolling somewhere else entirely — with the right walkthrough shape it degenerates into a scrolling loop the reviewer cannot escape.

## Root cause

Walkthrough stop-header items bake the current-stop selection into their CodeView item `version`:

```ts
version: getItemVersion(`${block.id}:walkthrough-header:${headerSelected ? 'selected' : 'idle'}`)
```

Crossing a stop boundary while scrolling changes `navigation.index`, which republishes two header items with new versions. CodeView treats a version change as a content change: it re-prepares the item, and the header's React-slotted annotation height falls back to the placeholder until the slot re-reports. The viewer's scroll anchoring then "corrects" the apparent shrink by scrolling backwards — by roughly the header's height, at every boundary, on every crossing. Driving the app over CDP shows the correlation exactly (each `STOP->n` transition below is one scroll event):

```
1699ms top=4681  STOP->2  REGRESSION from 4800
2801ms top=9361  STOP->3  REGRESSION from 9481
3889ms top=14042 STOP->4  REGRESSION from 14161
```

With realistic walkthroughs (multi-paragraph prose, one-hunk stops) the yank grows to ~230px per crossing; 120 wheel ticks that should land at 7200 only reached 6299. This is the same defect class 05e6cca fixed for file headers (selection styling must not feed item versions); the walkthrough header items kept the old pattern.

Two more defects compound the sidebar-click case:

- `syncSupportFromScroll` ignored the pending stop-scroll lock, so a click-initiated smooth scroll that crosses the support region flipped the mode to support mid-flight.
- The mode flip swapped the emitted block scroll target to the support branch, whose `request` comes from an independent counter — the shared dedupe ref in `ReviewCodeView` saw an unfamiliar number and issued a competing scroll command. Clicking a stop from the support region visibly reversed mid-flight and landed back in the support section.

## Fix

- Header item versions are stable (`${block.id}:walkthrough-header`). The current-stop accent is applied through the existing `codiff-selected-item` class in `onPostRender` plus a `.codiff-selected-item .wt-stop-block-header` rule, mirroring how 05e6cca handles file-header selection. `StopHeader`/`SupportHeader` lose their `current` prop; their content no longer depends on the active index at all.
- `useNarrativeNavigation` folds the stop and support scroll requests into one `scrollTarget: { index, kind, nonce }` with a single monotone nonce, and `getWalkthroughBlockScrollTarget` derives the target from that last explicit navigation action instead of the scroll-derived mode — a mode change caused by scrolling can no longer resurface an already-handled request as a new scroll command.
- `syncSupportFromScroll` respects the pending stop-scroll lock (released on arrival or by direct user scroll input, same as `syncIndexFromScroll`).

## Verification

Re-running the same CDP-driven experiments against the fixed build:

- 120 × 60px wheel ticks: **0 regressions**, final position **7200/7200**, active-stop tracking intact.
- The accent follows the active stop (exactly one accented header, always matching the arc) at every checked position.
- Clicking any stop — including from within the support region — lands at the correct block with zero scroll direction flips and settles in under a second.

Regression tests: walkthrough stop selection changes must not publish new header item versions (mirrors the existing file-selection test), `syncSupportFromScroll` honours the stop-scroll lock, stop/support requests share one nonce sequence, and `getWalkthroughBlockScrollTarget` tracks explicit navigation rather than scroll-derived mode.

`vp check --fix`, `vp test`, and `vp run build` pass (the pre-existing `web/`/`service/` lint findings on a clean tree are untouched).

---

This PR was investigated, written, and verified with Claude Code: the root-cause investigation drove the real Electron app over CDP with synthetic wheel/click input to measure the scroll regressions before and after the change, and the code, tests, and this description were AI-generated and human-reviewed.

banana banana banana
