### PR TITLE
Add Azure DevOps pull request review

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Codiff is a beautiful, minimal, local diff viewer for reviewing Git changes and 
 
 - **Fast Local Reviews:** Review and commit changes in any Git repository.
 - **LLM Walkthroughs:** Run `codiff -w` to generate an optimized commit walkthrough.
-- **Inline Review Comments:** Comment directly on GitHub pull requests and GitLab merge requests, or copy review comments as Markdown for follow-ups.
+- **Inline Review Comments:** Comment directly on GitHub pull requests, GitLab merge requests, and Azure DevOps pull requests, or copy review comments as Markdown for follow-ups.
 - **Lightweight Definition Navigation:** Mod/Ctrl-click an identifier to find likely local definitions without starting a language server.
 
 ## Download
@@ -48,20 +48,23 @@ Review the current branch against a target branch:
 codiff main
 ```
 
-Review a GitHub pull request or GitLab merge request using the current repository remote:
+Review a GitHub pull request, GitLab merge request, or Azure DevOps pull request using the current repository remote:
 
 ```bash
 codiff pr 75
 codiff pr owner:my-feature-branch
 codiff mr 23
+codiff ado 75
 ```
 
 Branch lookup uses `gh` and selects an open GitHub pull request. Include `owner:` for pull
-requests from forks.
+requests from forks. `codiff pr 75` also works against an Azure DevOps remote. `codiff ado 75`
+forces Azure DevOps when a repository has more than one review host.
 
-Full GitHub and GitLab review URLs are also supported. GitLab hosts and nested project paths are
-derived from the URL or local Git remote and authenticated through `glab`; Codiff does not require
-instance-specific configuration.
+Full GitHub, GitLab, and Azure DevOps review URLs are also supported. GitLab hosts and nested
+project paths are derived from the URL or local Git remote and authenticated through `glab`. Azure
+DevOps uses `az` (`az login`); Codiff searches PATH plus the usual Homebrew and `~/.local/bin`
+install locations, or `CODIFF_AZ_PATH` for an explicit binary.
 
 Start with an LLM-generated narrative walkthrough. When generating a walkthrough without an
 explicit target, Codiff uses local changes when present and falls back to `HEAD` when the working

--- a/bin/arguments.js
+++ b/bin/arguments.js
@@ -120,6 +120,7 @@ const usageExamples = [
     description: 'Review the open pull request for a branch.',
   },
   { command: 'codiff mr 75', description: 'Review GitLab merge request !75.' },
+  { command: 'codiff ado 75', description: 'Review Azure DevOps pull request #75.' },
   { command: 'codiff update', description: 'Update Codiff to the latest release.' },
   { command: 'codiff --plan plan.md', description: 'Edit a plan and wait for handoff.' },
   { command: 'codiff --plan plan.md --share', description: 'Share a Markdown plan.' },
@@ -135,8 +136,11 @@ export const getReviewSource = ({
   pullRequestProvider,
   pullRequestUrl,
   range,
-}) =>
-  range
+}) => {
+  const resolvedProvider = pullRequestUrl
+    ? parseReviewUrl(pullRequestUrl)?.provider || pullRequestProvider
+    : pullRequestProvider;
+  return range
     ? {
         base: range.base,
         head: range.head,
@@ -145,7 +149,7 @@ export const getReviewSource = ({
       }
     : pullRequestUrl
       ? {
-          ...(pullRequestProvider ? { provider: pullRequestProvider } : {}),
+          ...(resolvedProvider ? { provider: resolvedProvider } : {}),
           type: 'pull-request',
           url: pullRequestUrl,
         }
@@ -154,6 +158,7 @@ export const getReviewSource = ({
         : branchRef
           ? { ref: branchRef, type: 'branch-working-tree' }
           : undefined;
+};
 
 const parseArgsOptions = Object.fromEntries(
   flagDefinitions.map(({ name, short, type }) => [name, { type, ...(short ? { short } : {}) }]),
@@ -271,7 +276,9 @@ const getReviewProviderMarker = (arg) =>
     ? 'github'
     : /^(?:mr|merge-request)$/i.test(arg)
       ? 'gitlab'
-      : null;
+      : /^(?:ado|azdo|azure|azure-devops)$/i.test(arg)
+        ? 'azure-devops'
+        : null;
 
 // Store the canonical form so pasted review tabs, queries and anchors never reach the Git layer.
 const parsePullRequestUrlArgument = (arg) => parseReviewUrl(arg)?.url ?? null;

--- a/bin/codiff-app
+++ b/bin/codiff-app
@@ -221,6 +221,7 @@ show_help() {
   printf '  %-32s%s%s%s\n' "codiff pr 75" "$gray" "Review pull request #75 (alternate syntax)." "$reset"
   printf '  %-32s%s%s%s\n' "codiff pr owner:feature" "$gray" "Review the open pull request for a branch." "$reset"
   printf '  %-32s%s%s%s\n' "codiff mr 75" "$gray" "Review GitLab merge request !75." "$reset"
+  printf '  %-32s%s%s%s\n' "codiff ado 75" "$gray" "Review Azure DevOps pull request #75." "$reset"
   printf '  %-32s%s%s%s\n' "codiff --plan plan.md" "$gray" "Edit a plan and wait for handoff." "$reset"
   printf '  %-32s%s%s%s\n' "codiff --plan plan.md --share" "$gray" "Share a Markdown plan." "$reset"
   printf '  %-32s%s%s%s\n' "codiff -w" "$gray" "Walk through local changes, or HEAD when clean." "$reset"
@@ -323,7 +324,8 @@ is_explicit_path_arg() {
 # Matches review links as pasted from a browser: an optional scheme, an optional `/-/` separator,
 # and any trailing tab segment, query or anchor. Electron canonicalizes the link it receives.
 is_review_url_arg() {
-  printf '%s' "$1" | grep -Eq '^(https?://[^/]+|[^/[:space:]:@]+\.[^/[:space:]:@]+(:[0-9]+)?)/(.+/)?[^/]+/(-/)?(merge_requests|pull)/[1-9][0-9]*([/?#].*)?$'
+  printf '%s' "$1" | grep -Eq '^(https?://[^/]+|[^/[:space:]:@]+\.[^/[:space:]:@]+(:[0-9]+)?)/(.+/)?[^/]+/(-/)?(merge_requests|pull)/[1-9][0-9]*([/?#].*)?$' ||
+    printf '%s' "$1" | grep -Eqi '^(https?://[^/]+|[^/[:space:]:@]+\.[^/[:space:]:@]+(:[0-9]+)?)/.+/_git/[^/]+/pullrequests?/[1-9][0-9]*([/?#].*)?$'
 }
 
 is_git_branch_ref() {
@@ -531,6 +533,9 @@ for arg in "$@"; do
         expect_pull_request_value=1
       elif [ -z "$pull_request_source" ] && printf '%s' "$arg" | grep -Eiq '^(mr|merge-request)$'; then
         pull_request_provider="mr"
+        expect_pull_request_value=1
+      elif [ -z "$pull_request_source" ] && printf '%s' "$arg" | grep -Eiq '^(ado|azdo|azure|azure-devops)$'; then
+        pull_request_provider="ado"
         expect_pull_request_value=1
       elif [ -z "$pull_request_source" ] && printf '%s' "$arg" | grep -Eq '^#[1-9][0-9]*$'; then
         pull_request_source="$arg"

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -1757,7 +1757,10 @@ export default function App() {
         reviewStatus={state.source.type === 'pull-request' ? state.source.reviewStatus : undefined}
         showCommentReview={
           state.source.type === 'pull-request' &&
-          (state.source.provider === 'github' || state.source.host === 'github.com')
+          (state.source.provider === 'github' ||
+            state.source.provider === 'azure-devops' ||
+            state.source.host === 'github.com' ||
+            state.source.host === 'dev.azure.com')
         }
       />
     ) : undefined,

--- a/core/SharedWalkthroughApp.tsx
+++ b/core/SharedWalkthroughApp.tsx
@@ -825,7 +825,12 @@ export function ReviewSurface({
         onClosePullRequest={closePullRequest}
         onSubmitReview={submitReview}
         reviewStatus={source.reviewStatus}
-        showCommentReview={source.provider === 'github' || source.host === 'github.com'}
+        showCommentReview={
+          source.provider === 'github' ||
+          source.provider === 'azure-devops' ||
+          source.host === 'github.com' ||
+          source.host === 'dev.azure.com'
+        }
       >
         {sourceMergeStatusBadge}
       </PullRequestReviewButtons>

--- a/core/__tests__/azure-devops.test.ts
+++ b/core/__tests__/azure-devops.test.ts
@@ -1,0 +1,385 @@
+import { execFile } from 'node:child_process';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, test } from 'vite-plus/test';
+import { createTemporaryDirectory, createTemporaryEnvironment } from './helpers/resources.ts';
+
+const require = createRequire(import.meta.url);
+const {
+  AZ_NOT_FOUND_CODE,
+  createAzureDevOpsFetchRefspecs,
+  createAzureDevOpsThreadContext,
+  getAzCommand,
+  normalizeAzureDevOpsReviewComment,
+  parseAzureDevOpsPullRequestUrl,
+  submitAzureDevOpsComment,
+  submitAzureDevOpsReview,
+} = require('../../electron/git-state/azure-devops.cjs') as {
+  AZ_NOT_FOUND_CODE: string;
+  createAzureDevOpsFetchRefspecs: (
+    pullRequest: Record<string, unknown>,
+    metadata: Record<string, unknown>,
+  ) => ReadonlyArray<string>;
+  createAzureDevOpsThreadContext: (comment: Record<string, unknown>) => Record<string, unknown>;
+  getAzCommand: () => string;
+  normalizeAzureDevOpsReviewComment: (
+    comment: Record<string, unknown>,
+    thread: Record<string, unknown>,
+    url: string,
+  ) => Record<string, unknown> | null;
+  parseAzureDevOpsPullRequestUrl: (url: string) => Record<string, unknown>;
+  submitAzureDevOpsComment: (
+    launchPath: string,
+    request: {
+      comment: Record<string, unknown>;
+      source: Record<string, unknown>;
+    },
+  ) => Promise<Record<string, unknown>>;
+  submitAzureDevOpsReview: (
+    launchPath: string,
+    request: {
+      body?: string;
+      comments: ReadonlyArray<Record<string, unknown>>;
+      event: 'APPROVE' | 'COMMENT' | 'REQUEST_CHANGES';
+      source: Record<string, unknown>;
+    },
+  ) => Promise<void>;
+};
+
+const execFileAsync = promisify(execFile);
+
+type AzCall = {
+  args: ReadonlyArray<string>;
+};
+
+const withFakeAzureDevOps = async (
+  callback: (repo: string, readCalls: () => Promise<ReadonlyArray<AzCall>>) => Promise<void>,
+) => {
+  await using directory = await createTemporaryDirectory('codiff-azure-devops-');
+  const repo = join(directory.path, 'repo');
+  const fakeAzPath = join(directory.path, 'az');
+  const callsPath = join(directory.path, 'calls.jsonl');
+
+  await execFileAsync('git', ['init', repo]);
+  await execFileAsync('git', [
+    '-C',
+    repo,
+    'remote',
+    'add',
+    'origin',
+    'git@ssh.dev.azure.com:v3/mpc-tech-hub/MPCM/Dashboard',
+  ]);
+  await writeFile(
+    fakeAzPath,
+    `#!/usr/bin/env node
+const { appendFileSync } = require('node:fs');
+const args = process.argv.slice(2);
+const uriIndex = args.indexOf('--uri');
+const uri = uriIndex >= 0 ? args[uriIndex + 1] : '';
+const methodIndex = args.indexOf('--method');
+const method = (methodIndex >= 0 ? args[methodIndex + 1] : 'GET').toUpperCase();
+const bodyIndex = args.indexOf('--body');
+const body = bodyIndex >= 0 ? args[bodyIndex + 1] : '';
+appendFileSync(process.env.CODIFF_AZ_TEST_CALLS, JSON.stringify({ args }) + '\\n');
+if (method === 'POST' && uri.includes('/threads/') && uri.includes('/comments')) {
+  process.stdout.write(JSON.stringify({
+    author: { displayName: 'Ada', uniqueName: 'ada@contoso.com' },
+    commentType: 1,
+    content: JSON.parse(body).content,
+    id: 2,
+    publishedDate: '2026-08-19T00:00:00Z',
+  }));
+  return;
+}
+if (method === 'POST' && /\\/threads\\?/.test(uri)) {
+  const payload = JSON.parse(body);
+  process.stdout.write(JSON.stringify({
+    comments: [{
+      author: { displayName: 'Ada', uniqueName: 'ada@contoso.com' },
+      commentType: 1,
+      content: payload.comments[0].content,
+      id: 1,
+      publishedDate: '2026-08-19T00:00:00Z',
+    }],
+    id: 18,
+    threadContext: payload.threadContext || null,
+  }));
+  return;
+}
+if (uri.includes('/connectionData')) {
+  process.stdout.write(JSON.stringify({ authenticatedUser: { id: 'user-1' } }));
+  return;
+}
+if (method === 'PUT' && uri.includes('/reviewers/')) {
+  process.stdout.write(JSON.stringify({ id: 'user-1', vote: 10 }));
+  return;
+}
+if (uri.includes('/pullRequests/492?')) {
+  process.stdout.write(JSON.stringify({
+    createdBy: { displayName: 'Ada' },
+    lastMergeSourceCommit: { commitId: 'abc' },
+    targetRefName: 'refs/heads/main',
+    title: 'Add Azure DevOps reviews',
+  }));
+  return;
+}
+process.stdout.write('{}');
+`,
+  );
+  await chmod(fakeAzPath, 0o755);
+  await using _environment = createTemporaryEnvironment({
+    CODIFF_AZ_PATH: fakeAzPath,
+    CODIFF_AZ_TEST_CALLS: callsPath,
+    SHELL: undefined,
+  });
+
+  await callback(repo, async () =>
+    (await readFile(callsPath, 'utf8'))
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as AzCall),
+  );
+};
+
+describe('Azure DevOps pull requests', () => {
+  test('parses cloud and visualstudio pull request URLs', () => {
+    expect(
+      parseAzureDevOpsPullRequestUrl(
+        'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+      ),
+    ).toMatchObject({
+      host: 'dev.azure.com',
+      number: 492,
+      organization: 'mpc-tech-hub',
+      project: 'MPCM',
+      provider: 'azure-devops',
+      repo: 'Dashboard',
+    });
+  });
+
+  test('builds local head and target branch fetch refspecs', () => {
+    expect(
+      createAzureDevOpsFetchRefspecs(
+        { number: 492 },
+        {
+          targetRefName: 'refs/heads/main',
+        },
+      ),
+    ).toEqual([
+      '+refs/pull/492/head:refs/codiff/pull-requests/492/head',
+      '+refs/heads/main:refs/codiff/pull-requests/492/base',
+    ]);
+  });
+
+  test('builds Azure DevOps thread positions for lines and files', () => {
+    expect(
+      createAzureDevOpsThreadContext({
+        body: 'Comment',
+        filePath: 'src/a.ts',
+        lineNumber: 12,
+        side: 'additions',
+      }),
+    ).toEqual({
+      filePath: '/src/a.ts',
+      rightFileEnd: { line: 12, offset: 1 },
+      rightFileStart: { line: 12, offset: 1 },
+    });
+    expect(
+      createAzureDevOpsThreadContext({
+        body: 'Comment',
+        filePath: 'src/a.ts',
+        lineNumber: 8,
+        side: 'deletions',
+        startLineNumber: 6,
+      }),
+    ).toEqual({
+      filePath: '/src/a.ts',
+      leftFileEnd: { line: 8, offset: 1 },
+      leftFileStart: { line: 6, offset: 1 },
+    });
+    expect(
+      createAzureDevOpsThreadContext({
+        anchor: 'file',
+        body: 'Review the file.',
+        filePath: 'src/a.ts',
+      }),
+    ).toEqual({ filePath: '/src/a.ts' });
+  });
+
+  test('normalizes Azure DevOps threads for the renderer', () => {
+    expect(
+      normalizeAzureDevOpsReviewComment(
+        {
+          author: { displayName: 'Ada', uniqueName: 'ada@contoso.com' },
+          content: 'Please change this.',
+          id: 1,
+          publishedDate: '2026-08-19T00:00:00Z',
+        },
+        {
+          id: 18,
+          threadContext: {
+            filePath: '/src/a.ts',
+            rightFileEnd: { line: 12, offset: 1 },
+            rightFileStart: { line: 12, offset: 1 },
+          },
+        },
+        'https://dev.azure.com/org/project/_git/repo/pullrequest/42',
+      ),
+    ).toMatchObject({
+      author: { login: 'ada@contoso.com' },
+      body: 'Please change this.',
+      filePath: 'src/a.ts',
+      id: 'azure-devops:18:1',
+      lineNumber: 12,
+      side: 'additions',
+      threadId: '18',
+      url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/42?discussionId=18',
+    });
+  });
+
+  test('normalizes file-level Azure DevOps threads without line metadata', () => {
+    expect(
+      normalizeAzureDevOpsReviewComment(
+        {
+          author: { displayName: 'Ada' },
+          content: 'Please review the file structure.',
+          id: 2,
+          publishedDate: '2026-08-19T00:00:00Z',
+        },
+        {
+          id: 19,
+          threadContext: { filePath: '/src/a.ts' },
+        },
+        'https://dev.azure.com/org/project/_git/repo/pullrequest/42',
+      ),
+    ).toMatchObject({
+      anchor: 'file',
+      filePath: 'src/a.ts',
+      id: 'azure-devops:19:2',
+    });
+  });
+
+  test('resolves the Azure CLI from an explicit override', async () => {
+    await using directory = await createTemporaryDirectory('codiff-az-command-');
+    const fakeAz = join(directory.path, 'az');
+    await writeFile(fakeAz, '#!/bin/sh\nexit 0\n');
+    await chmod(fakeAz, 0o755);
+    await using _environment = createTemporaryEnvironment({ CODIFF_AZ_PATH: fakeAz });
+    expect(getAzCommand()).toBe(fakeAz);
+  });
+
+  test('rejects invalid explicit Azure CLI overrides', async () => {
+    await using _environment = createTemporaryEnvironment({
+      CODIFF_AZ_PATH: '/tmp/codiff-missing-az',
+    });
+    expect(() => getAzCommand()).toThrow('CODIFF_AZ_PATH');
+    try {
+      getAzCommand();
+    } catch (error) {
+      expect(error).toMatchObject({ code: AZ_NOT_FOUND_CODE });
+    }
+  });
+
+  test('submits Azure DevOps comments and reviews through az rest', async () => {
+    await withFakeAzureDevOps(async (repo, readCalls) => {
+      const source = {
+        provider: 'azure-devops',
+        type: 'pull-request',
+        url: 'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+      };
+
+      await expect(
+        submitAzureDevOpsComment(repo, {
+          comment: {
+            body: 'Keep this explicit.',
+            filePath: 'src/a.ts',
+            lineNumber: 12,
+            side: 'additions',
+          },
+          source,
+        }),
+      ).resolves.toMatchObject({
+        body: 'Keep this explicit.',
+        filePath: 'src/a.ts',
+        id: 'azure-devops:18:1',
+        threadId: '18',
+      });
+
+      await submitAzureDevOpsReview(repo, {
+        body: 'Looks good.',
+        comments: [
+          {
+            body: 'Nit.',
+            filePath: 'src/a.ts',
+            lineNumber: 12,
+            side: 'additions',
+          },
+        ],
+        event: 'APPROVE',
+        source,
+      });
+
+      const calls = await readCalls();
+      const uris = calls.map((call) => call.args[call.args.indexOf('--uri') + 1]);
+      expect(uris.some((uri) => uri.includes('/threads?'))).toBe(true);
+      expect(uris.some((uri) => uri.includes('/reviewers/user-1'))).toBe(true);
+      expect(
+        calls.every((call) => call.args.includes('499b84ac-1321-427f-aa17-267ca6975798')),
+      ).toBe(true);
+    });
+  });
+
+  test('authenticates az from the login shell environment when the app inherited none', async () => {
+    await using directory = await createTemporaryDirectory('codiff-az-login-env-');
+    const repo = join(directory.path, 'repo');
+    const fakeAz = join(directory.path, 'az');
+    const fakeShell = join(directory.path, 'fake-login-shell');
+
+    await execFileAsync('git', ['init', repo]);
+    await execFileAsync('git', [
+      '-C',
+      repo,
+      'remote',
+      'add',
+      'origin',
+      'git@ssh.dev.azure.com:v3/mpc-tech-hub/MPCM/Dashboard',
+    ]);
+
+    await writeFile(
+      fakeShell,
+      `#!/bin/sh
+AZURE_DEVOPS_EXT_PAT='from-login-shell' exec /bin/sh -c "$4"
+`,
+    );
+    await writeFile(
+      fakeAz,
+      `#!/bin/sh
+if [ "$AZURE_DEVOPS_EXT_PAT" != 'from-login-shell' ]; then
+  echo 'Please run az login' >&2
+  exit 1
+fi
+printf '%s' '{"authenticatedUser":{"id":"user-1"}}'
+`,
+    );
+    await Promise.all([chmod(fakeShell, 0o755), chmod(fakeAz, 0o755)]);
+
+    await using _environment = createTemporaryEnvironment({
+      AZURE_DEVOPS_EXT_PAT: undefined,
+      CODIFF_AZ_PATH: fakeAz,
+      SHELL: fakeShell,
+    });
+
+    await submitAzureDevOpsReview(repo, {
+      comments: [],
+      event: 'REQUEST_CHANGES',
+      source: {
+        provider: 'azure-devops',
+        type: 'pull-request',
+        url: 'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+      },
+    });
+  });
+});

--- a/core/__tests__/codiff-cli.test.ts
+++ b/core/__tests__/codiff-cli.test.ts
@@ -145,6 +145,15 @@ test('parseArguments canonicalizes review URLs copied from a review tab', () => 
       pullRequestUrl: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
     });
   }
+
+  for (const value of [
+    'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492?_a=files',
+    'dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullRequest/492',
+  ]) {
+    expect(parseArguments([value])).toMatchObject({
+      pullRequestUrl: 'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+    });
+  }
 });
 
 test('parseArguments treats plain branch refs as branch refs', async () => {
@@ -410,6 +419,27 @@ test('parseArguments treats GitLab MR marker values as review sources', () => {
   });
 });
 
+test('parseArguments treats Azure DevOps PR marker values as review sources', () => {
+  expect(parseArguments(['ado', '42'])).toMatchObject({
+    pullRequestNumber: 42,
+    pullRequestProvider: 'azure-devops',
+  });
+  expect(parseArguments(['azdo', '#42'])).toMatchObject({
+    pullRequestNumber: 42,
+    pullRequestProvider: 'azure-devops',
+  });
+});
+
+test('parseArguments accepts Azure DevOps pull request URLs', () => {
+  expect(
+    parseArguments([
+      'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492?_a=files',
+    ]),
+  ).toMatchObject({
+    pullRequestUrl: 'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+  });
+});
+
 test('parseArguments accepts nested GitLab merge request URLs', () => {
   expect(
     parseArguments(['https://gitlab.example.com/group/subgroup/project/-/merge_requests/23']),
@@ -445,6 +475,44 @@ test('resolvePullRequestUrl builds GitLab MR URLs from an arbitrary GitLab remot
 
   expect(resolvePullRequestUrl(repositoryPath, 23, 'gitlab')).toBe(
     'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
+  );
+});
+
+test('resolvePullRequestUrl builds Azure DevOps PR URLs from SSH remotes', async () => {
+  await using directory = await createTemporaryDirectory('codiff-cli-');
+  const repositoryPath = directory.path;
+
+  await git(repositoryPath, ['init']);
+  await git(repositoryPath, [
+    'remote',
+    'add',
+    'origin',
+    'git@ssh.dev.azure.com:v3/mpc-tech-hub/MPCM/Dashboard',
+  ]);
+
+  expect(resolvePullRequestUrl(repositoryPath, 492, 'azure-devops')).toBe(
+    'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+  );
+  expect(resolvePullRequestUrl(repositoryPath, 492, 'github')).toBe(
+    'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+  );
+});
+
+test('resolvePullRequestUrl prefers GitHub remotes when both GitHub and Azure exist', async () => {
+  await using directory = await createTemporaryDirectory('codiff-cli-');
+  const repositoryPath = directory.path;
+
+  await git(repositoryPath, ['init']);
+  await git(repositoryPath, [
+    'remote',
+    'add',
+    'azure',
+    'git@ssh.dev.azure.com:v3/mpc-tech-hub/MPCM/Dashboard',
+  ]);
+  await git(repositoryPath, ['remote', 'add', 'origin', 'git@github.com:nkzw-tech/codiff.git']);
+
+  expect(resolvePullRequestUrl(repositoryPath, 75, 'github')).toBe(
+    'https://github.com/nkzw-tech/codiff/pull/75',
   );
 });
 
@@ -573,6 +641,23 @@ test('packaged terminal helper forwards GitLab MR markers to Electron', async ()
   ]);
 });
 
+test('packaged terminal helper forwards Azure DevOps PR markers to Electron', async () => {
+  await using logger = await createFakeOpenLogger();
+
+  await execFileAsync(resolve('bin/codiff-app'), ['ado', '492'], {
+    env: logger.env,
+  });
+
+  expect(await logger.readArgs()).toEqual([
+    '-n',
+    resolve('bin/../../../..'),
+    '--args',
+    'ado',
+    '492',
+    process.cwd(),
+  ]);
+});
+
 test('packaged terminal helper forwards review URLs copied from a review tab', async () => {
   for (const value of [
     'https://github.com/nkzw-tech/codiff/pull/1728/changes#r4821',
@@ -581,6 +666,7 @@ test('packaged terminal helper forwards review URLs copied from a review tab', a
     'github.com/nkzw-tech/codiff/pull/1728',
     'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23/diffs#note_991',
     'https://gitlab.example.com/group/subgroup/project/merge_requests/23',
+    'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492?_a=files',
   ]) {
     await using logger = await createFakeOpenLogger();
 
@@ -1395,6 +1481,7 @@ test('formatHelpText includes version and all flags', () => {
   expect(text).toContain('codiff --share');
   expect(text).toContain('codiff --share HEAD');
   expect(text).toContain('codiff pr owner:feature');
+  expect(text).toContain('codiff ado 75');
 });
 
 test('formatHelpText styles titles and descriptions', () => {

--- a/core/app/components/OpenReviewSourceDialog.tsx
+++ b/core/app/components/OpenReviewSourceDialog.tsx
@@ -19,7 +19,7 @@ const dialogCopy: Record<
     title: 'Open Commit',
   },
   'pull-request': {
-    description: 'Paste a PR number or a GitHub or GitLab pull request link.',
+    description: 'Paste a PR number or a GitHub, GitLab, or Azure DevOps pull request link.',
     label: 'Pull request',
     placeholder: '#123 or https://github.com/owner/repo/pull/123',
     title: 'Open PR',

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -496,7 +496,7 @@ function ReadOnlyMarkdown({
 }
 
 const getPullRequestDescriptionLabel = (source: Extract<ReviewSource, { type: 'pull-request' }>) =>
-  source.provider === 'github'
+  source.provider === 'github' || source.provider === 'azure-devops'
     ? 'PR description'
     : source.provider === 'gitlab'
       ? 'MR description'
@@ -3123,7 +3123,9 @@ export function ReviewCodeView({
   }, []);
 
   const canCreateFileComments =
-    !isReadOnly && source.type === 'pull-request' && source.provider === 'gitlab';
+    !isReadOnly &&
+    source.type === 'pull-request' &&
+    (source.provider === 'gitlab' || source.provider === 'azure-devops');
 
   const createFileComment = useCallback(
     (meta: CodeViewItemMetadata, itemId: string) => {

--- a/core/lib/source.ts
+++ b/core/lib/source.ts
@@ -123,7 +123,9 @@ export const getSourceLabel = (source: ReviewSource) =>
               ? `${source.provider === 'gitlab' ? 'MR' : 'PR'} #${source.number}`
               : source.provider === 'gitlab'
                 ? 'Merge request'
-                : 'Pull request'
+                : source.provider === 'azure-devops'
+                  ? 'Azure DevOps pull request'
+                  : 'Pull request'
             : 'Uncommitted';
 
 export const getHistorySource = (source: ReviewSource): ReviewSource | undefined =>

--- a/core/types.ts
+++ b/core/types.ts
@@ -165,7 +165,7 @@ export type ReviewSource =
       number?: number;
       owner?: string;
       projectPath?: string;
-      provider?: 'github' | 'gitlab';
+      provider?: 'github' | 'gitlab' | 'azure-devops';
       repo?: string;
       reviewers?: ReadonlyArray<PullRequestReviewer>;
       reviewStatus?: PullRequestReviewStatus;

--- a/electron/__tests__/command-line.test.ts
+++ b/electron/__tests__/command-line.test.ts
@@ -395,6 +395,20 @@ test('canonicalizes GitLab merge request URLs copied from a review tab', () => {
   }
 });
 
+test('canonicalizes Azure DevOps pull request URLs copied from a review tab', () => {
+  for (const value of [
+    'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492?_a=files',
+    'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492?discussionId=18',
+    'dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullRequest/492',
+  ]) {
+    expect(readCommandLine(['codiff', value, '/repo']).launchOptions.source).toEqual({
+      provider: 'azure-devops',
+      type: 'pull-request',
+      url: 'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+    });
+  }
+});
+
 test('resolves GitHub and GitLab review markers through repository remotes', async () => {
   await using directory = await createTemporaryDirectory('codiff-review-markers-');
   const githubRepo = join(directory.path, 'github');
@@ -425,6 +439,31 @@ test('resolves GitHub and GitLab review markers through repository remotes', asy
     provider: 'gitlab',
     type: 'pull-request',
     url: 'https://gitlab.example.com/group/subgroup/project/-/merge_requests/23',
+  });
+});
+
+test('resolves Azure DevOps review markers through repository remotes', async () => {
+  await using directory = await createTemporaryDirectory('codiff-azure-review-markers-');
+  const azureRepo = join(directory.path, 'azure');
+
+  await mkdir(azureRepo);
+  await git(azureRepo, ['init']);
+  await git(azureRepo, [
+    'remote',
+    'add',
+    'origin',
+    'git@ssh.dev.azure.com:v3/mpc-tech-hub/MPCM/Dashboard',
+  ]);
+
+  expect(getCommandLineLaunchOptions(['codiff', 'ado', '492', azureRepo]).source).toEqual({
+    provider: 'azure-devops',
+    type: 'pull-request',
+    url: 'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+  });
+  expect(getCommandLineLaunchOptions(['codiff', 'pr', '492', azureRepo]).source).toEqual({
+    provider: 'azure-devops',
+    type: 'pull-request',
+    url: 'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
   });
 });
 

--- a/electron/__tests__/review-source.test.ts
+++ b/electron/__tests__/review-source.test.ts
@@ -3,13 +3,24 @@ import { expect, test } from 'vite-plus/test';
 
 const require = createRequire(import.meta.url);
 
-const { parseReviewUrl } = require('../review-source.cjs') as {
+const { parseReviewUrl, parseRemoteUrl } = require('../review-source.cjs') as {
+  parseRemoteUrl: (value: string) => {
+    host: string;
+    organization?: string;
+    project?: string;
+    projectPath: string;
+    provider: 'github' | 'gitlab' | 'azure-devops';
+    repo?: string;
+    webHost?: string;
+  } | null;
   parseReviewUrl: (value: string) => {
     host: string;
     number: number;
+    organization?: string;
     owner?: string;
+    project?: string;
     projectPath: string;
-    provider: 'github' | 'gitlab';
+    provider: 'github' | 'gitlab' | 'azure-devops';
     repo?: string;
     url: string;
   } | null;
@@ -124,8 +135,90 @@ test('parseReviewUrl rejects values that are not review URLs', () => {
     'https://github.com/nkzw-tech/codiff/pull/abc',
     'https://github.com/nkzw-tech/codiff/issues/1728',
     'https://example.com/nkzw-tech/codiff/pull/1728',
+    'https://dev.azure.com/org/project/_git/repo',
     'some/local/path/merge_requests/23',
   ]) {
     expect(parseReviewUrl(value)).toBe(null);
   }
+});
+
+test('parseReviewUrl reads Azure DevOps pull request URLs', () => {
+  expect(
+    parseReviewUrl('https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492'),
+  ).toMatchObject({
+    host: 'dev.azure.com',
+    number: 492,
+    organization: 'mpc-tech-hub',
+    project: 'MPCM',
+    projectPath: 'mpc-tech-hub/MPCM/Dashboard',
+    provider: 'azure-devops',
+    repo: 'Dashboard',
+    url: 'https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard/pullrequest/492',
+  });
+});
+
+test('parseReviewUrl ignores Azure DevOps tab segments, queries and fragments', () => {
+  for (const value of [
+    'https://dev.azure.com/org/project/_git/repo/pullrequest/42/',
+    'https://dev.azure.com/org/project/_git/repo/pullrequest/42?_a=files',
+    'https://dev.azure.com/org/project/_git/repo/pullrequest/42?discussionId=18',
+    'https://dev.azure.com/org/project/_git/repo/pullrequest/42#_a=overview',
+    'dev.azure.com/org/project/_git/repo/pullrequest/42?path=/src/a.ts',
+    '<https://dev.azure.com/org/project/_git/repo/pullRequest/42>',
+  ]) {
+    expect(parseReviewUrl(value)).toMatchObject({
+      number: 42,
+      provider: 'azure-devops',
+      url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/42',
+    });
+  }
+});
+
+test('parseReviewUrl reads visualstudio.com Azure DevOps pull request URLs', () => {
+  expect(
+    parseReviewUrl('https://contoso.visualstudio.com/Fabrikam/_git/Widgets/pullrequest/9'),
+  ).toMatchObject({
+    host: 'contoso.visualstudio.com',
+    number: 9,
+    organization: 'contoso',
+    project: 'Fabrikam',
+    provider: 'azure-devops',
+    repo: 'Widgets',
+    url: 'https://contoso.visualstudio.com/Fabrikam/_git/Widgets/pullrequest/9',
+  });
+});
+
+test('parseRemoteUrl classifies Azure DevOps HTTPS and SSH remotes', () => {
+  expect(parseRemoteUrl('https://dev.azure.com/mpc-tech-hub/MPCM/_git/Dashboard')).toMatchObject({
+    organization: 'mpc-tech-hub',
+    project: 'MPCM',
+    provider: 'azure-devops',
+    repo: 'Dashboard',
+    webHost: 'dev.azure.com',
+  });
+  expect(parseRemoteUrl('git@ssh.dev.azure.com:v3/mpc-tech-hub/MPCM/Dashboard')).toMatchObject({
+    organization: 'mpc-tech-hub',
+    project: 'MPCM',
+    provider: 'azure-devops',
+    repo: 'Dashboard',
+    webHost: 'dev.azure.com',
+  });
+  expect(
+    parseRemoteUrl('git@vs-ssh.visualstudio.com:v3/contoso/Fabrikam/Widgets.git'),
+  ).toMatchObject({
+    organization: 'contoso',
+    project: 'Fabrikam',
+    provider: 'azure-devops',
+    repo: 'Widgets',
+    webHost: 'contoso.visualstudio.com',
+  });
+  expect(
+    parseRemoteUrl('vsshadmin@contoso@vs-ssh.visualstudio.com:v3/contoso/Fabrikam/Widgets.git'),
+  ).toMatchObject({
+    organization: 'contoso',
+    project: 'Fabrikam',
+    provider: 'azure-devops',
+    repo: 'Widgets',
+    webHost: 'contoso.visualstudio.com',
+  });
 });

--- a/electron/git-state.cjs
+++ b/electron/git-state.cjs
@@ -48,6 +48,14 @@ const {
   submitMergeRequestComment,
   submitMergeRequestReview,
 } = require('./git-state/merge-request.cjs');
+const {
+  listAzureDevOpsHistory,
+  parseAzureDevOpsPullRequestUrl,
+  readAzureDevOpsImageContent,
+  readAzureDevOpsPullRequestState,
+  submitAzureDevOpsComment,
+  submitAzureDevOpsReview,
+} = require('./git-state/azure-devops.cjs');
 const { parseReviewUrl } = require('./review-source.cjs');
 const {
   readDiffSectionContent: readWorkingTreeDiffSectionContent,
@@ -71,10 +79,7 @@ const { annotateGeneratedFiles } = require('./generated-files.cjs');
 const readRepositoryState = async (launchPath, source = { type: 'working-tree' }, options = {}) => {
   const state =
     source.type === 'pull-request'
-      ? await (isGitLabReviewSource(source) ? readMergeRequestState : readPullRequestState)(
-          launchPath,
-          source,
-        )
+      ? await getPullRequestStateReader(source)(launchPath, source)
       : source.type === 'commit'
         ? await readCommitState(launchPath, source.ref)
         : source.type === 'range'
@@ -150,8 +155,53 @@ const readWalkthroughRepositoryState = async (launchPath, source, options = {}) 
 };
 
 /** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
-const isGitLabReviewSource = (source) =>
-  source.provider === 'gitlab' || parseReviewUrl(source.url)?.provider === 'gitlab';
+const getReviewProvider = (source) => parseReviewUrl(source.url)?.provider || source.provider;
+
+/** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
+const isGitLabReviewSource = (source) => getReviewProvider(source) === 'gitlab';
+
+/** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
+const isAzureDevOpsReviewSource = (source) => getReviewProvider(source) === 'azure-devops';
+
+/** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
+const getPullRequestStateReader = (source) =>
+  isGitLabReviewSource(source)
+    ? readMergeRequestState
+    : isAzureDevOpsReviewSource(source)
+      ? readAzureDevOpsPullRequestState
+      : readPullRequestState;
+
+/** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
+const getPullRequestHistoryReader = (source) =>
+  isGitLabReviewSource(source)
+    ? listMergeRequestHistory
+    : isAzureDevOpsReviewSource(source)
+      ? listAzureDevOpsHistory
+      : listPullRequestHistory;
+
+/** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
+const getPullRequestImageReader = (source) =>
+  isGitLabReviewSource(source)
+    ? readMergeRequestImageContent
+    : isAzureDevOpsReviewSource(source)
+      ? readAzureDevOpsImageContent
+      : readPullRequestImageContent;
+
+/** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
+const getPullRequestCommentSubmitter = (source) =>
+  isGitLabReviewSource(source)
+    ? submitMergeRequestComment
+    : isAzureDevOpsReviewSource(source)
+      ? submitAzureDevOpsComment
+      : submitPullRequestComment;
+
+/** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
+const getPullRequestReviewSubmitter = (source) =>
+  isGitLabReviewSource(source)
+    ? submitMergeRequestReview
+    : isAzureDevOpsReviewSource(source)
+      ? submitAzureDevOpsReview
+      : submitPullRequestReview;
 
 /** @param {Extract<ReviewSource, {type: 'branch' | 'branch-diff' | 'branch-working-tree'}>} source */
 const getBranchHistoryRef = (source) =>
@@ -162,11 +212,7 @@ const getBranchHistoryRef = (source) =>
 /** @param {string} launchPath @param {number} [limit] @param {ReviewSource} [source] @returns {Promise<RepositoryHistory>} */
 const readRepositoryHistory = (launchPath, limit, source) =>
   source?.type === 'pull-request'
-    ? (isGitLabReviewSource(source) ? listMergeRequestHistory : listPullRequestHistory)(
-        launchPath,
-        source,
-        limit,
-      )
+    ? getPullRequestHistoryReader(source)(launchPath, source, limit)
     : listRepositoryHistory(
         launchPath,
         limit,
@@ -203,9 +249,7 @@ const readDiffSectionContent = async (launchPath, request) =>
 /** @param {string} launchPath @param {DiffImageContentRequest} request @returns {Promise<DiffImageContentResult>} */
 const readDiffImageContent = (launchPath, request) =>
   request.source?.type === 'pull-request'
-    ? (isGitLabReviewSource(request.source)
-        ? readMergeRequestImageContent
-        : readPullRequestImageContent)(launchPath, request.source, request.path)
+    ? getPullRequestImageReader(request.source)(launchPath, request.source, request.path)
     : request.source?.type === 'range'
       ? readRangeImageContent(
           launchPath,
@@ -237,6 +281,7 @@ module.exports = {
   normalizeGitLabReviewComment,
   normalizePullRequestComment,
   parseStatus,
+  parseAzureDevOpsPullRequestUrl,
   parseGitHubPullRequestUrl,
   parseGitLabMergeRequestUrl,
   selectUnresolvedReviewComments,
@@ -252,14 +297,8 @@ module.exports = {
   readWorkingTreeState,
   resolvePullRequestContentRefs,
   submitPullRequestComment: (launchPath, request) =>
-    (isGitLabReviewSource(request.source) ? submitMergeRequestComment : submitPullRequestComment)(
-      launchPath,
-      request,
-    ),
+    getPullRequestCommentSubmitter(request.source)(launchPath, request),
   submitPullRequestReview: (launchPath, request) =>
-    (isGitLabReviewSource(request.source) ? submitMergeRequestReview : submitPullRequestReview)(
-      launchPath,
-      request,
-    ),
+    getPullRequestReviewSubmitter(request.source)(launchPath, request),
   validateRepositoryPath,
 };

--- a/electron/git-state/azure-devops.cjs
+++ b/electron/git-state/azure-devops.cjs
@@ -1,0 +1,772 @@
+// @ts-check
+
+const { spawn } = require('node:child_process');
+const { homedir } = require('node:os');
+const { join } = require('node:path');
+const { findExecutableOnPath, isExecutableFile } = require('../agent-shared.cjs');
+const { getCommandEnvironment } = require('../login-shell-environment.cjs');
+const {
+  getFingerprint,
+  git,
+  gitOrEmpty,
+  readGitImageFile,
+  validateRepositoryPath,
+} = require('./common.cjs');
+const { readGitFiles } = require('./git-files.cjs');
+const {
+  createPatchFromPullRequestFile,
+  createPullRequestSection,
+  normalizeGitHubCommit,
+} = require('./pull-request.cjs');
+const { parseReviewUrl, readReviewRemotes } = require('../review-source.cjs');
+
+/**
+ * @typedef {import('../../core/types.ts').ChangedFile} ChangedFile
+ * @typedef {import('../../core/types.ts').PullRequestReviewComment} PullRequestReviewComment
+ * @typedef {import('../../core/types.ts').ReviewSource} ReviewSource
+ */
+
+const AZURE_DEVOPS_RESOURCE = '499b84ac-1321-427f-aa17-267ca6975798';
+const AZURE_DEVOPS_API_VERSION = '7.1';
+const AZ_NOT_FOUND_CODE = 'AZ_NOT_FOUND';
+const AZ_NOT_FOUND_MESSAGE =
+  'Azure DevOps support requires az. Install the Azure CLI, run `az login`, and verify `az --version` works in Terminal. Codiff searches PATH, ~/.local/bin/az, /opt/homebrew/bin/az, and /usr/local/bin/az. If az is installed somewhere else, launch Codiff with `CODIFF_AZ_PATH=/absolute/path/to/az codiff`.';
+
+const CLOSED_THREAD_STATUSES = new Set([
+  'bydesign',
+  'closed',
+  'fixed',
+  'wontfix',
+  2,
+  3,
+  4,
+  5,
+  '2',
+  '3',
+  '4',
+  '5',
+]);
+
+/** @param {string} [detail] */
+const createAzNotFoundError = (detail) =>
+  Object.assign(new Error(detail ? `${AZ_NOT_FOUND_MESSAGE} ${detail}` : AZ_NOT_FOUND_MESSAGE), {
+    code: AZ_NOT_FOUND_CODE,
+  });
+
+const getAzCommand = () => {
+  const azPath = process.env.CODIFF_AZ_PATH?.trim();
+  if (azPath) {
+    if (isExecutableFile(azPath)) {
+      return azPath;
+    }
+
+    throw createAzNotFoundError(
+      `CODIFF_AZ_PATH is set to ${JSON.stringify(azPath)}, but that file is not executable.`,
+    );
+  }
+
+  const pathCommand = findExecutableOnPath('az');
+  if (pathCommand) {
+    return pathCommand;
+  }
+
+  for (const path of [
+    join(homedir(), '.local/bin/az'),
+    '/opt/homebrew/bin/az',
+    '/usr/local/bin/az',
+  ]) {
+    if (isExecutableFile(path)) {
+      return path;
+    }
+  }
+
+  throw createAzNotFoundError();
+};
+
+/** @param {string} value */
+const parseAzureDevOpsPullRequestUrl = (value) => {
+  const parsed = parseReviewUrl(value);
+  if (!parsed || parsed.provider !== 'azure-devops') {
+    throw new Error('Codiff expected an Azure DevOps pull request URL.');
+  }
+  return parsed;
+};
+
+/**
+ * @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest
+ * @param {string} [suffix]
+ * @param {string} [query]
+ */
+const pullRequestEndpoint = (pullRequest, suffix = '', query = '') => {
+  const extra = query ? `&${query}` : '';
+  return `${pullRequest.apiBase}/_apis/git/repositories/${encodeURIComponent(
+    pullRequest.repo,
+  )}/pullRequests/${pullRequest.number}${suffix}?api-version=${AZURE_DEVOPS_API_VERSION}${extra}`;
+};
+
+/** @param {string} value */
+const stripLeadingSlash = (value) => value.replace(/^\/+/, '');
+
+/** @param {string} repoRoot @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest */
+const selectAzureDevOpsRemote = (repoRoot, pullRequest) => {
+  const remote = readReviewRemotes(repoRoot)
+    .filter(
+      (candidate) =>
+        candidate.provider === 'azure-devops' &&
+        candidate.organization?.toLowerCase() === pullRequest.organization.toLowerCase() &&
+        candidate.project?.toLowerCase() === pullRequest.project.toLowerCase() &&
+        candidate.repo?.toLowerCase() === pullRequest.repo.toLowerCase(),
+    )
+    .sort((left, right) =>
+      left.name === right.name
+        ? left.direction === 'fetch'
+          ? -1
+          : 1
+        : left.name === 'origin'
+          ? -1
+          : 1,
+    )[0];
+  if (!remote) {
+    throw new Error(
+      `Pull request ${pullRequest.projectPath}#${pullRequest.number} does not match an Azure DevOps remote in this repository.`,
+    );
+  }
+  return remote;
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {ReadonlyArray<string>} args
+ */
+const azRest = async (repoRoot, args) => {
+  const environment = await getCommandEnvironment();
+  return new Promise((resolve, reject) => {
+    let command;
+    try {
+      command = getAzCommand();
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env: environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const stdout = [];
+    const stderr = [];
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.stderr.on('data', (chunk) => stderr.push(chunk));
+    child.on('error', (error) => {
+      reject(error.code === 'ENOENT' ? createAzNotFoundError() : error);
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(Buffer.concat(stdout).toString('utf8'));
+      } else {
+        reject(
+          new Error(
+            Buffer.concat(stderr).toString('utf8').trim() || `az rest exited with code ${code}.`,
+          ),
+        );
+      }
+    });
+  });
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest
+ * @param {string} uri
+ * @param {string} [method]
+ * @param {unknown} [body]
+ */
+const azureApi = async (repoRoot, pullRequest, uri, method = 'GET', body) => {
+  const args = [
+    'rest',
+    '--method',
+    method,
+    '--uri',
+    uri,
+    '--resource',
+    AZURE_DEVOPS_RESOURCE,
+    ...(body == null
+      ? []
+      : ['--headers', 'Content-Type=application/json', '--body', JSON.stringify(body)]),
+  ];
+  const output = await azRest(repoRoot, args);
+  const trimmed = output.trim();
+  return trimmed ? JSON.parse(trimmed) : null;
+};
+
+/** @param {string} repoRoot @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest */
+const readPullRequestMetadata = (repoRoot, pullRequest) =>
+  azureApi(repoRoot, pullRequest, pullRequestEndpoint(pullRequest));
+
+/** @param {string} repoRoot @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest */
+const readPullRequestThreads = async (repoRoot, pullRequest) => {
+  const payload = await azureApi(
+    repoRoot,
+    pullRequest,
+    pullRequestEndpoint(pullRequest, '/threads', '$top=200'),
+  );
+  return Array.isArray(payload?.value) ? payload.value : [];
+};
+
+/** @param {string} repoRoot @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest */
+const readPullRequestCommits = async (repoRoot, pullRequest) => {
+  const payload = await azureApi(
+    repoRoot,
+    pullRequest,
+    pullRequestEndpoint(pullRequest, '/commits', '$top=200'),
+  );
+  return Array.isArray(payload?.value) ? payload.value : [];
+};
+
+/** @param {any} author */
+const normalizeAzureAuthor = (author) => ({
+  avatarUrl: author?.imageUrl,
+  login: author?.uniqueName || author?.displayName || 'Azure DevOps user',
+  url: author?._links?.web?.href || author?.url,
+});
+
+/** @param {any} threadContext @param {string} [filePath] */
+const getAzureThreadLocation = (threadContext, filePath) => {
+  if (!filePath) {
+    return null;
+  }
+  const rightStart = threadContext?.rightFileStart?.line;
+  const rightEnd = threadContext?.rightFileEnd?.line;
+  const leftStart = threadContext?.leftFileStart?.line;
+  const leftEnd = threadContext?.leftFileEnd?.line;
+  const hasRight = typeof rightEnd === 'number' || typeof rightStart === 'number';
+  const hasLeft = typeof leftEnd === 'number' || typeof leftStart === 'number';
+  if (!hasRight && !hasLeft) {
+    return { anchor: /** @type {const} */ ('file'), filePath };
+  }
+
+  const side = hasRight ? /** @type {const} */ ('additions') : /** @type {const} */ ('deletions');
+  const start = hasRight ? rightStart : leftStart;
+  const end = hasRight ? (rightEnd ?? rightStart) : (leftEnd ?? leftStart);
+  return {
+    filePath,
+    lineNumber: end,
+    side,
+    ...(typeof start === 'number' && start !== end
+      ? { startLineNumber: start, startSide: side }
+      : {}),
+  };
+};
+
+/** @param {any} comment @param {any} thread @param {string} url */
+const normalizeAzureDevOpsReviewComment = (comment, thread, url) => {
+  if (!comment?.content || comment.commentType === 'system' || comment.commentType === 3) {
+    return null;
+  }
+  const filePath = thread.threadContext?.filePath
+    ? stripLeadingSlash(thread.threadContext.filePath)
+    : '';
+  const location = getAzureThreadLocation(thread.threadContext, filePath);
+  if (!location) {
+    return null;
+  }
+  return {
+    author: normalizeAzureAuthor(comment.author),
+    body: comment.content,
+    ...location,
+    id: `azure-devops:${thread.id}:${comment.id}`,
+    submittedAt: comment.publishedDate || comment.lastContentUpdatedDate,
+    threadId: String(thread.id),
+    url: `${url}?discussionId=${thread.id}`,
+  };
+};
+
+/** @param {any} comment @param {PullRequestReviewComment} submittedComment @param {any} thread @param {string} url */
+const normalizeSubmittedAzureDevOpsReviewComment = (comment, submittedComment, thread, url) => {
+  const normalized = normalizeAzureDevOpsReviewComment(comment, thread, url);
+  if (normalized) {
+    return normalized;
+  }
+  if (!comment?.content || comment.id == null) {
+    return null;
+  }
+  return {
+    ...submittedComment,
+    author: normalizeAzureAuthor(comment.author),
+    body: comment.content,
+    id: `azure-devops:${thread.id}:${comment.id}`,
+    submittedAt: comment.publishedDate || comment.lastContentUpdatedDate,
+    threadId: String(thread.id),
+    url: `${url}?discussionId=${thread.id}`,
+  };
+};
+
+/** @param {string} repoRoot @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest */
+const readAzureDevOpsComments = async (repoRoot, pullRequest) => {
+  const threads = await readPullRequestThreads(repoRoot, pullRequest);
+  return threads
+    .filter((thread) => !CLOSED_THREAD_STATUSES.has(thread.status) && !thread.isDeleted)
+    .flatMap((thread) =>
+      (thread.comments || [])
+        .filter((comment) => !comment.isDeleted)
+        .map((comment) => normalizeAzureDevOpsReviewComment(comment, thread, pullRequest.url)),
+    )
+    .filter(Boolean);
+};
+
+/** @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest @param {any} metadata @returns {Extract<ReviewSource, {type: 'pull-request'}>} */
+const createAzureDevOpsSource = (pullRequest, metadata) => ({
+  ...(metadata.createdBy?.displayName || metadata.createdBy?.uniqueName
+    ? { author: normalizeAzureAuthor(metadata.createdBy) }
+    : {}),
+  ...(typeof metadata.description === 'string' && metadata.description.trim()
+    ? { description: metadata.description.trim() }
+    : {}),
+  headSha: metadata.lastMergeSourceCommit?.commitId || metadata.lastMergeCommit?.commitId,
+  host: pullRequest.host,
+  number: pullRequest.number,
+  owner: pullRequest.organization,
+  projectPath: pullRequest.projectPath,
+  provider: 'azure-devops',
+  repo: pullRequest.repo,
+  title: metadata.title,
+  type: 'pull-request',
+  url: pullRequest.url,
+});
+
+/** @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest @param {any} metadata */
+const createAzureDevOpsFetchRefspecs = (pullRequest, metadata) => [
+  `+refs/pull/${pullRequest.number}/head:refs/codiff/pull-requests/${pullRequest.number}/head`,
+  ...(metadata.targetRefName
+    ? [`+${metadata.targetRefName}:refs/codiff/pull-requests/${pullRequest.number}/base`]
+    : []),
+];
+
+/** @param {string} repoRoot @param {any} remote @param {any} pullRequest @param {any} metadata */
+const fetchAzureDevOpsRefs = (repoRoot, remote, pullRequest, metadata) =>
+  git(repoRoot, [
+    'fetch',
+    '--no-tags',
+    remote.name,
+    ...createAzureDevOpsFetchRefspecs(pullRequest, metadata),
+  ]);
+
+/** @param {string} repoRoot @param {any} pullRequest @param {any} metadata */
+const resolveAzureDevOpsContentRefs = async (repoRoot, pullRequest, metadata) => {
+  const head = `refs/codiff/pull-requests/${pullRequest.number}/head`;
+  const base = `refs/codiff/pull-requests/${pullRequest.number}/base`;
+  const localHead = (await gitOrEmpty(repoRoot, ['rev-parse', '--verify', '--quiet', head])).trim();
+  const localBase = (await gitOrEmpty(repoRoot, ['rev-parse', '--verify', '--quiet', base])).trim();
+  const headSha = metadata.lastMergeSourceCommit?.commitId;
+  if (!localHead || !localBase || (headSha && localHead !== headSha)) {
+    await fetchAzureDevOpsRefs(
+      repoRoot,
+      selectAzureDevOpsRemote(repoRoot, pullRequest),
+      pullRequest,
+      metadata,
+    );
+  }
+  const metadataBase = metadata.lastMergeTargetCommit?.commitId;
+  if (
+    metadataBase &&
+    (await gitOrEmpty(repoRoot, ['rev-parse', '--verify', '--quiet', `${metadataBase}^{commit}`]))
+  ) {
+    return { base: metadataBase, head };
+  }
+  const mergeBase = (await gitOrEmpty(repoRoot, ['merge-base', base, head])).trim();
+  return mergeBase ? { base: mergeBase, head } : null;
+};
+
+/**
+ * @param {string} raw
+ * @returns {Array<{filename: string; previous_filename?: string; status: string}>}
+ */
+const parseNameStatusFiles = (raw) => {
+  const parts = raw.split('\0').filter(Boolean);
+  const files = [];
+  for (let index = 0; index < parts.length;) {
+    const statusCode = parts[index++];
+    const statusType = statusCode[0];
+    if (statusType === 'R' || statusType === 'C') {
+      const oldPath = parts[index++];
+      const path = parts[index++];
+      files.push({
+        filename: path,
+        previous_filename: oldPath,
+        status: 'renamed',
+      });
+    } else {
+      const path = parts[index++];
+      files.push({
+        filename: path,
+        status: statusType === 'A' ? 'added' : statusType === 'D' ? 'removed' : 'modified',
+      });
+    }
+  }
+  return files;
+};
+
+/**
+ * @param {string} repoRoot
+ * @param {string} oldRef
+ * @param {string} newRef
+ * @param {ReadonlyArray<string>} paths
+ */
+const readAzureDevOpsPatches = async (repoRoot, oldRef, newRef, paths) => {
+  /** @type {Map<string, string>} */
+  const patches = new Map();
+  if (paths.length === 0) {
+    return patches;
+  }
+
+  const raw = await git(repoRoot, [
+    'diff',
+    '--patch',
+    '--no-ext-diff',
+    '--find-renames',
+    oldRef,
+    newRef,
+    '--',
+    ...paths,
+  ]);
+  const chunks = raw
+    .split(/(?=^diff --git )/m)
+    .map((chunk) => chunk.trimEnd())
+    .filter((chunk) => chunk.startsWith('diff --git '));
+  for (const chunk of chunks) {
+    const newPath = chunk.match(/^\+\+\+\s+b\/(.+)$/m)?.[1];
+    const oldPath = chunk.match(/^---\s+a\/(.+)$/m)?.[1];
+    const renamePath = chunk.match(/^rename to (.+)$/m)?.[1];
+    const path = newPath && newPath !== '/dev/null' ? newPath : renamePath || oldPath;
+    if (path) {
+      patches.set(path, `${chunk}\n`);
+    }
+  }
+  return patches;
+};
+
+/** @param {string} launchPath @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
+const readAzureDevOpsPullRequestState = async (launchPath, source) => {
+  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
+  const pullRequest = parseAzureDevOpsPullRequestUrl(source.url);
+  selectAzureDevOpsRemote(repoRoot, pullRequest);
+  const [metadata, reviewComments] = await Promise.all([
+    readPullRequestMetadata(repoRoot, pullRequest),
+    readAzureDevOpsComments(repoRoot, pullRequest),
+  ]);
+  const refs = await resolveAzureDevOpsContentRefs(repoRoot, pullRequest, metadata);
+  if (!refs) {
+    throw new Error(
+      `Could not fetch Azure DevOps pull request #${pullRequest.number} refs. Check that this repository's remote can access the pull request.`,
+    );
+  }
+  const files = parseNameStatusFiles(
+    await git(repoRoot, ['diff', '--name-status', '-r', '-z', '-M', refs.base, refs.head]),
+  );
+  const patches = await readAzureDevOpsPatches(
+    repoRoot,
+    refs.base,
+    refs.head,
+    files.map((file) => file.filename),
+  );
+  const reviewFiles = files.map((file) => ({
+    file,
+    oldPath: file.previous_filename || file.filename,
+    patch: patches.get(file.filename) || createPatchFromPullRequestFile(file),
+  }));
+  const [oldFiles, newFiles] = await Promise.all([
+    readGitFiles(
+      repoRoot,
+      refs.base,
+      reviewFiles.map(({ oldPath }) => oldPath),
+      { refScopedEmptyCacheKey: true },
+    ),
+    readGitFiles(
+      repoRoot,
+      refs.head,
+      reviewFiles.map(({ file }) => file.filename),
+      { refScopedEmptyCacheKey: true },
+    ),
+  ]);
+  /** @type {Array<ChangedFile>} */
+  const changedFiles = reviewFiles.map(({ file, oldPath, patch }) => {
+    const oldFile = oldFiles.get(oldPath);
+    const newFile = newFiles.get(file.filename);
+    const section = createPullRequestSection(pullRequest, file, patch, oldFile, newFile);
+    return {
+      fingerprint: getFingerprint(
+        [
+          metadata.lastMergeSourceCommit?.commitId || '',
+          file.status,
+          file.previous_filename || '',
+          file.filename,
+          patch,
+        ].join('\n'),
+      ),
+      oldPath: file.previous_filename,
+      path: file.filename,
+      sections: [section],
+      status:
+        file.status === 'added'
+          ? 'added'
+          : file.status === 'removed'
+            ? 'deleted'
+            : file.status === 'renamed'
+              ? 'renamed'
+              : 'modified',
+    };
+  });
+  return {
+    files: changedFiles.sort((left, right) => left.path.localeCompare(right.path)),
+    generatedAt: Date.now(),
+    launchPath,
+    reviewComments,
+    root: repoRoot,
+    source: createAzureDevOpsSource(pullRequest, metadata),
+  };
+};
+
+/** @param {any} commit @param {'base' | 'pull-request'} scope */
+const normalizeAzureDevOpsCommit = (commit, scope) =>
+  normalizeGitHubCommit(
+    {
+      author: { avatar_url: undefined },
+      commit: {
+        author: {
+          date: commit.author?.date || commit.committer?.date,
+          name: commit.author?.name || commit.committer?.name,
+        },
+        message: commit.comment || commit.commentTruncated,
+      },
+      parents: (commit.parents || []).map((parent) => ({
+        sha: typeof parent === 'string' ? parent : parent.commitId || parent.sha,
+      })),
+      sha: commit.commitId || commit.sha,
+    },
+    scope,
+  );
+
+/** @param {string} launchPath @param {Extract<ReviewSource, {type: 'pull-request'}>} source @param {number} [limit] */
+const listAzureDevOpsHistory = async (launchPath, source, limit = 200) => {
+  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
+  const pullRequest = parseAzureDevOpsPullRequestUrl(source.url);
+  const metadata = await readPullRequestMetadata(repoRoot, pullRequest);
+  const commits = await readPullRequestCommits(repoRoot, pullRequest);
+  let baseCommits = [];
+  const refs = await resolveAzureDevOpsContentRefs(repoRoot, pullRequest, metadata).catch(
+    () => null,
+  );
+  if (refs?.base) {
+    const raw = await gitOrEmpty(repoRoot, [
+      'log',
+      `--max-count=${limit}`,
+      '--format=%H%x00%an%x00%aI%x00%s%x00%P',
+      refs.base,
+    ]);
+    baseCommits = raw
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const [sha, name, date, subject, parents] = line.split('\0');
+        return normalizeGitHubCommit(
+          {
+            commit: { author: { date, name }, message: subject },
+            parents: (parents || '')
+              .split(' ')
+              .filter(Boolean)
+              .map((parent) => ({ sha: parent })),
+            sha,
+          },
+          'base',
+        );
+      })
+      .filter(Boolean);
+  }
+  return {
+    entries: [
+      ...commits
+        .map((commit) => normalizeAzureDevOpsCommit(commit, 'pull-request'))
+        .filter(Boolean)
+        .reverse(),
+      ...baseCommits,
+    ],
+    root: repoRoot,
+  };
+};
+
+/** @param {PullRequestReviewComment} comment */
+const createAzureDevOpsThreadContext = (comment) => {
+  const filePath = `/${comment.filePath.replace(/^\/+/, '')}`;
+  if (comment.anchor === 'file' || comment.lineNumber == null || comment.side == null) {
+    return { filePath };
+  }
+
+  const end = { line: comment.lineNumber, offset: 1 };
+  const start =
+    typeof comment.startLineNumber === 'number'
+      ? { line: comment.startLineNumber, offset: 1 }
+      : end;
+  return comment.side === 'deletions'
+    ? { filePath, leftFileEnd: end, leftFileStart: start }
+    : { filePath, rightFileEnd: end, rightFileStart: start };
+};
+
+/** @param {unknown} event */
+const getAzureDevOpsVote = (event) => {
+  if (event === 'APPROVE') {
+    return 10;
+  }
+  if (event === 'REQUEST_CHANGES') {
+    return -10;
+  }
+  if (event === 'COMMENT') {
+    return 0;
+  }
+  throw new Error(`Azure DevOps pull request reviews do not support ${String(event)}.`);
+};
+
+/** @param {string} repoRoot @param {ReturnType<typeof parseAzureDevOpsPullRequestUrl>} pullRequest */
+const readAuthenticatedUserId = async (repoRoot, pullRequest) => {
+  const payload = await azureApi(
+    repoRoot,
+    pullRequest,
+    `${pullRequest.organizationUrl}/_apis/connectionData?api-version=${AZURE_DEVOPS_API_VERSION}`,
+  );
+  const id = payload?.authenticatedUser?.id || payload?.authenticatedUser?.descriptor;
+  if (!id) {
+    throw new Error('Azure DevOps did not return the signed-in user needed to vote on a review.');
+  }
+  return id;
+};
+
+/** @param {string} launchPath @param {any} request */
+const submitAzureDevOpsComment = async (launchPath, request) => {
+  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
+  const pullRequest = parseAzureDevOpsPullRequestUrl(request.source.url);
+  selectAzureDevOpsRemote(repoRoot, pullRequest);
+  if (request.comment.threadId) {
+    const comment = await azureApi(
+      repoRoot,
+      pullRequest,
+      pullRequestEndpoint(
+        pullRequest,
+        `/threads/${encodeURIComponent(request.comment.threadId)}/comments`,
+      ),
+      'POST',
+      { content: request.comment.body, parentCommentId: 0 },
+    );
+    const normalized = normalizeSubmittedAzureDevOpsReviewComment(
+      comment,
+      request.comment,
+      { id: request.comment.threadId, threadContext: { filePath: `/${request.comment.filePath}` } },
+      pullRequest.url,
+    );
+    if (!normalized) {
+      throw new Error('Azure DevOps accepted the reply but did not return comment metadata.');
+    }
+    return normalized;
+  }
+
+  const thread = await azureApi(
+    repoRoot,
+    pullRequest,
+    pullRequestEndpoint(pullRequest, '/threads'),
+    'POST',
+    {
+      comments: [{ commentType: 1, content: request.comment.body, parentCommentId: 0 }],
+      status: 1,
+      threadContext: createAzureDevOpsThreadContext(request.comment),
+    },
+  );
+  const normalized = normalizeSubmittedAzureDevOpsReviewComment(
+    thread.comments?.[0],
+    request.comment,
+    thread,
+    pullRequest.url,
+  );
+  if (!normalized) {
+    throw new Error('Azure DevOps accepted the comment but did not return comment metadata.');
+  }
+  return normalized;
+};
+
+/** @param {string} launchPath @param {any} request */
+const submitAzureDevOpsReview = async (launchPath, request) => {
+  const vote = getAzureDevOpsVote(request.event);
+  const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
+  const pullRequest = parseAzureDevOpsPullRequestUrl(request.source.url);
+  selectAzureDevOpsRemote(repoRoot, pullRequest);
+  for (const comment of request.comments) {
+    await azureApi(repoRoot, pullRequest, pullRequestEndpoint(pullRequest, '/threads'), 'POST', {
+      comments: [{ commentType: 1, content: comment.body, parentCommentId: 0 }],
+      status: 1,
+      threadContext: createAzureDevOpsThreadContext(comment),
+    });
+  }
+  if (typeof request.body === 'string' && request.body.trim()) {
+    await azureApi(repoRoot, pullRequest, pullRequestEndpoint(pullRequest, '/threads'), 'POST', {
+      comments: [{ commentType: 1, content: request.body.trim(), parentCommentId: 0 }],
+      status: 1,
+    });
+  }
+  if (vote === 0) {
+    return;
+  }
+  const userId = await readAuthenticatedUserId(repoRoot, pullRequest);
+  await azureApi(
+    repoRoot,
+    pullRequest,
+    pullRequestEndpoint(pullRequest, `/reviewers/${encodeURIComponent(userId)}`),
+    'PUT',
+    { id: userId, vote },
+  );
+};
+
+/** @param {string} launchPath @param {Extract<ReviewSource, {type: 'pull-request'}>} source @param {string} requestedPath */
+const readAzureDevOpsImageContent = async (launchPath, source, requestedPath) => {
+  try {
+    const repoRoot = (await git(launchPath, ['rev-parse', '--show-toplevel'])).trim();
+    const path = validateRepositoryPath(requestedPath);
+    const pullRequest = parseAzureDevOpsPullRequestUrl(source.url);
+    const metadata = await readPullRequestMetadata(repoRoot, pullRequest);
+    const refs = await resolveAzureDevOpsContentRefs(repoRoot, pullRequest, metadata);
+    if (!refs) {
+      throw new Error('File is not part of this pull request.');
+    }
+    const files = parseNameStatusFiles(
+      await git(repoRoot, ['diff', '--name-status', '-r', '-z', '-M', refs.base, refs.head]),
+    );
+    const file = files.find((candidate) => candidate.filename === path);
+    if (!file) {
+      throw new Error('File is not part of this pull request.');
+    }
+    const [oldImage, newImage] = await Promise.all([
+      readGitImageFile(repoRoot, refs.base, file.previous_filename || file.filename),
+      readGitImageFile(repoRoot, refs.head, file.filename),
+    ]);
+    return oldImage || newImage
+      ? { ...(newImage ? { newImage } : {}), ...(oldImage ? { oldImage } : {}), status: 'ready' }
+      : { reason: 'Codiff could not load either side of this image.', status: 'unavailable' };
+  } catch (error) {
+    return {
+      reason: error instanceof Error ? error.message : 'Codiff could not load this image.',
+      status: 'unavailable',
+    };
+  }
+};
+
+module.exports = {
+  AZ_NOT_FOUND_CODE,
+  createAzureDevOpsFetchRefspecs,
+  createAzureDevOpsThreadContext,
+  getAzCommand,
+  listAzureDevOpsHistory,
+  normalizeAzureDevOpsReviewComment,
+  parseAzureDevOpsPullRequestUrl,
+  readAzureDevOpsImageContent,
+  readAzureDevOpsPullRequestState,
+  submitAzureDevOpsComment,
+  submitAzureDevOpsReview,
+};

--- a/electron/main/command-line.cjs
+++ b/electron/main/command-line.cjs
@@ -93,7 +93,9 @@ const getReviewProviderMarker = (arg) =>
     ? 'github'
     : /^(?:mr|merge-request)$/i.test(arg)
       ? 'gitlab'
-      : null;
+      : /^(?:ado|azdo|azure|azure-devops)$/i.test(arg)
+        ? 'azure-devops'
+        : null;
 
 /** Stores the canonical form so pasted review tabs, queries and anchors never reach the Git layer.
  * @param {string} arg */
@@ -299,7 +301,9 @@ const parseCommandLineArguments = (commandLine = process.argv) => {
     undefined;
   const sourcePullRequestNumber = envPullRequestNumber ?? pullRequestNumber;
   const sourceReviewProvider =
-    envReviewProvider === 'github' || envReviewProvider === 'gitlab'
+    envReviewProvider === 'github' ||
+    envReviewProvider === 'gitlab' ||
+    envReviewProvider === 'azure-devops'
       ? envReviewProvider
       : pullRequestProvider;
   const sourceRef = envCommitRef || commitRef;
@@ -375,20 +379,22 @@ const getCommandLineLaunchOptions = (commandLine = process.argv, fallbackPath = 
     return launchOptions;
   }
 
+  const url = resolvePullRequestUrl(
+    resolve(
+      (commandLine === process.argv ? process.env.CODIFF_REPOSITORY_PATH : '') ||
+        repositoryPath ||
+        fallbackPath,
+    ),
+    pullRequestNumber,
+    pullRequestProvider ?? undefined,
+  );
+  const resolvedProvider = parseReviewUrl(url)?.provider || pullRequestProvider;
   return {
     ...launchOptions,
     source: {
       type: 'pull-request',
-      url: resolvePullRequestUrl(
-        resolve(
-          (commandLine === process.argv ? process.env.CODIFF_REPOSITORY_PATH : '') ||
-            repositoryPath ||
-            fallbackPath,
-        ),
-        pullRequestNumber,
-        pullRequestProvider ?? undefined,
-      ),
-      ...(pullRequestProvider ? { provider: pullRequestProvider } : {}),
+      url,
+      ...(resolvedProvider ? { provider: resolvedProvider } : {}),
     },
   };
 };

--- a/electron/review-source.cjs
+++ b/electron/review-source.cjs
@@ -2,7 +2,7 @@
 
 const { execFileSync } = require('node:child_process');
 
-/** @typedef {'github' | 'gitlab'} ReviewProvider */
+/** @typedef {'github' | 'gitlab' | 'azure-devops'} ReviewProvider */
 
 // Reviews are usually pasted straight from a browser, so anything after the review number is a tab
 // (`/files`, `/changes`, `/diffs`), a query, or an anchor, and none of it identifies the review.
@@ -10,6 +10,10 @@ const gitHubPullRequestPattern = /^\/([^/]+)\/([^/]+)\/pull\/([1-9]\d*)(?:\/.*)?
 const gitLabMergeRequestPattern = /^\/(.+?)\/-\/merge_requests\/([1-9]\d*)(?:\/.*)?$/;
 // GitLab only introduced the `/-/` separator in 11.0; older instances and links still omit it.
 const legacyGitLabMergeRequestPattern = /^\/(.+?)\/merge_requests\/([1-9]\d*)(?:\/.*)?$/;
+const azureDevOpsPullRequestPattern =
+  /^\/(.+?)\/_git\/([^/]+)\/pullrequests?\/([1-9]\d*)(?:\/.*)?$/i;
+const azureDevOpsGitRemotePattern = /^(.+)\/_git\/([^/]+)$/i;
+const azureDevOpsSshRemotePattern = /^v3\/([^/]+)\/(.+)\/([^/]+)$/i;
 const markdownAutolinkPattern = /^<(.+)>$/;
 const schemePattern = /^[A-Za-z][A-Za-z\d+.-]*:/;
 // A scheme-less paste only counts as a URL when it starts with something host-shaped, so relative
@@ -18,6 +22,185 @@ const hostPrefixPattern = /^[^/\s:@]+\.[^/\s:@]+(?::\d+)?\//;
 
 /** @param {string} value */
 const stripGitSuffix = (value) => value.replace(/\.git$/i, '');
+
+/** @param {string} value */
+const decodePathSegment = (value) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+/** @param {string} hostname */
+const isGitHubHost = (hostname) => {
+  const normalized = hostname.toLowerCase();
+  return normalized === 'github.com' || normalized === 'www.github.com';
+};
+
+/** @param {string} hostname */
+const isAzureDevOpsSshHost = (hostname) => {
+  const normalized = hostname.toLowerCase();
+  return normalized === 'ssh.dev.azure.com' || normalized === 'vs-ssh.visualstudio.com';
+};
+
+/** @param {string} hostname */
+const isAzureDevOpsWebHost = (hostname) => {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === 'dev.azure.com' ||
+    normalized === 'www.dev.azure.com' ||
+    normalized.endsWith('.visualstudio.com')
+  );
+};
+
+/** @param {string} hostname */
+const isAzureDevOpsHost = (hostname) =>
+  isAzureDevOpsWebHost(hostname) || isAzureDevOpsSshHost(hostname);
+
+/**
+ * @param {string} hostname
+ * @param {string} organization
+ */
+const getAzureDevOpsWebHost = (hostname, organization) => {
+  const normalized = hostname.toLowerCase().replace(/^www\./, '');
+  if (normalized === 'vs-ssh.visualstudio.com' || normalized === 'visualstudio.com') {
+    return `${organization}.visualstudio.com`;
+  }
+  if (normalized.endsWith('.visualstudio.com')) {
+    return normalized;
+  }
+  if (
+    normalized === 'dev.azure.com' ||
+    normalized === 'ssh.dev.azure.com' ||
+    normalized.endsWith('.dev.azure.com')
+  ) {
+    return 'dev.azure.com';
+  }
+  return normalized;
+};
+
+/** @param {string} value */
+const encodePath = (value) => value.split('/').map(encodeURIComponent).join('/');
+
+/**
+ * @param {string} webHost
+ * @param {string} organization
+ * @param {string} project
+ * @param {string} repo
+ * @param {number} [number]
+ */
+const formatAzureDevOpsUrl = (webHost, organization, project, repo, number) => {
+  const encodedProject = encodePath(project);
+  const encodedRepo = encodeURIComponent(repo);
+  const suffix = number == null ? '' : `/pullrequest/${number}`;
+  if (webHost.endsWith('.visualstudio.com')) {
+    return `https://${webHost}/${encodedProject}/_git/${encodedRepo}${suffix}`;
+  }
+  return `https://${webHost}/${encodePath(organization)}/${encodedProject}/_git/${encodedRepo}${suffix}`;
+};
+
+/**
+ * @param {string} webHost
+ * @param {string} organization
+ * @param {string} project
+ */
+const getAzureDevOpsOrganizationUrl = (webHost, organization) =>
+  webHost.endsWith('.visualstudio.com')
+    ? `https://${webHost}`
+    : `https://${webHost}/${encodePath(organization)}`;
+
+/**
+ * @param {string} webHost
+ * @param {string} organization
+ * @param {string} project
+ */
+const getAzureDevOpsApiBase = (webHost, organization, project) =>
+  `${getAzureDevOpsOrganizationUrl(webHost, organization)}/${encodePath(project)}`;
+
+/**
+ * @param {string} hostname
+ * @param {string} projectPath
+ * @returns {{
+ *   apiBase: string;
+ *   host: string;
+ *   organization: string;
+ *   organizationUrl: string;
+ *   project: string;
+ *   projectPath: string;
+ *   provider: 'azure-devops';
+ *   repo: string;
+ *   webHost: string;
+ * } | null}
+ */
+const parseAzureDevOpsRemote = (hostname, projectPath) => {
+  const host = hostname.toLowerCase();
+  const path = stripGitSuffix(projectPath).replace(/^\/+/, '');
+  const sshMatch = isAzureDevOpsSshHost(host) ? path.match(azureDevOpsSshRemotePattern) : null;
+  if (sshMatch) {
+    const organization = decodePathSegment(sshMatch[1]);
+    const project = decodePathSegment(sshMatch[2]);
+    const repo = decodePathSegment(sshMatch[3]);
+    const webHost = getAzureDevOpsWebHost(host, organization);
+    return {
+      apiBase: getAzureDevOpsApiBase(webHost, organization, project),
+      host,
+      organization,
+      organizationUrl: getAzureDevOpsOrganizationUrl(webHost, organization),
+      project,
+      projectPath: `${organization}/${project}/${repo}`,
+      provider: /** @type {const} */ ('azure-devops'),
+      repo,
+      webHost,
+    };
+  }
+
+  const gitMatch = path.match(azureDevOpsGitRemotePattern);
+  if (!gitMatch) {
+    return null;
+  }
+  if (!isAzureDevOpsHost(host) && !path.includes('/_git/')) {
+    return null;
+  }
+
+  const rawPrefix = gitMatch[1].split('/').map(decodePathSegment).filter(Boolean);
+  const visualStudioCloud = host.endsWith('.visualstudio.com');
+  const prefix = visualStudioCloud
+    ? rawPrefix.filter((segment) => segment.toLowerCase() !== 'defaultcollection')
+    : rawPrefix;
+  const repo = decodePathSegment(gitMatch[2]);
+  let organization;
+  let project;
+  if (host === 'dev.azure.com' || host === 'www.dev.azure.com' || host === 'ssh.dev.azure.com') {
+    organization = prefix[0] || '';
+    project = prefix.slice(1).join('/') || repo;
+  } else if (visualStudioCloud) {
+    organization =
+      host === 'vs-ssh.visualstudio.com' || host === 'visualstudio.com'
+        ? prefix[0] || ''
+        : host.replace(/\.visualstudio\.com$/i, '').replace(/^www\./, '');
+    project = (host === 'vs-ssh.visualstudio.com' ? prefix.slice(1) : prefix).join('/') || repo;
+  } else {
+    organization = prefix[0] || host;
+    project = prefix.slice(1).join('/') || prefix[0] || repo;
+  }
+  if (!organization || !project || !repo) {
+    return null;
+  }
+
+  const webHost = getAzureDevOpsWebHost(host, organization);
+  return {
+    apiBase: getAzureDevOpsApiBase(webHost, organization, project),
+    host,
+    organization,
+    organizationUrl: getAzureDevOpsOrganizationUrl(webHost, organization),
+    project,
+    projectPath: `${organization}/${project}/${repo}`,
+    provider: /** @type {const} */ ('azure-devops'),
+    repo,
+    webHost,
+  };
+};
 
 /** @param {string} value */
 const toReviewUrl = (value) => {
@@ -40,12 +223,6 @@ const toReviewUrl = (value) => {
   }
 };
 
-/** @param {URL} url */
-const isGitHubHost = (url) => {
-  const hostname = url.hostname.toLowerCase();
-  return hostname === 'github.com' || hostname === 'www.github.com';
-};
-
 /** @param {string} value */
 const parseReviewUrl = (value) => {
   const url = toReviewUrl(value);
@@ -53,7 +230,7 @@ const parseReviewUrl = (value) => {
     return null;
   }
 
-  const github = isGitHubHost(url) ? url.pathname.match(gitHubPullRequestPattern) : null;
+  const github = isGitHubHost(url.hostname) ? url.pathname.match(gitHubPullRequestPattern) : null;
   const repo = github ? stripGitSuffix(github[2]) : '';
   if (github && repo) {
     return {
@@ -64,6 +241,26 @@ const parseReviewUrl = (value) => {
       provider: /** @type {const} */ ('github'),
       repo,
       url: `https://github.com/${github[1]}/${repo}/pull/${github[3]}`,
+    };
+  }
+
+  const azurePath = url.pathname.match(azureDevOpsPullRequestPattern);
+  const azureRemote = azurePath
+    ? parseAzureDevOpsRemote(url.hostname, `${azurePath[1]}/_git/${azurePath[2]}`)
+    : null;
+  if (azureRemote) {
+    const number = Number(azurePath[3]);
+    return {
+      ...azureRemote,
+      host: azureRemote.webHost,
+      number,
+      url: formatAzureDevOpsUrl(
+        azureRemote.webHost,
+        azureRemote.organization,
+        azureRemote.project,
+        azureRemote.repo,
+        number,
+      ),
     };
   }
 
@@ -87,32 +284,40 @@ const parseReviewUrl = (value) => {
 /** @param {string} value */
 const parseRemoteUrl = (value) => {
   const trimmed = value.trim();
-  const scp = trimmed.match(/^(?:[^@/\s]+@)?([^:/\s]+):(.+)$/);
+  const scp = trimmed.match(/^(?:[^@/\s]+@)*([^@/\s:]+):(.+)$/);
   if (scp && !trimmed.includes('://') && !/^[A-Za-z]:/.test(trimmed)) {
+    const host = scp[1].toLowerCase();
     const projectPath = scp[2].replaceAll(/^\/+|\.git$/gi, '');
-    return projectPath
-      ? {
-          host: scp[1].toLowerCase(),
-          projectPath,
-          provider: /** @type {ReviewProvider} */ (
-            scp[1].toLowerCase() === 'github.com' ? 'github' : 'gitlab'
-          ),
-        }
-      : null;
+    if (!projectPath) {
+      return null;
+    }
+    const azure = parseAzureDevOpsRemote(host, projectPath);
+    if (azure) {
+      return azure;
+    }
+    return {
+      host,
+      projectPath,
+      provider: /** @type {ReviewProvider} */ (isGitHubHost(host) ? 'github' : 'gitlab'),
+    };
   }
 
   try {
     const url = new URL(trimmed);
+    const host = url.host.toLowerCase();
     const projectPath = url.pathname.replaceAll(/^\/+|\.git$/gi, '');
-    return projectPath
-      ? {
-          host: url.host.toLowerCase(),
-          projectPath,
-          provider: /** @type {ReviewProvider} */ (
-            url.hostname.toLowerCase() === 'github.com' ? 'github' : 'gitlab'
-          ),
-        }
-      : null;
+    if (!projectPath) {
+      return null;
+    }
+    const azure = parseAzureDevOpsRemote(url.hostname, projectPath);
+    if (azure) {
+      return azure;
+    }
+    return {
+      host,
+      projectPath,
+      provider: /** @type {ReviewProvider} */ (isGitHubHost(url.hostname) ? 'github' : 'gitlab'),
+    };
   } catch {
     return null;
   }
@@ -146,6 +351,30 @@ const remotePriority = (remote) =>
       : 3;
 
 /**
+ * `codiff pr` is GitHub-first, but Azure DevOps also calls them pull requests.
+ * Prefer a GitHub remote when both exist; otherwise use the Azure remote.
+ *
+ * @param {ReviewProvider | undefined} provider
+ * @param {{provider: ReviewProvider}} remote
+ */
+const remoteMatchesProvider = (provider, remote) =>
+  !provider ||
+  remote.provider === provider ||
+  (provider === 'github' && remote.provider === 'azure-devops');
+
+/**
+ * @param {ReviewProvider | undefined} provider
+ * @param {{provider: ReviewProvider}} left
+ * @param {{provider: ReviewProvider}} right
+ */
+const providerPriority = (provider, left, right) => {
+  if (provider !== 'github') {
+    return 0;
+  }
+  return (left.provider === 'github' ? 0 : 1) - (right.provider === 'github' ? 0 : 1);
+};
+
+/**
  * @param {string} repositoryPath
  * @param {number} number
  * @param {ReviewProvider | undefined} provider
@@ -161,20 +390,42 @@ const resolveReviewUrl = (repositoryPath, number, provider) => {
   }
 
   const remote = remotes
-    .filter((candidate) => !provider || candidate.provider === provider)
-    .sort((left, right) => remotePriority(left) - remotePriority(right))[0];
+    .filter((candidate) => remoteMatchesProvider(provider, candidate))
+    .sort(
+      (left, right) =>
+        providerPriority(provider, left, right) || remotePriority(left) - remotePriority(right),
+    )[0];
   if (!remote) {
     throw new Error(
-      `Could not resolve ${provider === 'gitlab' ? 'MR' : provider === 'github' ? 'PR' : 'review'} #${number} from this repository's remotes.`,
+      `Could not resolve ${
+        provider === 'gitlab'
+          ? 'MR'
+          : provider === 'azure-devops'
+            ? 'Azure DevOps PR'
+            : provider === 'github'
+              ? 'PR'
+              : 'review'
+      } #${number} from this repository's remotes.`,
     );
   }
 
-  return remote.provider === 'github'
-    ? `https://github.com/${remote.projectPath}/pull/${number}`
-    : `https://${remote.host}/${remote.projectPath}/-/merge_requests/${number}`;
+  if (remote.provider === 'github') {
+    return `https://github.com/${remote.projectPath}/pull/${number}`;
+  }
+  if (remote.provider === 'azure-devops') {
+    return formatAzureDevOpsUrl(
+      remote.webHost,
+      remote.organization,
+      remote.project,
+      remote.repo,
+      number,
+    );
+  }
+  return `https://${remote.host}/${remote.projectPath}/-/merge_requests/${number}`;
 };
 
 module.exports = {
+  parseRemoteUrl,
   parseReviewUrl,
   readReviewRemotes,
   resolveReviewUrl,

--- a/electron/window-identity.cjs
+++ b/electron/window-identity.cjs
@@ -80,8 +80,8 @@ const resolveMergeBase = (repositoryRoot, baseRef, headRef) => {
 /** @param {Extract<ReviewSource, {type: 'pull-request'}>} source */
 const getPullRequestSourceKey = (source) => {
   const review = parseReviewUrl(source.url);
-  if (review?.provider === 'gitlab') {
-    return `pull-request:gitlab:${review.host}/${review.projectPath.toLowerCase()}#${
+  if (review?.provider === 'gitlab' || review?.provider === 'azure-devops') {
+    return `pull-request:${review.provider}:${review.host}/${review.projectPath.toLowerCase()}#${
       review.number
     }`;
   }


### PR DESCRIPTION
## Summary
Add Azure DevOps pull request review alongside GitHub PRs and GitLab MRs.

Codiff can now open Azure Repos PRs from a number, marker, or pasted URL, fetch the review diff through `refs/pull/{id}/head`, show inline thread comments, and post comments plus approve/request-changes votes through `az rest`.

```bash
codiff ado 75
codiff pr 75
codiff https://dev.azure.com/{org}/{project}/_git/{repo}/pullrequest/75
```

`codiff pr 75` still prefers a GitHub remote when both hosts are present. Use `codiff ado 75` (also `azdo`, `azure`, `azure-devops`) to force Azure DevOps. Auth is the Azure CLI: `az login`, with `CODIFF_AZ_PATH` for a non-PATH binary.

Supported remotes include `dev.azure.com`, `*.visualstudio.com`, and SSH (`git@ssh.dev.azure.com:v3/{org}/{project}/{repo}`).

## AI assistance
This PR was written primarily with Grok. I used it for implementation, tests, and the pull request description.

banana banana banana