### PR TITLE
feat: add OrcaRouter as an OpenCode model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,17 @@ once and complete `/login` if you have not already.
 
 OpenCode keeps its own configured model when `settings.opencodeModel` is `opencode-default`.
 Choose another model from the application `Model` menu, or set a provider-qualified id such as
-`anthropic/claude-sonnet-4-6`, `openai/gpt-5.5`, or another model available to your OpenCode
-account. When Codiff launches OpenCode for walkthroughs or review assistance and an explicit model
-is unavailable, it retries with OpenCode's configured default and persists that fallback. The
-managed `/codiff` command runs directly in OpenCode, so OpenCode reports access errors for its
-selected model; choose `opencode-default` when portability is more important than pinning.
+`anthropic/claude-sonnet-4-6`, `openai/gpt-5.5`, `orcarouter/auto`, or another model available to
+your OpenCode account. When Codiff launches OpenCode for walkthroughs or review assistance and an
+explicit model is unavailable, it retries with OpenCode's configured default and persists that
+fallback. The managed `/codiff` command runs directly in OpenCode, so OpenCode reports access errors
+for its selected model; choose `opencode-default` when portability is more important than pinning.
+
+To use [OrcaRouter](https://www.orcarouter.ai) as an OpenCode model provider, set
+`settings.opencodeModel` to `orcarouter/auto` and configure OpenCode with your OrcaRouter API key
+(`sk-orca-...`) and the `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level,
+zero-trust security for AI agents on the same endpoint — screening every prompt/response and
+governing every tool call on a default-deny basis, with no application code changes.
 
 Set `settings.walkthroughPrompt` to add custom instructions to generated walkthrough prompts. Use it
 to request a specific language, tone, or level of detail while Codiff keeps its walkthrough guide,

--- a/core/config/codiff-config.schema.json
+++ b/core/config/codiff-config.schema.json
@@ -71,7 +71,7 @@
         "opencodeModel": {
           "type": "string",
           "default": "opencode-default",
-          "description": "The OpenCode model to use for review assistance, walkthroughs, and the managed /codiff command when agentBackend is 'opencode'. Use 'opencode-default' to preserve OpenCode's configured default, or a provider-qualified model id such as 'anthropic/claude-sonnet-4-6'."
+          "description": "The OpenCode model to use for review assistance, walkthroughs, and the managed /codiff command when agentBackend is 'opencode'. Use 'opencode-default' to preserve OpenCode's configured default, or a provider-qualified model id such as 'anthropic/claude-sonnet-4-6' or 'orcarouter/auto'."
         },
         "piModel": {
           "type": "string",

--- a/electron/__tests__/opencode.test.ts
+++ b/electron/__tests__/opencode.test.ts
@@ -70,9 +70,11 @@ test('exposes selectable OpenCode models while keeping its configured default', 
     { id: DEFAULT_OPENCODE_MODEL, label: 'OpenCode configured default' },
     { id: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
     { id: 'openai/gpt-5.5', label: 'GPT-5.5' },
+    { id: 'orcarouter/auto', label: 'OrcaRouter auto' },
   ]);
   expect(normalizeOpenCodeModel(DEFAULT_OPENCODE_MODEL)).toBe(DEFAULT_OPENCODE_MODEL);
   expect(normalizeOpenCodeModel('openai/gpt-5.5')).toBe('openai/gpt-5.5');
+  expect(normalizeOpenCodeModel('orcarouter/auto')).toBe('orcarouter/auto');
   expect(normalizeOpenCodeModel('custom-provider/custom-model')).toBe(
     'custom-provider/custom-model',
   );

--- a/electron/opencode.cjs
+++ b/electron/opencode.cjs
@@ -27,6 +27,7 @@ const OPENCODE_MODELS = Object.freeze([
   { id: DEFAULT_OPENCODE_MODEL, label: 'OpenCode configured default' },
   { id: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
   { id: 'openai/gpt-5.5', label: 'GPT-5.5' },
+  { id: 'orcarouter/auto', label: 'OrcaRouter auto' },
 ]);
 const OPENCODE_MODEL_PATTERN = /^[a-z0-9][a-z0-9._:-]*(?:\/[@a-z0-9][@a-z0-9._:-]*)+$/i;
 


### PR DESCRIPTION
Add [OrcaRouter](https://www.orcarouter.ai) as an OpenCode model provider.

OrcaRouter is an OpenAI-compatible model gateway (`https://api.orcarouter.ai/v1`, API keys start with `sk-orca-`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- Add `orcarouter/auto` to the selectable OpenCode models (`electron/opencode.cjs`). The model id passes the existing `OPENCODE_MODEL_PATTERN`, so it is selectable from the application Model menu and valid in `settings.opencodeModel`.
- Document the new provider id in the config schema (`core/config/codiff-config.schema.json`) and the README, including how to point OpenCode at OrcaRouter (`settings.opencodeModel: "orcarouter/auto"` + `sk-orca-` key + `https://api.orcarouter.ai/v1`).

## Verification

- `vitest run electron/__tests__/opencode.test.ts` — 8 passed (model list, normalization, command rendering, fallback).
- `vp lint` on the touched files — clean (the only reported errors are pre-existing `web/` type errors that also occur on `main`; `electron/` is in the lint ignore list).
- Live API check against `https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` — HTTP 200.

This PR was written primarily with Claude Code.

Disclosure: I'm an engineer on the OrcaRouter team.

banana banana banana
