### PR TITLE
Drop the port from remote-derived hosts so `glab --hostname` accepts them

### DIFF
--- a/electron/__tests__/review-source.test.ts
+++ b/electron/__tests__/review-source.test.ts
@@ -143,9 +143,9 @@ test('parseRemoteUrl drops a custom port from `ssh://` remotes', () => {
   });
 });
 
-test('parseRemoteUrl drops a custom port from `https://` remotes', () => {
+test('parseRemoteUrl keeps an explicit port on `https://` remotes', () => {
   expect(parseRemoteUrl('https://gitlab.example.com:8443/group/subgroup/project.git')).toEqual({
-    host: 'gitlab.example.com',
+    host: 'gitlab.example.com:8443',
     projectPath: 'group/subgroup/project',
     provider: 'gitlab',
   });

--- a/electron/__tests__/review-source.test.ts
+++ b/electron/__tests__/review-source.test.ts
@@ -3,7 +3,12 @@ import { expect, test } from 'vite-plus/test';
 
 const require = createRequire(import.meta.url);
 
-const { parseReviewUrl } = require('../review-source.cjs') as {
+const { parseRemoteUrl, parseReviewUrl } = require('../review-source.cjs') as {
+  parseRemoteUrl: (value: string) => {
+    host: string;
+    projectPath: string;
+    provider: 'github' | 'gitlab';
+  } | null;
   parseReviewUrl: (value: string) => {
     host: string;
     number: number;
@@ -128,4 +133,33 @@ test('parseReviewUrl rejects values that are not review URLs', () => {
   ]) {
     expect(parseReviewUrl(value)).toBe(null);
   }
+});
+
+test('parseRemoteUrl drops a custom port from `ssh://` remotes', () => {
+  expect(parseRemoteUrl('ssh://git@gitlab.example.com:2222/group/project.git')).toEqual({
+    host: 'gitlab.example.com',
+    projectPath: 'group/project',
+    provider: 'gitlab',
+  });
+});
+
+test('parseRemoteUrl drops a custom port from `https://` remotes', () => {
+  expect(parseRemoteUrl('https://gitlab.example.com:8443/group/subgroup/project.git')).toEqual({
+    host: 'gitlab.example.com',
+    projectPath: 'group/subgroup/project',
+    provider: 'gitlab',
+  });
+});
+
+test('parseRemoteUrl reads scp-style and GitHub remotes', () => {
+  expect(parseRemoteUrl('git@gitlab.example.com:group/project.git')).toEqual({
+    host: 'gitlab.example.com',
+    projectPath: 'group/project',
+    provider: 'gitlab',
+  });
+  expect(parseRemoteUrl('https://github.com/nkzw-tech/codiff.git')).toEqual({
+    host: 'github.com',
+    projectPath: 'nkzw-tech/codiff',
+    provider: 'github',
+  });
 });

--- a/electron/review-source.cjs
+++ b/electron/review-source.cjs
@@ -106,9 +106,10 @@ const parseRemoteUrl = (value) => {
     const projectPath = url.pathname.replaceAll(/^\/+|\.git$/gi, '');
     return projectPath
       ? {
-          // `url.host` includes the port (e.g. a custom SSH port in `ssh://` remotes);
-          // glab's `--hostname` rejects `host:port`, so use the bare hostname.
-          host: url.hostname.toLowerCase(),
+          // A custom SSH port (`ssh://git@host:2222/...`) is transport detail, not part
+          // of the instance identifier, and glab's `--hostname` rejects `host:port` —
+          // strip it. An explicit port on `https://` remotes stays: it identifies the instance.
+          host: (url.protocol === 'ssh:' ? url.hostname : url.host).toLowerCase(),
           projectPath,
           provider: /** @type {ReviewProvider} */ (
             url.hostname.toLowerCase() === 'github.com' ? 'github' : 'gitlab'

--- a/electron/review-source.cjs
+++ b/electron/review-source.cjs
@@ -106,7 +106,9 @@ const parseRemoteUrl = (value) => {
     const projectPath = url.pathname.replaceAll(/^\/+|\.git$/gi, '');
     return projectPath
       ? {
-          host: url.host.toLowerCase(),
+          // `url.host` includes the port (e.g. a custom SSH port in `ssh://` remotes);
+          // glab's `--hostname` rejects `host:port`, so use the bare hostname.
+          host: url.hostname.toLowerCase(),
           projectPath,
           provider: /** @type {ReviewProvider} */ (
             url.hostname.toLowerCase() === 'github.com' ? 'github' : 'gitlab'
@@ -175,6 +177,7 @@ const resolveReviewUrl = (repositoryPath, number, provider) => {
 };
 
 module.exports = {
+  parseRemoteUrl,
   parseReviewUrl,
   readReviewRemotes,
   resolveReviewUrl,


### PR DESCRIPTION
# fix: drop port from remote host so `glab --hostname` accepts it



`parseRemoteUrl` used `URL.host` for `ssh://` / `https://` remotes, which includes the port
(`ssh://git@gitlab.example.com:2222/group/project.git` → `gitlab.example.com:2222`). That value is passed
to `glab api --hostname`, which rejects any `host:port` → `Error parsing --hostname: invalid hostname`
and `codiff mr <n>` fails with "Unable to read repository" on such GitLab instances.

Use `URL.hostname` instead. No behaviour change for remotes without a port (`host === hostname`);
the scp-style branch already had no port.

Test added: `parseRemoteUrl('ssh://git@gitlab.example.com:2222/group/project.git')` → `host: 'gitlab.example.com'`.

## Repro

Any repository whose `origin` remote is an `ssh://` (or `https://`) URL **with a port**, e.g.

```
git remote set-url origin ssh://git@gitlab.example.com:2222/group/project.git
codiff mr 1
```

Result (desktop window):

```
Unable to read repository
Error invoking remote method 'codiff:getRepositoryState':
Error: ERROR Error parsing --hostname: invalid hostname.
```

`glab` itself works fine in the same repo (`glab mr view 1` resolves the host from the remote).

