### PR TITLE
Add a commentOnLineClick setting to keep line clicks from opening comment drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ is running so changes apply to open windows.
 Set `settings.showWhitespace` to `true` to show whitespace-only changes in diffs and file line
 counts; when it is `false`, Codiff hides those changes from the working-tree review state.
 
+Set `settings.commentOnLineClick` to `false` to stop clicks and drags on diff lines from opening a
+review comment draft. The comment button in the gutter still opens one.
+
 ```jsonc
 {
   "$schema": "https://raw.githubusercontent.com/nkzw-tech/codiff/main/core/config/codiff-config.schema.json",
@@ -141,6 +144,7 @@ counts; when it is `false`, Codiff hides those changes from the working-tree rev
     "claudeModel": "claude-sonnet-4-6",
     "codeFontFamily": "",
     "codeFontSize": 13,
+    "commentOnLineClick": true,
     "copyCommentsOnClose": false,
     "diffStyle": "split",
     "editorCommand": "",

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -5,6 +5,7 @@
     "claudeModel": "claude-sonnet-4-6",
     "codeFontFamily": "",
     "codeFontSize": 13,
+    "commentOnLineClick": true,
     "copyCommentsOnClose": false,
     "diffStyle": "split",
     "editorCommand": "",

--- a/core/App.tsx
+++ b/core/App.tsx
@@ -1714,6 +1714,7 @@ export default function App() {
     agentLabel,
     codeQualityFindings: state.codeQualityFindings,
     collapsed,
+    commentOnLineClick: preferences.commentOnLineClick,
     comments: visibleReviewComments,
     commitMetadata,
     diffLineHeight,

--- a/core/__tests__/App-render.test.tsx
+++ b/core/__tests__/App-render.test.tsx
@@ -178,6 +178,7 @@ const createCodiffMock = (overrides: Partial<Window['codiff']> = {}): Window['co
     claudeModel: defaultSettings.claudeModel,
     codeFontFamily: defaultSettings.codeFontFamily,
     codeFontSize: defaultSettings.codeFontSize,
+    commentOnLineClick: true,
     copyCommentsOnClose: true,
     diffStyle: 'split' as const,
     editorCommand: '',

--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -2510,3 +2510,46 @@ test('line content clicks create review comments unless text is selected', async
   });
   expect(onCreateComment).toHaveBeenCalledTimes(3);
 });
+
+test('commentOnLineClick=false leaves comment creation to the gutter button', async () => {
+  const onCreateComment = vi.fn();
+  const file = createChangedFileWithPatch(
+    'src/click.ts',
+    'diff --git a/src/click.ts b/src/click.ts\n@@ -1 +1 @@\n-old\n+new\n',
+  );
+  await using _view = await renderReact(
+    <ReviewCodeViewHarness
+      commentOnLineClick={false}
+      files={[file]}
+      onCreateComment={onCreateComment}
+    />,
+  );
+  const { item, onGutterUtilityClick, onLineClick, onLineSelectionEnd } =
+    getReviewCodeViewHandlers();
+  const range = { end: 1, side: 'additions' as const, start: 1 };
+  await act(async () => {
+    onLineClick(
+      {
+        annotationSide: 'additions',
+        event: nonInteractivePointerEvent,
+        lineNumber: 1,
+      },
+      { item },
+    );
+    onLineSelectionEnd(range, { item });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(onCreateComment).not.toHaveBeenCalled();
+  expect(codeViewMock.lastOptions?.enableLineSelection).toBe(false);
+  await act(async () => {
+    onGutterUtilityClick(range, { item });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(onCreateComment).toHaveBeenCalledTimes(1);
+  expect(onCreateComment).toHaveBeenLastCalledWith({
+    filePath: 'src/click.ts',
+    lineNumber: 1,
+    sectionId: 'src/click.ts:unstaged',
+    side: 'additions',
+  });
+});

--- a/core/__tests__/config-defaults.test.ts
+++ b/core/__tests__/config-defaults.test.ts
@@ -88,6 +88,16 @@ test('electron config normalizes sidebar position', () => {
   ).toBe('left');
 });
 
+test('electron config keeps commentOnLineClick only when it is a boolean', () => {
+  expect(readElectronConfig({}).settings.commentOnLineClick).toBe(true);
+  expect(
+    readElectronConfig({ settings: { commentOnLineClick: false } }).settings.commentOnLineClick,
+  ).toBe(false);
+  expect(
+    readElectronConfig({ settings: { commentOnLineClick: 'no' } }).settings.commentOnLineClick,
+  ).toBe(true);
+});
+
 test('electron config keeps custom walkthrough prompt text only when it is a string', () => {
   expect(
     readElectronConfig({

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -2499,6 +2499,7 @@ export function ReviewCodeView({
   bottomInset = codeViewLayout.paddingBottom,
   codeQualityFindings = [],
   collapsed,
+  commentOnLineClick = true,
   comments,
   commitMetadata,
   diffLineHeight = DIFF_LINE_HEIGHT,
@@ -2561,6 +2562,7 @@ export function ReviewCodeView({
   bottomInset?: number;
   codeQualityFindings?: ReadonlyArray<PullRequestCodeQualityFinding>;
   collapsed: ReadonlySet<string>;
+  commentOnLineClick?: boolean;
   comments: ReadonlyArray<ReviewComment>;
   commitMetadata: CommitMetadata | null;
   diffLineHeight?: number;
@@ -3286,7 +3288,7 @@ export function ReviewCodeView({
         diffIndicators: 'bars',
         diffStyle,
         enableGutterUtility: !isReadOnly,
-        enableLineSelection: !isReadOnly,
+        enableLineSelection: !isReadOnly && commentOnLineClick,
         expandUnchanged: false,
         expansionLineCount: diffContextExpansionLineCount,
         hunkSeparators: 'line-info-basic',
@@ -3377,7 +3379,7 @@ export function ReviewCodeView({
             return;
           }
 
-          if (hasActiveTextSelection()) {
+          if (!commentOnLineClick || hasActiveTextSelection()) {
             return;
           }
 
@@ -3403,7 +3405,7 @@ export function ReviewCodeView({
             return;
           }
 
-          if (!range) {
+          if (!range || !commentOnLineClick) {
             return;
           }
 
@@ -3455,6 +3457,7 @@ export function ReviewCodeView({
     [
       bottomInset,
       cancelPendingEmptyCommentDeletes,
+      commentOnLineClick,
       createCommentForRange,
       diffStyle,
       isReadOnly,

--- a/core/config/codiff-config.schema.json
+++ b/core/config/codiff-config.schema.json
@@ -42,6 +42,11 @@
           "default": 13,
           "description": "Font size in pixels used for diff and code rendering."
         },
+        "commentOnLineClick": {
+          "type": "boolean",
+          "default": true,
+          "description": "Open a review comment draft when clicking or dragging across diff lines. The gutter comment button keeps working when this is false."
+        },
         "copyCommentsOnClose": {
           "type": "boolean",
           "default": false,

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -8,6 +8,7 @@ export type CodiffSettings = {
   claudeModel: string;
   codeFontFamily: string;
   codeFontSize: number;
+  commentOnLineClick: boolean;
   copyCommentsOnClose: boolean;
   diffStyle: CodiffDiffStyle;
   editorCommand: string;

--- a/core/types.ts
+++ b/core/types.ts
@@ -780,6 +780,7 @@ export type CodiffPreferences = {
   claudeModel: string;
   codeFontFamily: string;
   codeFontSize: number;
+  commentOnLineClick: boolean;
   copyCommentsOnClose: boolean;
   diffStyle: CodiffDiffStyle;
   editorCommand: string;

--- a/electron/config.cjs
+++ b/electron/config.cjs
@@ -285,6 +285,10 @@ const mergeConfig = (raw) => {
           : defaults.settings.claudeModel,
       codeFontFamily: normalizeCodeFontFamily(rawSettings.codeFontFamily),
       codeFontSize: normalizeCodeFontSize(rawSettings.codeFontSize),
+      commentOnLineClick:
+        typeof rawSettings.commentOnLineClick === 'boolean'
+          ? rawSettings.commentOnLineClick
+          : defaults.settings.commentOnLineClick,
       copyCommentsOnClose:
         typeof rawSettings.copyCommentsOnClose === 'boolean'
           ? rawSettings.copyCommentsOnClose


### PR DESCRIPTION
<!-- title: Add a commentOnLineClick setting to keep line clicks from opening comment drafts -->
## TL;DR
Adds `settings.commentOnLineClick` (default `true`). When set to `false`, clicking or dragging on diff lines no longer opens a review comment draft, and the gutter comment button remains the way to start one.

**Risk:** Low
**Change type:** Additive

## References
- Docs: [README § Configuration](https://github.com/nkzw-tech/codiff/blob/main/README.md#configuration) — the settings documentation this PR extends

## Background

<details>
<summary>Selecting text in a diff opened an empty comment draft under the line</summary>

To reproduce on main: open a diff, press the mouse inside a changed line, drag across a few characters, and release. An empty review comment draft opens under that line.

I select spans of code constantly while reading, so every selection left a stray draft to dismiss. The browser fires a click after a drag that starts and ends on one element, the diff library forwards it as a line click, and Codiff turns every line click into a draft. The text-selection guard only helps while the selection is still non-collapsed when that click fires.

With this change, a reader who prefers explicit commenting sets `commentOnLineClick` to `false` and keeps the gutter button (the comment control in the line-number gutter) as the one deliberate way to add a comment. Everyone else sees no change.

</details>

## Architecture

<details>
<summary>One setting gating two callbacks, with the gutter button left as the explicit path</summary>

- I gate the behavior behind a setting instead of detecting a text drag in the line-click handler. Whether the selection is still non-collapsed when the click arrives depends on timing, so a guard there is flaky. A setting is deterministic.
- The setting gates `onLineSelectionEnd` too. The code view starts a line-range selection only from a pointer-down in the line-number column (`startLineSelectionFromPointerDown` in `@pierre/diffs`) and reports it through that callback, so a number-column drag also ended in a draft. `onGutterUtilityClick` is untouched, so the gutter button stays a working, explicit path.
- With the setting off I also pass `enableLineSelection: false`, so a number-column drag no longer highlights a range that then does nothing.
- The default is `true`, so existing users see no change.

</details>

## Testing

<details>
<summary>Vitest cases for the gated callbacks and the config normalizer</summary>

- `core/__tests__/ReviewCodeView-scroll.test.tsx`: with `commentOnLineClick={false}`, a line click and a line-range selection end create no comment, the code view receives `enableLineSelection: false`, and a gutter button click still creates the comment at the expected line and section.
- `core/__tests__/config-defaults.test.ts`: the Electron reader keeps `false` when set and falls back to `true` on a missing or non-boolean value.
- `vp check`, `vp run build`, and the full `vp test` suite ran locally before pushing; CI is authoritative.
- By hand: set `"commentOnLineClick": false` in `~/.codiff/codiff.jsonc`, run this branch, then drag across text in a diff line and drag in the line-number column. No draft opens in either case, and the gutter button still opens one.

</details>

---

AI assistance: the code, tests, and this description were written with Claude Code (Claude Fable 5.1), directed and reviewed by the author.
