### PR TITLE
Update diffs to 1.4.2

### DIFF
--- a/core/__tests__/App.test.tsx
+++ b/core/__tests__/App.test.tsx
@@ -190,6 +190,8 @@ test('patch-only diffs are registered for lazy hydration and side-cached content
   const reparsedFlippedFlag = getVisibleDiffSections(file, true)[0].fileDiff;
   expect(reparsedFlippedFlag.isPartial).toBe(false);
   expect(reparsedFlippedFlag).not.toBe(fileDiff);
+  expect(reparsedFlippedFlag.cacheKey).toBeTruthy();
+  expect(reparsedFlippedFlag.cacheKey).not.toBe(fileDiff.cacheKey);
 });
 
 test('non-loadable and placeholder diffs are not registered for hydration', () => {

--- a/core/__tests__/ReviewCodeView-scroll.test.tsx
+++ b/core/__tests__/ReviewCodeView-scroll.test.tsx
@@ -659,7 +659,7 @@ test('focused walkthrough blocks render only global comments visible in the focu
 test('focused walkthrough blocks keep cross-side comments when their rendered anchor is visible', async () => {
   const file = createChangedFileWithPatch(
     'src/ranged-comment.ts',
-    'diff --git a/src/ranged-comment.ts b/src/ranged-comment.ts\n@@ -8,3 +8,3 @@\n context\n-old\n+new\n',
+    'diff --git a/src/ranged-comment.ts b/src/ranged-comment.ts\n@@ -8,3 +8,3 @@\n context\n-old\n+new\n trailing context\n',
   );
   const rangedComment = {
     body: 'Cross-side comment.',

--- a/core/app/components/ReviewCodeView.tsx
+++ b/core/app/components/ReviewCodeView.tsx
@@ -2615,7 +2615,7 @@ export function ReviewCodeView({
   walkthroughNotes: ReadonlyMap<string, WalkthroughNote>;
   wordWrap: boolean;
 }) {
-  const codeViewRef = useRef<CodeViewHandle<ReviewAnnotationMetadata>>(null);
+  const codeViewRef = useRef<CodeViewHandle<ReviewAnnotationMetadata, undefined>>(null);
   const markdownEditorRefs = useRef(new Map<string, MarkdownDocumentEditorHandle>());
   const refreshingMarkdownSectionsRef = useRef(new Set<string>());
   const deferredTimersRef = useRef<Set<number>>(new Set());
@@ -3363,7 +3363,7 @@ export function ReviewCodeView({
     };
   }, [isReadOnly, onLoadSectionContents]);
 
-  const codeViewOptions: CodeViewOptions<ReviewAnnotationMetadata> = useMemo(
+  const codeViewOptions: CodeViewOptions<ReviewAnnotationMetadata, undefined> = useMemo(
     () =>
       ({
         collapsedContextThreshold: diffCollapsedContextThreshold,
@@ -3535,7 +3535,7 @@ export function ReviewCodeView({
         themeType: theme,
         tokenizeMaxLength: 100_000,
         unsafeCSS: codeViewUnsafeCSS,
-      }) satisfies CodeViewOptions<ReviewAnnotationMetadata>,
+      }) satisfies CodeViewOptions<ReviewAnnotationMetadata, undefined>,
     [
       bottomInset,
       cancelPendingEmptyCommentDeletes,

--- a/core/lib/app-types.ts
+++ b/core/lib/app-types.ts
@@ -51,7 +51,7 @@ export type ReviewAnnotationMetadata =
   | WalkthroughHeaderAnnotationMetadata;
 
 export type CodeViewInstance = NonNullable<
-  ReturnType<CodeViewHandle<ReviewAnnotationMetadata>['getInstance']>
+  ReturnType<CodeViewHandle<ReviewAnnotationMetadata, undefined>['getInstance']>
 >;
 
 export type DiffSearchMatch = {

--- a/core/lib/diff.ts
+++ b/core/lib/diff.ts
@@ -342,7 +342,7 @@ export const parseSectionDiffWithOptions = (
   } else if (section.patch.trim().length === 0) {
     fileDiff = createEmptyFileDiff(file, section);
   } else {
-    const parsedFileDiff = parsePatchFiles(section.patch)[0]?.files[0];
+    const parsedFileDiff = parsePatchFiles(section.patch, cacheKey)[0]?.files[0];
     if (parsedFileDiff) {
       const loaded = parsedFileDiff.isPartial ? getLoadedSectionContents(file, section) : undefined;
       let hydrated: FileDiffMetadata | null = null;

--- a/core/package.json
+++ b/core/package.json
@@ -57,7 +57,7 @@
     "@nkzw/mdx-editor": "^1.0.1",
     "@nkzw/use-relative-time": "^1.2.3",
     "@phosphor-icons/react": "^2.1.10",
-    "@pierre/diffs": "1.3.6",
+    "@pierre/diffs": "1.4.2",
     "@pierre/trees": "1.0.0-beta.6",
     "@radix-ui/react-slot": "^1.3.3",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,8 +218,8 @@ importers:
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@pierre/diffs':
-        specifier: 1.3.6
-        version: 1.3.6(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 1.4.2
+        version: 1.4.2(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@pierre/trees':
         specifier: 1.0.0-beta.6
         version: 1.0.0-beta.6(@pierre/theme@2.0.0)(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.4.3)
@@ -2580,11 +2580,16 @@ packages:
       react: '>= 16.8'
       react-dom: '>= 16.8'
 
-  '@pierre/diffs@1.3.6':
-    resolution: {integrity: sha512-a3woaW2QHy78JDxPJK0OJzwZUN4xoQLLIS/pceO8X6+L8gA5D682mP7/w3YxxEVRPXOaoe/p/RJ5Oj/3nrEzew==}
+  '@pierre/diffs@1.4.2':
+    resolution: {integrity: sha512-X9njBs6fGN+BIBhJ/otJRcxzNfsU3fd31VNquPiRW5nK051IyjuNS5JuOunqFDmEN3VCS9fm0gauyka/nMdokg==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@pierre/theme@2.0.0':
     resolution: {integrity: sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==}
@@ -9279,7 +9284,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@pierre/diffs@1.3.6(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@pierre/diffs@1.4.2(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@pierre/theme': 2.0.0
       '@pierre/theming': 1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.4.3)
@@ -9287,9 +9292,10 @@ snapshots:
       diff: 9.0.0
       hast-util-to-html: 9.0.5
       lru_map: 0.4.1
+      shiki: 4.4.3
+    optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      shiki: 4.4.3
     transitivePeerDependencies:
       - '@shikijs/themes'
 


### PR DESCRIPTION
Had codex run an update to the latest 1.4.2.

There was a small migration guide that I also gave it for context: https://github.com/pierrecomputer/pierre/releases/tag/diffs-v1.4.0